### PR TITLE
Add headless oracle mode for differential testing

### DIFF
--- a/src/crimson/cli.py
+++ b/src/crimson/cli.py
@@ -380,22 +380,57 @@ def cmd_oracle(
     input_file: Path | None = typer.Option(None, "--input-file", "-i", help="JSON file with input sequence"),
     max_frames: int = typer.Option(36000, help="Maximum frames to run (default: 10 min at 60fps)"),
     frame_rate: int = typer.Option(60, help="Frame rate for simulation"),
+    sample_rate: int = typer.Option(60, "--sample-rate", "-s", help="Emit state every N frames (1=every frame, 60=1/sec)"),
+    output_mode: str = typer.Option(
+        "summary",
+        "--output", "-o",
+        help="Output mode: full (all entities), summary (fast), hash (ultra-fast), checkpoints (on events only)",
+    ),
 ) -> None:
     """Run headless oracle mode for differential testing.
 
-    Emits JSON game state to stdout each frame. Use with --seed for deterministic
-    runs and --input-file for replaying specific input sequences.
+    Emits JSON game state to stdout. Use with --seed for deterministic runs
+    and --input-file for replaying specific input sequences.
 
-    Example:
-        crimson oracle --seed 12345 --input-file replay.json > states.jsonl
+    Output modes:
+      - summary: Score, kills, player pos/health (default, fast)
+      - full: All entities including creatures, projectiles, bonuses
+      - hash: SHA256 hash of full state (ultra-fast comparison)
+      - checkpoints: Emit only when score/kills/level/weapon changes
+
+    Examples:
+        # Fast validation at 1 Hz sampling
+        crimson oracle --seed 12345 -i replay.json -s 60 -o summary
+
+        # Full frame-by-frame for debugging divergence
+        crimson oracle --seed 12345 -i replay.json -s 1 -o full
+
+        # Ultra-fast hash comparison
+        crimson oracle --seed 12345 -i replay.json -o hash
+
+        # Event-driven checkpoints only
+        crimson oracle --seed 12345 -i replay.json -o checkpoints
     """
-    from .oracle import OracleConfig, run_headless
+    from .oracle import OracleConfig, OutputMode, run_headless
+
+    # Validate output mode
+    mode_map = {
+        "full": OutputMode.FULL,
+        "summary": OutputMode.SUMMARY,
+        "hash": OutputMode.HASH,
+        "checkpoints": OutputMode.CHECKPOINTS,
+    }
+    if output_mode not in mode_map:
+        typer.echo(f"Invalid output mode: {output_mode!r}. Choose from: {', '.join(mode_map)}", err=True)
+        raise typer.Exit(code=1)
 
     config = OracleConfig(
         seed=seed,
         input_file=input_file,
         max_frames=max_frames,
         frame_rate=frame_rate,
+        sample_rate=sample_rate,
+        output_mode=mode_map[output_mode],
     )
     run_headless(config)
 


### PR DESCRIPTION
## Summary

Adds a `crimson oracle` CLI command for headless differential testing, enabling automated validation of Crimsonland reimplementations.

## Context

We're building a [competitive leaderboard](https://crimson-leaderboard.paradigm-36f.workers.dev) for the AI rewrite challenge. To validate submissions, we want to run them in parallel with this Python implementation as the oracle — same seed, same inputs, compare game state every frame.

## What this adds

### New CLI command: `crimson oracle`

```bash
crimson oracle --seed 12345 --input-file replay.json > states.jsonl
```

Options:
- `--seed N` — Deterministic RNG seed
- `--input-file replay.json` — JSON file with input sequence
- `--max-frames N` — Maximum frames to run (default: 36000 = 10 min @ 60fps)
- `--frame-rate N` — Simulation frame rate (default: 60)

### Input file format

```json
{
  "frames": [
    {"frame": 0, "move_x": 1.0, "move_y": 0.0, "aim_x": 100, "aim_y": 200, "fire_down": true},
    {"frame": 60, "move_x": 0.0, "move_y": -1.0, "fire_pressed": true}
  ]
}
```

### State output (JSONL to stdout)

Each frame emits a JSON line with:
- `frame`, `elapsed_ms`, `rng_state`
- `score`, `kills`
- `players[]` — position, health, weapon, experience, level
- `creatures[]` — active enemies with position and HP
- `bonuses[]` — active pickups
- `projectiles[]` — active projectiles
- `bonus_timers` — weapon power-up, reflex boost, freeze

## Usage for differential testing

1. Generate input sequence with random seed
2. Run: `crimson oracle --seed 42 --input-file inputs.json > oracle.jsonl`
3. Run submission with same seed/inputs, capture its state output
4. Compare frame-by-frame, flag divergence

Let me know if you'd structure the state output differently or want additional fields exposed.