### PR TITLE
Match quest level label to original format

### DIFF
--- a/src/crimson/modes/quest_mode.py
+++ b/src/crimson/modes/quest_mode.py
@@ -121,9 +121,17 @@ def _quest_attempt_counter_index(level: str) -> int | None:
 def _quest_level_label(level: str) -> str:
     try:
         tier_text, quest_text = level.split(".", 1)
-        return f"{int(tier_text)}-{int(quest_text)}"
+        major = int(tier_text)
+        minor = int(quest_text)
     except Exception:
-        return level.replace(".", "-", 1)
+        return str(level)
+
+    # Match `ui_render_hud` (0x0041bf94): quest minor can temporarily exceed 10
+    # (e.g. after incrementing), and the HUD carries it into the major.
+    while minor > 10:
+        major += 1
+        minor -= 10
+    return f"{major}.{minor}"
 
 
 class QuestMode(BaseGameplayMode):

--- a/tests/test_quest_level_label_format.py
+++ b/tests/test_quest_level_label_format.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from crimson.modes.quest_mode import _quest_level_label
+
+
+def test_quest_level_label_matches_exe_format() -> None:
+    assert _quest_level_label("1.1") == "1.1"
+    assert _quest_level_label("1.10") == "1.10"
+
+
+def test_quest_level_label_carries_minor_overflow() -> None:
+    assert _quest_level_label("1.11") == "2.1"
+


### PR DESCRIPTION
Summary
- update `_quest_level_label` to parse the tier/minor segment, carry minor overflow into the major number, and return the label in the original dot-separated format
- added tests that cover the expected formatting and the carry-over behavior observed in `ui_render_hud`

Testing
- Not run (not requested)