### PR TITLE
feat: match player turning movement and wire direction arrow

### DIFF
--- a/src/crimson/game_world.py
+++ b/src/crimson/game_world.py
@@ -71,6 +71,7 @@ class GameWorld:
     particles_texture: rl.Texture | None = field(init=False, default=None)
     bullet_texture: rl.Texture | None = field(init=False, default=None)
     bullet_trail_texture: rl.Texture | None = field(init=False, default=None)
+    arrow_texture: rl.Texture | None = field(init=False, default=None)
     bonuses_texture: rl.Texture | None = field(init=False, default=None)
     bodyset_texture: rl.Texture | None = field(init=False, default=None)
     clock_table_texture: rl.Texture | None = field(init=False, default=None)
@@ -320,6 +321,11 @@ class GameWorld:
             cache_path="load/bulletTrail.tga",
             file_path="load/bulletTrail.png",
         )
+        self.arrow_texture = self._load_texture(
+            "arrow",
+            cache_path="load/arrow.tga",
+            file_path="load/arrow.png",
+        )
         self.bonuses_texture = self._load_texture(
             "bonuses",
             cache_path="game/bonuses.jaz",
@@ -372,6 +378,7 @@ class GameWorld:
         self.particles_texture = None
         self.bullet_texture = None
         self.bullet_trail_texture = None
+        self.arrow_texture = None
         self.bonuses_texture = None
         self.wicons_texture = None
         self.bodyset_texture = None

--- a/tests/test_alternate_weapon_perk.py
+++ b/tests/test_alternate_weapon_perk.py
@@ -11,8 +11,9 @@ from crimson.perks import PerkId
 
 def test_alternate_weapon_slows_movement() -> None:
     state = GameplayState()
-    base = PlayerState(index=0, pos=Vec2(), move_speed=2.0)
-    perk = PlayerState(index=0, pos=Vec2(), move_speed=2.0)
+    move_heading = Vec2(1.0, 0.0).to_heading()
+    base = PlayerState(index=0, pos=Vec2(), move_speed=2.0, heading=move_heading)
+    perk = PlayerState(index=0, pos=Vec2(), move_speed=2.0, heading=move_heading)
     perk.perk_counts[int(PerkId.ALTERNATE_WEAPON)] = 1
 
     player_update(base, PlayerInput(move=Vec2(1.0, 0.0)), dt=1.0, state=state)

--- a/tests/test_player_update.py
+++ b/tests/test_player_update.py
@@ -254,6 +254,18 @@ def test_player_update_tracks_aim_point() -> None:
     assert player.aim == Vec2(123.0, 456.0)
 
 
+def test_player_update_turns_toward_move_heading_with_turn_slowdown() -> None:
+    state = GameplayState()
+    player = PlayerState(index=0, pos=Vec2(100.0, 100.0), move_speed=2.0, heading=0.0)
+    input_state = PlayerInput(move=Vec2(1.0, 0.0), aim=Vec2(101.0, 100.0))
+
+    player_update(player, input_state, 0.1, state)
+
+    assert math.isclose(player.pos.x, 103.53553390593274, abs_tol=1e-9)
+    assert math.isclose(player.pos.y, 96.46446609406726, abs_tol=1e-9)
+    assert math.isclose(player.heading, math.pi / 4.0, abs_tol=1e-9)
+
+
 def test_player_fire_weapon_uses_disc_spread_jitter() -> None:
     pool = ProjectilePool(size=8)
     state = GameplayState(projectiles=pool)

--- a/tests/test_reflex_boosted_perk.py
+++ b/tests/test_reflex_boosted_perk.py
@@ -22,6 +22,7 @@ def test_reflex_boosted_scales_dt_by_0_9_in_world_step() -> None:
 
     player = PlayerState(index=0, pos=Vec2())
     player.move_speed = 2.0
+    player.heading = Vec2(1.0, 0.0).to_heading()
     player.perk_counts[int(PerkId.REFLEX_BOOSTED)] = 1
     world.players.append(player)
 

--- a/tests/test_speed_bonus_scaling.py
+++ b/tests/test_speed_bonus_scaling.py
@@ -10,14 +10,15 @@ from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_upd
 def test_speed_bonus_adds_one_to_speed_multiplier() -> None:
     dt = 0.1
     input_state = PlayerInput(move=Vec2(1.0, 0.0), aim=Vec2(101.0, 100.0))
+    move_heading = Vec2(1.0, 0.0).to_heading()
 
     base_state = GameplayState()
-    base_player = PlayerState(index=0, pos=Vec2(100.0, 100.0), move_speed=2.0)
+    base_player = PlayerState(index=0, pos=Vec2(100.0, 100.0), move_speed=2.0, heading=move_heading)
     player_update(base_player, input_state, dt, base_state)
     assert base_player.pos.x == pytest.approx(110.0)
 
     boosted_state = GameplayState()
-    boosted_player = PlayerState(index=0, pos=Vec2(100.0, 100.0), move_speed=2.0)
+    boosted_player = PlayerState(index=0, pos=Vec2(100.0, 100.0), move_speed=2.0, heading=move_heading)
     boosted_player.speed_bonus_timer = 1.0
     player_update(boosted_player, input_state, dt, boosted_state)
     assert boosted_player.pos.x == pytest.approx(115.0)

--- a/tests/test_unstoppable_perk.py
+++ b/tests/test_unstoppable_perk.py
@@ -4,7 +4,7 @@ from grim.geom import Vec2
 
 import math
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_update
 from crimson.perks import PerkId
 from crimson.player_damage import player_take_damage
 
@@ -33,3 +33,18 @@ def test_player_take_damage_suppresses_heading_jitter_and_spread_heat_with_unsto
     assert math.isclose(player.heading, 1.0, abs_tol=1e-9)
     assert math.isclose(player.spread_heat, 0.1, abs_tol=1e-9)
 
+
+def test_player_take_damage_heading_jitter_is_not_snapped_by_player_update() -> None:
+    state = GameplayState()
+    player = PlayerState(index=0, pos=Vec2(100.0, 100.0), health=100.0, heading=1.0, move_speed=2.0)
+
+    player_take_damage(state, player, 10.0, rand=lambda: 0)
+    target_heading = Vec2(1.0, 0.0).to_heading()
+    player_update(
+        player,
+        PlayerInput(move=Vec2(1.0, 0.0), aim=Vec2(200.0, 100.0)),
+        dt=0.1,
+        state=state,
+    )
+
+    assert not math.isclose(player.heading % math.tau, target_heading, abs_tol=1e-9)


### PR DESCRIPTION
## Summary
- port native-like `player_heading_approach_target` behavior into `player_update` so movement turns toward target heading instead of snapping
- apply turn-alignment movement slowdown based on angular difference, which preserves bite-induced heading disruptions visibly/behaviorally
- wire world direction-arrow rendering behind `config.data["hud_indicators"]` with native-like tint/alpha behavior
- load `load/arrow.tga` into `GameWorld` and make the Controls panel checkbox actually toggle + persist `hud_indicators`
- add/update movement tests to lock heading where intended and cover new turning behavior

## Validation
- `uv run ruff check src/crimson/gameplay.py src/crimson/game_world.py src/crimson/render/world_renderer.py src/crimson/frontend/panels/controls.py tests/test_player_update.py tests/test_unstoppable_perk.py tests/test_speed_bonus_scaling.py tests/test_reflex_boosted_perk.py tests/test_alternate_weapon_perk.py`
- `uv run pytest`
