### PR TITLE
fix(gameplay): normalize movement heading for up-left turns

### DIFF
--- a/src/crimson/gameplay.py
+++ b/src/crimson/gameplay.py
@@ -2356,7 +2356,7 @@ def player_update(
     if moving_input:
         inv = 1.0 / raw_mag if raw_mag > 1e-9 else 0.0
         move = raw_move * inv
-        target_heading = move.to_heading()
+        target_heading = _normalize_heading_angle(move.to_heading())
         angle_diff = _player_heading_approach_target(player, target_heading, dt)
         move = Vec2.from_heading(player.heading)
         turn_alignment_scale = max(0.0, (math.pi - angle_diff) / math.pi)
@@ -2471,11 +2471,7 @@ def player_update(
 def _player_heading_approach_target(player: PlayerState, target_heading: float, dt: float) -> float:
     """Native `player_heading_approach_target`: ease heading and return angular diff."""
 
-    heading = float(player.heading)
-    while heading < 0.0:
-        heading += math.tau
-    while heading > math.tau:
-        heading -= math.tau
+    heading = _normalize_heading_angle(float(player.heading))
     player.heading = heading
 
     direct = abs(float(target_heading) - heading)
@@ -2491,6 +2487,14 @@ def _player_heading_approach_target(player: PlayerState, target_heading: float, 
 
     player.heading = heading + turn_sign * dt * diff * 5.0
     return diff
+
+
+def _normalize_heading_angle(value: float) -> float:
+    while value < 0.0:
+        value += math.tau
+    while value > math.tau:
+        value -= math.tau
+    return value
 
 
 @dataclass(slots=True)

--- a/tests/test_player_update.py
+++ b/tests/test_player_update.py
@@ -266,6 +266,30 @@ def test_player_update_turns_toward_move_heading_with_turn_slowdown() -> None:
     assert math.isclose(player.heading, math.pi / 4.0, abs_tol=1e-9)
 
 
+def test_player_update_w_then_up_left_converges_to_diagonal_heading() -> None:
+    def _angular_distance(a: float, b: float) -> float:
+        diff = abs((a - b) % math.tau)
+        return min(diff, math.tau - diff)
+
+    state = GameplayState()
+    player = PlayerState(index=0, pos=Vec2(100.0, 100.0), move_speed=2.0, heading=0.0)
+    dt = 1.0 / 60.0
+    aim = Vec2(200.0, 100.0)
+
+    for _ in range(30):
+        player_update(player, PlayerInput(move=Vec2(0.0, -1.0), aim=aim), dt, state)
+
+    target_heading = Vec2(-1.0, -1.0).to_heading() % math.tau
+    start_diff = _angular_distance(player.heading % math.tau, target_heading)
+
+    for _ in range(20):
+        player_update(player, PlayerInput(move=Vec2(-1.0, -1.0), aim=aim), dt, state)
+
+    end_diff = _angular_distance(player.heading % math.tau, target_heading)
+    assert end_diff < start_diff - 0.25
+    assert end_diff < 0.4
+
+
 def test_player_fire_weapon_uses_disc_spread_jitter() -> None:
     pool = ProjectilePool(size=8)
     state = GameplayState(projectiles=pool)


### PR DESCRIPTION
## Summary
- normalize movement target heading to [0, 2π] before calling `player_heading_approach_target`
- share heading wrapping logic via `_normalize_heading_angle`
- add regression test for the reproduced sequence: hold up, then hold up+left

## Root Cause
Negative target headings (e.g. up-left) were passed directly into turn interpolation, which made the heading direction flip around 0/2π and caused the movement arrow to wiggle/reset instead of converging diagonally.

## Validation
- `uv run ruff check src/crimson/gameplay.py tests/test_player_update.py`
- `uv run pytest tests/test_player_update.py -q`
- manual repro verified in-game

Closes #67
