### PR TITLE
fix(render): scale ground RT on retina and stabilize camera clamp

### DIFF
--- a/src/crimson/render/world_renderer.py
+++ b/src/crimson/render/world_renderer.py
@@ -249,9 +249,19 @@ class WorldRenderer:
         return Vec2(screen_w, screen_h)
 
     def _clamp_camera(self, camera: Vec2, screen_size: Vec2) -> Vec2:
+        cam_x = camera.x
+        cam_y = camera.y
+        if cam_x > -1.0:
+            cam_x = -1.0
+        if cam_y > -1.0:
+            cam_y = -1.0
         min_x = screen_size.x - float(self.world_size)
         min_y = screen_size.y - float(self.world_size)
-        return camera.clamp_rect(min_x, min_y, -1.0, -1.0)
+        if cam_x < min_x:
+            cam_x = min_x
+        if cam_y < min_y:
+            cam_y = min_y
+        return Vec2(cam_x, cam_y)
 
     def _world_params(self) -> tuple[Vec2, Vec2]:
         out_size = Vec2(float(rl.get_screen_width()), float(rl.get_screen_height()))

--- a/src/grim/terrain_render.py
+++ b/src/grim/terrain_render.py
@@ -673,9 +673,19 @@ class GroundRenderer:
             )
 
     def _clamp_camera(self, camera: Vec2, screen_w: float, screen_h: float) -> Vec2:
+        cam_x = camera.x
+        cam_y = camera.y
+        if cam_x > -1.0:
+            cam_x = -1.0
+        if cam_y > -1.0:
+            cam_y = -1.0
         min_x = screen_w - float(self.width)
         min_y = screen_h - float(self.height)
-        return camera.clamp_rect(min_x, min_y, -1.0, -1.0)
+        if cam_x < min_x:
+            cam_x = min_x
+        if cam_y < min_y:
+            cam_y = min_y
+        return Vec2(cam_x, cam_y)
 
     def _ensure_render_target(self, render_w: int, render_h: int) -> bool:
         if self.render_target is not None:
@@ -709,14 +719,27 @@ class GroundRenderer:
         return True
 
     def _render_target_size_for(self, scale: float) -> tuple[int, int]:
-        render_w = max(1, int(self.width / scale))
-        render_h = max(1, int(self.height / scale))
+        pixel_scale = 1.0
+        screen_w = int(rl.get_screen_width())
+        screen_h = int(rl.get_screen_height())
+        render_w = int(rl.get_render_width())
+        render_h = int(rl.get_render_height())
+        if render_w == screen_w * 2 and render_h == screen_h * 2:
+            pixel_scale = 2.0
+        render_w = max(1, int((self.width * pixel_scale) / scale))
+        render_h = max(1, int((self.height * pixel_scale) / scale))
         return render_w, render_h
 
     def _normalized_texture_scale(self) -> float:
         scale = self.texture_scale
         if scale < 0.5:
             scale = 0.5
+        screen_w = int(rl.get_screen_width())
+        screen_h = int(rl.get_screen_height())
+        render_w = int(rl.get_render_width())
+        render_h = int(rl.get_render_height())
+        if render_w == screen_w * 2 and render_h == screen_h * 2:
+            scale *= 0.5
         return scale
 
     def _set_stamp_filters(self, *, point: bool) -> None:

--- a/tests/test_camera_clamp_regression.py
+++ b/tests/test_camera_clamp_regression.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from crimson.render.world_renderer import WorldRenderer
+from grim.geom import Vec2
+from grim.terrain_render import GroundRenderer
+
+
+def test_ground_clamp_is_stable_when_screen_matches_world_width() -> None:
+    texture = SimpleNamespace(id=1, width=16, height=16)
+    ground = GroundRenderer(texture=texture, width=1024, height=1024)
+    clamped = ground._clamp_camera(Vec2(-0.25, -5.0), 1024.0, 768.0)
+    assert clamped.x == 0.0
+
+
+def test_world_clamp_is_stable_when_screen_matches_world_width() -> None:
+    world = SimpleNamespace(world_size=1024.0)
+    renderer = WorldRenderer(world)
+    clamped = renderer._clamp_camera(Vec2(-0.25, -5.0), Vec2(1024.0, 768.0))
+    assert clamped.x == 0.0

--- a/tests/test_ground_render_target_scaling.py
+++ b/tests/test_ground_render_target_scaling.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import grim.terrain_render as terrain_render
+from grim.terrain_render import GroundRenderer
+
+
+def _renderer() -> GroundRenderer:
+    texture = SimpleNamespace(id=1, width=16, height=16)
+    return GroundRenderer(
+        texture=texture,
+        width=1024,
+        height=1024,
+        texture_scale=1.0,
+        screen_width=1024.0,
+        screen_height=768.0,
+    )
+
+
+def test_render_target_size_stays_native_without_hidpi(monkeypatch) -> None:
+    monkeypatch.setattr(terrain_render.rl, "get_screen_width", lambda: 1024)
+    monkeypatch.setattr(terrain_render.rl, "get_screen_height", lambda: 768)
+    monkeypatch.setattr(terrain_render.rl, "get_render_width", lambda: 1024)
+    monkeypatch.setattr(terrain_render.rl, "get_render_height", lambda: 768)
+    assert _renderer()._render_target_size_for(1.0) == (1024, 1024)
+
+
+def test_render_target_size_doubles_with_double_render_resolution(monkeypatch) -> None:
+    monkeypatch.setattr(terrain_render.rl, "get_screen_width", lambda: 1024)
+    monkeypatch.setattr(terrain_render.rl, "get_screen_height", lambda: 768)
+    monkeypatch.setattr(terrain_render.rl, "get_render_width", lambda: 2048)
+    monkeypatch.setattr(terrain_render.rl, "get_render_height", lambda: 1536)
+    assert _renderer()._render_target_size_for(1.0) == (2048, 2048)
+
+
+def test_effective_texture_scale_halves_with_double_render_resolution(monkeypatch) -> None:
+    monkeypatch.setattr(terrain_render.rl, "get_screen_width", lambda: 1024)
+    monkeypatch.setattr(terrain_render.rl, "get_screen_height", lambda: 768)
+    monkeypatch.setattr(terrain_render.rl, "get_render_width", lambda: 2048)
+    monkeypatch.setattr(terrain_render.rl, "get_render_height", lambda: 1536)
+    assert _renderer()._normalized_texture_scale() == 0.5


### PR DESCRIPTION
## Summary
- render the terrain/ground RT at 2x only when raylib render size is exactly 2x the logical screen size
- keep terrain stamping/decal baking mapped correctly in that mode by adjusting effective texture scale
- fix camera clamp ordering to match original behavior and remove subtle left/right jitter when screen width matches world width
- add focused regressions for retina RT sizing and camera clamp stability

## Validation
- uv run ruff check src/grim/terrain_render.py src/crimson/render/world_renderer.py tests/test_ground_render_target_scaling.py tests/test_camera_clamp_regression.py
- uv run pytest tests/test_ground_render_target_scaling.py tests/test_camera_clamp_regression.py