### PR TITLE
docs(readme): add Wayland raylib wheel note

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,8 @@ If you just want to play the rewrite:
 uvx crimsonland@latest
 ```
 
+Linux Wayland users: current PyPI `raylib` wheels are still X11-oriented on `x86_64`, so `uvx crimsonland` may require `xwayland` + `libX11` (see [electronstudio/raylib-python-cffi#199](https://github.com/electronstudio/raylib-python-cffi/pull/199)).
+
 ### Run from a checkout
 
 ```bash


### PR DESCRIPTION
## Summary
- add a README note that current PyPI raylib wheels are X11-oriented on x86_64
- document that Wayland users running `uvx crimsonland` may need `xwayland` and `libX11`
- link upstream context in electronstudio/raylib-python-cffi#199