### PR TITLE
fix(ui): match perk menu description text scale to decompile

### DIFF
--- a/src/crimson/modes/components/perk_menu_controller.py
+++ b/src/crimson/modes/components/perk_menu_controller.py
@@ -20,7 +20,6 @@ from ...perks import PerkId, perk_display_description, perk_display_name
 from ...ui.menu_panel import draw_classic_menu_panel
 from ...ui.perk_menu import (
     PERK_MENU_TRANSITION_MS,
-    PERK_MENU_DESC_TEXT_SCALE,
     PerkMenuAssets,
     PerkMenuLayout,
     UiButtonState,
@@ -377,12 +376,11 @@ class PerkMenuController:
         desc = perk_display_description(int(selected), fx_toggle=int(ctx.fx_toggle))
         if ctx.font is not None:
             desc = self._prewrapped_perk_desc(int(selected), ctx.font, fx_toggle=int(ctx.fx_toggle))
-        desc_scale = scale * PERK_MENU_DESC_TEXT_SCALE
         draw_ui_text(
             ctx.font,
             desc,
             computed.desc.top_left,
-            scale=desc_scale,
+            scale=scale,
             color=UI_TEXT_COLOR,
         )
 

--- a/src/crimson/ui/perk_menu.py
+++ b/src/crimson/ui/perk_menu.py
@@ -42,9 +42,6 @@ MENU_DESC_Y_EXTRA_TIGHTEN = 20.0
 MENU_BUTTON_X = 162.0
 MENU_BUTTON_Y = 276.0
 MENU_DESC_RIGHT_X = 480.0
-# `perk_selection_screen_update` draws description text through `grim_draw_text_small`
-# with no extra local downscale.
-PERK_MENU_DESC_TEXT_SCALE = 1.0
 
 
 @dataclass(slots=True)

--- a/src/crimson/views/perk_menu_debug.py
+++ b/src/crimson/views/perk_menu_debug.py
@@ -10,7 +10,6 @@ from grim.view import View, ViewContext
 from ..perks import PERK_BY_ID, PerkId, perk_display_description, perk_display_name
 from ..ui.menu_panel import draw_classic_menu_panel
 from ..ui.perk_menu import (
-    PERK_MENU_DESC_TEXT_SCALE,
     PerkMenuAssets,
     PerkMenuLayout,
     UiButtonState,
@@ -367,12 +366,11 @@ class PerkMenuDebugView:
 
                 selected_id = choices[self._selected]
                 desc = perk_display_description(int(selected_id))
-                desc_scale = scale * PERK_MENU_DESC_TEXT_SCALE
                 draw_wrapped_ui_text_in_rect(
                     self._small,
                     desc,
                     rect=computed.desc,
-                    scale=desc_scale,
+                    scale=scale,
                     color=UI_TEXT_COLOR,
                 )
 

--- a/src/crimson/views/perks.py
+++ b/src/crimson/views/perks.py
@@ -17,7 +17,6 @@ from ..gameplay import (
 from ..perks import PERK_BY_ID, PerkId, perk_display_description, perk_display_name
 from ..ui.menu_panel import draw_classic_menu_panel
 from ..ui.perk_menu import (
-    PERK_MENU_DESC_TEXT_SCALE,
     PerkMenuLayout,
     UiButtonState,
     button_draw,
@@ -341,12 +340,11 @@ class PerkSelectionView:
 
         selected = choices[self._perk_menu_selected]
         desc = perk_display_description(int(selected))
-        desc_scale = scale * PERK_MENU_DESC_TEXT_SCALE
         draw_wrapped_ui_text_in_rect(
             self._small,
             desc,
             rect=computed.desc,
-            scale=desc_scale,
+            scale=scale,
             color=UI_TEXT_COLOR,
         )
 


### PR DESCRIPTION
## Summary
- align perk menu description rendering with decompile behavior (no extra local downscale)
- add `PERK_MENU_DESC_TEXT_SCALE = 1.0` and reuse it across runtime perk menu, perks view, and perk menu debug view
- remove hardcoded `* 0.85` description scale in all perk-menu render paths

## Verification
- manual in-game check (user-verified)
- `just check`
