### PR TITLE
docs: require body-file for gh pr descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,8 @@ for deterministic gameplay code, prefer native float32 fidelity over readability
 - do not normalize values like 0.6000000238418579 -> 0.6 in parity-critical paths unless captures/tests prove no behavioral change.
 
 run `just check` before commits
+
+when creating pull requests with `gh`:
+- do not pass multiline bodies via `--body` with escaped `\n` inside shell quotes.
+- write the PR description to a markdown file (or heredoc) and use `gh pr create --body-file <file>` / `gh pr edit --body-file <file>`.
+- after creating/updating a PR, verify formatting with `gh pr view`.


### PR DESCRIPTION
## Summary
- add explicit `gh` PR authoring guidance to `AGENTS.md`
- require `--body-file`/heredoc for multiline PR descriptions
- add a verification step with `gh pr view` after PR create/edit

## Testing
- `just check`
