### PR TITLE
fix(game): preserve gameplay ground when returning to menu

### DIFF
--- a/src/crimson/frontend/menu.py
+++ b/src/crimson/frontend/menu.py
@@ -63,6 +63,13 @@ MENU_SIGN_POS_X_PAD = 4.0
 MENU_DEMO_IDLE_START_MS = 23_000
 
 
+def menu_ground_camera(state: GameState) -> Vec2:
+    camera = getattr(state, "menu_ground_camera", None)
+    if isinstance(camera, Vec2):
+        return camera
+    return Vec2()
+
+
 def ensure_menu_ground(state: GameState, *, regenerate: bool = False) -> GroundRenderer | None:
     cache = state.texture_cache
     if cache is None:
@@ -101,6 +108,7 @@ def ensure_menu_ground(state: GameState, *, regenerate: bool = False) -> GroundR
             regenerate = True
     if regenerate:
         ground.schedule_generate(seed=state.rng.randrange(0, 10_000), layers=3)
+        state.menu_ground_camera = None
     return ground
 
 
@@ -269,7 +277,7 @@ class MenuView:
     def draw(self) -> None:
         rl.clear_background(rl.BLACK)
         if self._ground is not None:
-            self._ground.draw(Vec2())
+            self._ground.draw(menu_ground_camera(self._state))
         _draw_screen_fade(self._state)
         assets = self._assets
         if assets is None:

--- a/src/crimson/frontend/panels/alien_zookeeper.py
+++ b/src/crimson/frontend/panels/alien_zookeeper.py
@@ -31,6 +31,7 @@ from ..menu import (
     MenuView,
     _draw_menu_cursor,
     ensure_menu_ground,
+    menu_ground_camera,
 )
 from ..transitions import _draw_screen_fade
 from ..types import GameState
@@ -420,7 +421,7 @@ class AlienZooKeeperView:
         if pause_background is not None:
             pause_background.draw_pause_background()
         elif self._ground is not None:
-            self._ground.draw(Vec2())
+            self._ground.draw(menu_ground_camera(self._state))
         _draw_screen_fade(self._state)
 
         font = self._ensure_small_font()

--- a/src/crimson/frontend/panels/base.py
+++ b/src/crimson/frontend/panels/base.py
@@ -35,6 +35,7 @@ from ..menu import (
     MenuView,
     _draw_menu_cursor,
     ensure_menu_ground,
+    menu_ground_camera,
 )
 from ..transitions import _draw_screen_fade
 
@@ -217,7 +218,7 @@ class PanelMenuView:
             pause_background.draw_pause_background()
             return
         if self._ground is not None:
-            self._ground.draw(Vec2())
+            self._ground.draw(menu_ground_camera(self._state))
 
     def _draw_panel(self) -> None:
         assets = self._assets

--- a/src/crimson/frontend/panels/credits.py
+++ b/src/crimson/frontend/panels/credits.py
@@ -34,6 +34,7 @@ from ..menu import (
     MenuView,
     _draw_menu_cursor,
     ensure_menu_ground,
+    menu_ground_camera,
 )
 from ..transitions import _draw_screen_fade
 from ..types import GameState
@@ -552,7 +553,7 @@ class CreditsView:
         if pause_background is not None:
             pause_background.draw_pause_background()
         elif self._ground is not None:
-            self._ground.draw(Vec2())
+            self._ground.draw(menu_ground_camera(self._state))
         _draw_screen_fade(self._state)
 
         assets = self._assets

--- a/src/crimson/frontend/panels/databases.py
+++ b/src/crimson/frontend/panels/databases.py
@@ -29,6 +29,7 @@ from ..menu import (
     MenuView,
     _draw_menu_cursor,
     ensure_menu_ground,
+    menu_ground_camera,
 )
 from ..transitions import _draw_screen_fade
 from ..types import GameState
@@ -225,7 +226,7 @@ class _DatabaseBaseView:
         if pause_background is not None:
             pause_background.draw_pause_background()
         elif self._ground is not None:
-            self._ground.draw(Vec2())
+            self._ground.draw(menu_ground_camera(self._state))
         _draw_screen_fade(self._state)
 
         assets = self._assets

--- a/src/crimson/frontend/panels/stats.py
+++ b/src/crimson/frontend/panels/stats.py
@@ -28,6 +28,7 @@ from ..menu import (
     MenuView,
     _draw_menu_cursor,
     ensure_menu_ground,
+    menu_ground_camera,
 )
 from ..transitions import _draw_screen_fade
 from ..types import GameState
@@ -265,7 +266,7 @@ class StatisticsMenuView:
         if pause_background is not None:
             pause_background.draw_pause_background()
         elif self._ground is not None:
-            self._ground.draw(Vec2())
+            self._ground.draw(menu_ground_camera(self._state))
         _draw_screen_fade(self._state)
 
         assets = self._assets

--- a/src/crimson/frontend/types.py
+++ b/src/crimson/frontend/types.py
@@ -26,6 +26,7 @@ class GameState(Protocol):
     console: Any
 
     menu_ground: Any
+    menu_ground_camera: Any
     pause_background: PauseBackground | None
 
     demo_enabled: bool

--- a/src/crimson/modes/base_gameplay_mode.py
+++ b/src/crimson/modes/base_gameplay_mode.py
@@ -314,6 +314,9 @@ class BaseGameplayMode:
         self._world.ground = None
         return ground
 
+    def menu_ground_camera(self) -> Vec2:
+        return self._world.camera
+
     def _draw_screen_fade(self) -> None:
         fade_alpha = 0.0
         if self._screen_fade is not None:

--- a/tests/test_game_loop_ground_persistence.py
+++ b/tests/test_game_loop_ground_persistence.py
@@ -3,24 +3,36 @@ from __future__ import annotations
 from pathlib import Path
 import random
 import time
+from typing import Any, cast
 
 import pyray as rl
 
 from crimson.game import GameLoopView, GameState
+from crimson.frontend.menu import ensure_menu_ground
 from crimson.persistence import save_status
 from grim.config import ensure_crimson_cfg
 from grim.console import create_console
+from grim.geom import Vec2
 from grim.terrain_render import GroundRenderer
 
 
 class _GroundSourceView:
-    def __init__(self, ground: GroundRenderer | None) -> None:
+    def __init__(self, ground: GroundRenderer | None, camera: Vec2 | None = None) -> None:
         self._ground = ground
+        self._camera = camera
 
     def steal_ground_for_menu(self) -> GroundRenderer | None:
         ground = self._ground
         self._ground = None
         return ground
+
+    def menu_ground_camera(self) -> Vec2 | None:
+        return self._camera
+
+
+class _TextureCacheStub:
+    def texture(self, _name: str) -> rl.Texture:
+        return cast(rl.Texture, rl.Texture())
 
 
 def _build_state(tmp_path: Path) -> GameState:
@@ -50,9 +62,11 @@ def test_capture_gameplay_ground_from_active_view(tmp_path: Path) -> None:
 
     menu_ground = GroundRenderer(texture=rl.Texture())
     gameplay_ground = GroundRenderer(texture=rl.Texture())
-    gameplay_view = _GroundSourceView(gameplay_ground)
+    gameplay_camera = Vec2(-321.25, -456.5)
+    gameplay_view = _GroundSourceView(gameplay_ground, gameplay_camera)
 
     state.menu_ground = menu_ground
+    state.menu_ground_camera = Vec2(-1.0, -1.0)
     loop._front_active = gameplay_view
     loop._front_stack = []
     loop._gameplay_views = frozenset({gameplay_view})
@@ -60,6 +74,7 @@ def test_capture_gameplay_ground_from_active_view(tmp_path: Path) -> None:
     loop._capture_gameplay_ground_for_menu()
 
     assert state.menu_ground is gameplay_ground
+    assert state.menu_ground_camera == gameplay_camera
     assert gameplay_view.steal_ground_for_menu() is None
 
 
@@ -69,10 +84,12 @@ def test_capture_gameplay_ground_from_stacked_view(tmp_path: Path) -> None:
 
     menu_ground = GroundRenderer(texture=rl.Texture())
     gameplay_ground = GroundRenderer(texture=rl.Texture())
-    gameplay_view = _GroundSourceView(gameplay_ground)
+    gameplay_camera = Vec2(-611.0, -322.0)
+    gameplay_view = _GroundSourceView(gameplay_ground, gameplay_camera)
     overlay_view = object()
 
     state.menu_ground = menu_ground
+    state.menu_ground_camera = Vec2(-1.0, -1.0)
     loop._front_active = overlay_view
     loop._front_stack = [gameplay_view]
     loop._gameplay_views = frozenset({gameplay_view})
@@ -80,4 +97,16 @@ def test_capture_gameplay_ground_from_stacked_view(tmp_path: Path) -> None:
     loop._capture_gameplay_ground_for_menu()
 
     assert state.menu_ground is gameplay_ground
+    assert state.menu_ground_camera == gameplay_camera
     assert gameplay_view.steal_ground_for_menu() is None
+
+
+def test_regenerate_menu_ground_resets_menu_camera(tmp_path: Path) -> None:
+    state = _build_state(tmp_path)
+    state.texture_cache = cast(Any, _TextureCacheStub())
+    state.menu_ground_camera = Vec2(-100.0, -200.0)
+
+    ground = ensure_menu_ground(state, regenerate=True)
+
+    assert ground is not None
+    assert state.menu_ground_camera is None


### PR DESCRIPTION
## Summary
- capture gameplay `GroundRenderer` before gameplay views close and transfer it into `state.menu_ground` on menu-return transitions
- support both direct gameplay->menu and stacked flows (for example gameplay->high scores->menu)
- add regression tests for active and stacked capture paths

## Validation
- `just check`
