### PR TITLE
feat(original-capture): enforce capture format version gate

### DIFF
--- a/docs/frida/differential-playbook.md
+++ b/docs/frida/differential-playbook.md
@@ -38,6 +38,7 @@ from crimson.original.capture import load_capture
 p = Path("artifacts/frida/share/gameplay_diff_capture.json")
 print("sha256", hashlib.sha256(p.read_bytes()).hexdigest())
 cap = load_capture(p)
+print("capture_format_version", int(cap.capture_format_version))
 ticks = cap.ticks
 print("ticks", len(ticks))
 if ticks:
@@ -49,6 +50,8 @@ PY
 Notes:
 
 - Loader success is the gate. If it decodes cleanly, continue.
+- Loader enforces exact `capture_format_version`; stale version captures must be
+  re-recorded with the current script.
 - Capture loading is strict: a truncated trailing JSONL row is a blocker and should be recaptured.
 
 ## 3) Decide session bookkeeping

--- a/docs/frida/gameplay-diff-capture.md
+++ b/docs/frida/gameplay-diff-capture.md
@@ -35,6 +35,8 @@ The capture file is newline-delimited JSON rows:
 
 - `{"event":"capture_meta","capture":{...}}` exactly once at start
 - `{"event":"tick","tick":{...}}` once per captured gameplay tick
+- `capture_meta.capture_format_version` is required and must match the current
+  loader version (`2`).
 
 `uv run crimson original ...` commands load this stream and normalize it to the
 typed `CaptureFile` schema in Python (`msgspec`).
@@ -46,6 +48,8 @@ Notes:
 - Before detaching from a live Frida session, call `crimsonCaptureStop("manual_stop")`
   in the REPL and wait for the `capture_shutdown` log line.
 - Loader behavior is strict: truncated trailing JSON rows are rejected.
+- Loader behavior is strict: only captures with the current
+  `capture_format_version` are accepted.
 - Loader accepts only stream rows (`capture_meta` + `tick`), not legacy
   monolithic JSON captures.
 - Entity `samples` payloads are strictly typed (`creatures`, `projectiles`,

--- a/scripts/frida/gameplay_diff_capture.js
+++ b/scripts/frida/gameplay_diff_capture.js
@@ -16,6 +16,7 @@ const DEFAULT_LOG_DIR = "C:\\share\\frida";
 const DEFAULT_TRACKED_STATES = "6,7,8,9,10,12,14,18";
 const DEFAULT_CONSOLE_EVENTS =
   "start,ready,capture_shutdown,error,hook_error,hook_skip,tickless_event";
+const CAPTURE_FORMAT_VERSION = 2;
 const LINK_BASE = ptr("0x00400000");
 const GAME_MODULE = "crimsonland.exe";
 const GRIM_MODULE = "grim.dll";
@@ -1945,6 +1946,7 @@ function emitRngRollEvent(rollRow) {
   writeLine({
     event: "rng_roll",
     script: "gameplay_diff_capture",
+    capture_format_version: CAPTURE_FORMAT_VERSION,
     session_id: outState.sessionId,
     seq: rollRow.seq,
     seed_epoch: rollRow.seed_epoch,
@@ -3722,6 +3724,7 @@ function main() {
     enable_creature_lifecycle_digest: CONFIG.enableCreatureLifecycleDigest,
   };
   const captureMeta = {
+    capture_format_version: CAPTURE_FORMAT_VERSION,
     script: "gameplay_diff_capture",
     session_id: outState.sessionId,
     out_path: CONFIG.outPath,
@@ -3752,6 +3755,7 @@ function main() {
 
   writeLine({
     event: "start",
+    capture_format_version: CAPTURE_FORMAT_VERSION,
     session_id: outState.sessionId,
     out_path: CONFIG.outPath,
     capture_file_started: outState.captureStarted,
@@ -3777,7 +3781,12 @@ function main() {
     shutdownCapture("script_unload");
   });
 
-  writeLine({ event: "ready", session_id: outState.sessionId, capture_file_started: outState.captureStarted });
+  writeLine({
+    event: "ready",
+    capture_format_version: CAPTURE_FORMAT_VERSION,
+    session_id: outState.sessionId,
+    capture_file_started: outState.captureStarted,
+  });
 }
 
 main();

--- a/src/crimson/original/schema.py
+++ b/src/crimson/original/schema.py
@@ -4,6 +4,8 @@ from typing import Literal, TypeAlias
 
 import msgspec
 
+CAPTURE_FORMAT_VERSION = 2
+
 
 class CaptureConfig(msgspec.Struct):
     log_mode: str = "truncate"
@@ -675,6 +677,7 @@ class CaptureFile(msgspec.Struct, forbid_unknown_fields=True):
     script: Literal["gameplay_diff_capture"]
     session_id: str
     out_path: str
+    capture_format_version: int = -1
     config: CaptureConfig = msgspec.field(default_factory=CaptureConfig)
     session_fingerprint: SessionFingerprint = msgspec.field(default_factory=_default_session_fingerprint)
     process: ProcessInfo = msgspec.field(default_factory=_default_process_info)

--- a/tests/test_original_capture_divergence_report_rng_calls.py
+++ b/tests/test_original_capture_divergence_report_rng_calls.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from grim.geom import Vec2
 
+from crimson.original.schema import CAPTURE_FORMAT_VERSION
 from crimson.replay.checkpoints import (
     ReplayCheckpoint,
     ReplayDeathLedgerEntry,
@@ -378,6 +379,7 @@ def test_load_raw_tick_debug_tracks_sample_coverage(tmp_path: Path) -> None:
         },
     }
     capture_obj = {
+        "capture_format_version": int(CAPTURE_FORMAT_VERSION),
         "script": "gameplay_diff_capture",
         "session_id": "s",
         "out_path": "capture.json",

--- a/tests/test_original_capture_divergence_report_summary.py
+++ b/tests/test_original_capture_divergence_report_summary.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from grim.geom import Vec2
 
+from crimson.original.schema import CAPTURE_FORMAT_VERSION
 from crimson.replay.checkpoints import (
     ReplayCheckpoint,
     ReplayEventSummary,
@@ -121,6 +122,7 @@ def _capture_tick(
 
 def _capture_obj(*, ticks: list[dict[str, object]]) -> dict[str, object]:
     return {
+        "capture_format_version": int(CAPTURE_FORMAT_VERSION),
         "script": "gameplay_diff_capture",
         "session_id": "s",
         "out_path": "capture.json",


### PR DESCRIPTION
## Summary
- add explicit `capture_format_version` to gameplay differential captures and set the current version to `2`
- enforce strict version matching in `load_capture`/`dump_capture` so stale or missing-version captures fail fast
- add regression tests for missing/unsupported format versions and update divergence-report fixtures to include the required version
- document the strict version requirement in differential capture/playbook docs
- append Session 8 notes for SHA `6ee322a6...` showing stale-capture triage outcome

## Validation
- `uv run pytest tests/test_original_capture_conversion.py`
- `just check`
- `uv run python - <<'PY' ... load_capture("artifacts/frida/share/gameplay_diff_capture.json.gz") ...` (verified explicit error: `got -1, expected 2`)
