### PR TITLE
fix: align transition timing and entity fade parity

### DIFF
--- a/src/crimson/frontend/types.py
+++ b/src/crimson/frontend/types.py
@@ -6,7 +6,7 @@ from typing import Any, Protocol
 
 
 class PauseBackground(Protocol):
-    def draw_pause_background(self) -> None: ...
+    def draw_pause_background(self, *, entity_alpha: float = 1.0) -> None: ...
 
 
 class GameState(Protocol):

--- a/src/crimson/modes/base_gameplay_mode.py
+++ b/src/crimson/modes/base_gameplay_mode.py
@@ -310,8 +310,18 @@ class BaseGameplayMode:
             self._action = "back_to_menu"
             self.close_requested = True
 
-    def draw_pause_background(self) -> None:
-        self._world.draw(draw_aim_indicators=False)
+    def _world_entity_alpha(self) -> float:
+        if not self._game_over_active:
+            return 1.0
+        return float(self._game_over_ui.world_entity_alpha())
+
+    def draw_pause_background(self, *, entity_alpha: float = 1.0) -> None:
+        alpha = float(entity_alpha)
+        if alpha < 0.0:
+            alpha = 0.0
+        elif alpha > 1.0:
+            alpha = 1.0
+        self._world.draw(draw_aim_indicators=False, entity_alpha=self._world_entity_alpha() * alpha)
 
     def steal_ground_for_menu(self):
         ground = self._world.ground

--- a/src/crimson/modes/quest_mode.py
+++ b/src/crimson/modes/quest_mode.py
@@ -691,7 +691,10 @@ class QuestMode(BaseGameplayMode):
 
     def draw(self) -> None:
         perk_menu_active = self._perk_menu.active
-        self._world.draw(draw_aim_indicators=not perk_menu_active)
+        self._world.draw(
+            draw_aim_indicators=not perk_menu_active,
+            entity_alpha=self._world_entity_alpha(),
+        )
         self._draw_screen_fade()
 
         hud_bottom = 0.0

--- a/src/crimson/modes/rush_mode.py
+++ b/src/crimson/modes/rush_mode.py
@@ -372,7 +372,10 @@ class RushMode(BaseGameplayMode):
         draw_aim_cursor(self._world.particles_texture, aim_tex, pos=mouse_pos)
 
     def draw(self) -> None:
-        self._world.draw(draw_aim_indicators=(not self._game_over_active))
+        self._world.draw(
+            draw_aim_indicators=(not self._game_over_active),
+            entity_alpha=self._world_entity_alpha(),
+        )
         self._draw_screen_fade()
 
         hud_bottom = 0.0

--- a/src/crimson/modes/tutorial_mode.py
+++ b/src/crimson/modes/tutorial_mode.py
@@ -350,7 +350,10 @@ class TutorialMode(BaseGameplayMode):
 
     def draw(self) -> None:
         perk_menu_active = self._perk_menu.active
-        self._world.draw(draw_aim_indicators=not perk_menu_active)
+        self._world.draw(
+            draw_aim_indicators=not perk_menu_active,
+            entity_alpha=self._world_entity_alpha(),
+        )
         self._draw_screen_fade()
 
         hud_bottom = 0.0

--- a/src/crimson/modes/typo_mode.py
+++ b/src/crimson/modes/typo_mode.py
@@ -398,7 +398,7 @@ class TypoShooterMode(BaseGameplayMode):
         alive = self._player.health > 0.0
         show_gameplay_ui = alive and (not self._game_over_active)
 
-        self._world.draw(draw_aim_indicators=show_gameplay_ui)
+        self._world.draw(draw_aim_indicators=show_gameplay_ui, entity_alpha=self._world_entity_alpha())
         self._draw_screen_fade()
 
         if show_gameplay_ui:

--- a/src/crimson/original/focus_trace.py
+++ b/src/crimson/original/focus_trace.py
@@ -847,7 +847,7 @@ def trace_focus_tick(
                     hook_index += 1
                     return bool(handled)
 
-                world.state.rng.rand = traced_rand  # type: ignore[assignment]
+                world.state.rng.rand = traced_rand
                 world.state.particles._rand = traced_rand
                 world.state.sprite_effects._rand = traced_rand
                 projectiles_mod._within_native_find_radius = traced_within_native_find_radius  # type: ignore[assignment]
@@ -876,7 +876,7 @@ def trace_focus_tick(
                 )
 
             if int(tick_index) == int(tick):
-                world.state.rng.rand = orig_rand  # type: ignore[assignment]
+                world.state.rng.rand = orig_rand
                 world.state.particles._rand = orig_particles_rand
                 world.state.sprite_effects._rand = orig_sprite_effects_rand
                 projectiles_mod._within_native_find_radius = orig_within
@@ -887,7 +887,7 @@ def trace_focus_tick(
                 for _ in range(draws):
                     world.state.rng.rand()
     finally:
-        world.state.rng.rand = orig_rand  # type: ignore[assignment]
+        world.state.rng.rand = orig_rand
         world.state.particles._rand = orig_particles_rand
         world.state.sprite_effects._rand = orig_sprite_effects_rand
         projectiles_mod._within_native_find_radius = orig_within

--- a/src/crimson/ui/game_over.py
+++ b/src/crimson/ui/game_over.py
@@ -215,6 +215,18 @@ class GameOverUi:
             return True
         return False
 
+    def world_entity_alpha(self) -> float:
+        if not self._closing:
+            return 1.0
+        if PANEL_SLIDE_DURATION_MS <= 1e-6:
+            return 0.0
+        alpha = float(self._intro_ms) / float(PANEL_SLIDE_DURATION_MS)
+        if alpha < 0.0:
+            return 0.0
+        if alpha > 1.0:
+            return 1.0
+        return alpha
+
     def _text_width(self, text: str, scale: float) -> float:
         if self.font is None:
             return float(rl.measure_text(text, int(20 * scale)))

--- a/src/crimson/ui/quest_results.py
+++ b/src/crimson/ui/quest_results.py
@@ -263,6 +263,24 @@ class QuestResultsUi:
         self._closing = True
         self._close_action = action
 
+    def world_entity_alpha(self) -> float:
+        if not self._closing:
+            return 1.0
+        t_ms = float(self._intro_ms)
+        if t_ms <= PANEL_SLIDE_END_MS:
+            return 0.0
+        if t_ms >= PANEL_SLIDE_START_MS:
+            return 1.0
+        span = float(PANEL_SLIDE_START_MS - PANEL_SLIDE_END_MS)
+        if span <= 1e-6:
+            return 1.0
+        alpha = (t_ms - PANEL_SLIDE_END_MS) / span
+        if alpha < 0.0:
+            return 0.0
+        if alpha > 1.0:
+            return 1.0
+        return alpha
+
     def _text_width(self, text: str, scale: float) -> float:
         if self.font is None:
             return float(rl.measure_text(text, int(20 * scale)))

--- a/tests/test_end_note_view.py
+++ b/tests/test_end_note_view.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+import random
+import time
+from types import SimpleNamespace
+
+import pyray as rl
+
+from crimson.game import EndNoteView, GameState, PANEL_TIMELINE_START_MS
+from crimson.persistence import save_status
+from grim.config import ensure_crimson_cfg
+from grim.console import create_console
+
+
+def _make_state(tmp_path: Path, *, audio) -> GameState:  # noqa: ANN001
+    cfg = ensure_crimson_cfg(tmp_path)
+    return GameState(
+        base_dir=tmp_path,
+        assets_dir=tmp_path,
+        rng=random.Random(0),
+        config=cfg,
+        status=save_status.ensure_game_status(tmp_path),
+        console=create_console(tmp_path, assets_dir=tmp_path),
+        demo_enabled=False,
+        preserve_bugs=False,
+        logos=None,
+        texture_cache=None,
+        audio=audio,
+        resource_paq=tmp_path / "crimson.paq",
+        session_start=time.monotonic(),
+    )
+
+
+def test_end_note_escape_waits_for_close_transition(monkeypatch, tmp_path: Path) -> None:
+    state = _make_state(tmp_path, audio=object())
+    played: list[str] = []
+
+    class _DummyCache:
+        def get_or_load(self, *_args, **_kwargs):  # noqa: ANN001
+            return SimpleNamespace(texture=None)
+
+    def _play_sfx(_audio, key, *, rng=None, allow_variants=True) -> None:  # noqa: ARG001
+        played.append(key)
+
+    monkeypatch.setattr("crimson.game.update_audio", lambda _audio, _dt: None)
+    monkeypatch.setattr("crimson.game._ensure_texture_cache", lambda _state: _DummyCache())
+    monkeypatch.setattr("crimson.game.play_sfx", _play_sfx)
+    monkeypatch.setattr("crimson.game.rl.is_key_pressed", lambda _key: False)
+
+    view = EndNoteView(state)
+    view.open()
+    view.update(0.1)
+    view.update(0.1)
+    view.update(0.1)
+
+    monkeypatch.setattr("crimson.game.rl.is_key_pressed", lambda key: int(key) == int(rl.KeyboardKey.KEY_ESCAPE))
+    view.update(0.1)
+
+    assert played == ["sfx_ui_buttonclick"]
+    assert view.take_action() is None
+
+    monkeypatch.setattr("crimson.game.rl.is_key_pressed", lambda _key: False)
+    action = None
+    for _ in range(30):
+        view.update(1.0 / 60.0)
+        action = view.take_action()
+        if action is not None:
+            break
+    assert action == "back_to_menu"
+
+
+def test_end_note_draw_fades_pause_background_during_close(monkeypatch, tmp_path: Path) -> None:
+    state = _make_state(tmp_path, audio=None)
+    captured_alpha: list[float] = []
+    state.pause_background = SimpleNamespace(
+        draw_pause_background=lambda *, entity_alpha=1.0: captured_alpha.append(float(entity_alpha))
+    )
+
+    class _DummyCache:
+        def get_or_load(self, *_args, **_kwargs):  # noqa: ANN001
+            return SimpleNamespace(texture=None)
+
+    monkeypatch.setattr("crimson.game.update_audio", lambda _audio, _dt: None)
+    monkeypatch.setattr("crimson.game._ensure_texture_cache", lambda _state: _DummyCache())
+    monkeypatch.setattr("crimson.game.rl.clear_background", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("crimson.game._draw_screen_fade", lambda *_args, **_kwargs: None)
+
+    view = EndNoteView(state)
+    view.open()
+    view._closing = True
+    view._timeline_ms = PANEL_TIMELINE_START_MS // 2
+    view._panel_tex = None
+    view.draw()
+
+    assert captured_alpha
+    assert captured_alpha[-1] == 0.5

--- a/tests/test_game_over_layout.py
+++ b/tests/test_game_over_layout.py
@@ -98,3 +98,18 @@ def test_game_over_draw_uses_classic_menu_panel(monkeypatch, tmp_path: Path) -> 
     assert panel_rect.width == 510.0
     assert panel_rect.height == 378.0
     assert shadow_enabled is False
+
+
+def test_game_over_world_entity_alpha_tracks_close_timeline(tmp_path: Path) -> None:
+    ui = GameOverUi(assets_root=tmp_path, base_dir=tmp_path, config=object())
+
+    ui._closing = True
+    ui._intro_ms = PANEL_SLIDE_DURATION_MS * 0.5
+    assert ui.world_entity_alpha() == 0.5
+
+    ui._intro_ms = -1.0
+    assert ui.world_entity_alpha() == 0.0
+
+    ui._closing = False
+    ui._intro_ms = 0.0
+    assert ui.world_entity_alpha() == 1.0

--- a/tests/test_game_over_sfx.py
+++ b/tests/test_game_over_sfx.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 import pyray as rl
 
-from crimson.game import GameState, HighScoresRequest, HighScoresView
+from crimson.game import PANEL_TIMELINE_START_MS, GameState, HighScoresRequest, HighScoresView
 from crimson.persistence import save_status
 from crimson.persistence.highscores import HighScoreRecord
 from crimson.ui.game_over import GameOverUi, PANEL_SLIDE_DURATION_MS
@@ -103,4 +103,58 @@ def test_high_scores_view_open_plays_panel_click_and_escape_plays_button_click(m
     view.update(0.1)
 
     assert played == ["sfx_ui_panelclick", "sfx_ui_buttonclick"]
-    assert view.take_action() == "back_to_previous"
+    assert view.take_action() is None
+    action = None
+    for _ in range(30):
+        view.update(1.0 / 60.0)
+        action = view.take_action()
+        if action is not None:
+            break
+    assert action == "back_to_previous"
+
+
+def test_high_scores_view_draw_fades_pause_background_during_close(monkeypatch, tmp_path: Path) -> None:
+    assets_dir = tmp_path
+    cfg = ensure_crimson_cfg(tmp_path)
+    state = GameState(
+        base_dir=tmp_path,
+        assets_dir=assets_dir,
+        rng=random.Random(0),
+        config=cfg,
+        status=save_status.ensure_game_status(tmp_path),
+        console=create_console(tmp_path, assets_dir=assets_dir),
+        demo_enabled=False,
+        preserve_bugs=False,
+        logos=None,
+        texture_cache=None,
+        audio=None,
+        resource_paq=tmp_path / "crimson.paq",
+        session_start=time.monotonic(),
+    )
+    state.pending_high_scores = HighScoresRequest(game_mode_id=1)
+    captured_alpha: list[float] = []
+    state.pause_background = SimpleNamespace(
+        draw_pause_background=lambda *, entity_alpha=1.0: captured_alpha.append(float(entity_alpha))
+    )
+
+    class _DummyCache:
+        def get_or_load(self, *_args, **_kwargs):  # noqa: ANN001
+            return SimpleNamespace(texture=None)
+
+    monkeypatch.setattr("crimson.game.update_audio", lambda _audio, _dt: None)
+    monkeypatch.setattr("crimson.game._ensure_texture_cache", lambda _state: _DummyCache())
+    monkeypatch.setattr(
+        "crimson.game.load_menu_assets",
+        lambda _state: SimpleNamespace(sign=None, item=None, panel=None, labels=None),
+    )
+    monkeypatch.setattr("crimson.game.rl.clear_background", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("crimson.game._draw_screen_fade", lambda *_args, **_kwargs: None)
+
+    view = HighScoresView(state)
+    view.open()
+    view._closing = True
+    view._timeline_ms = PANEL_TIMELINE_START_MS // 2
+    view.draw()
+
+    assert captured_alpha
+    assert captured_alpha[-1] == 0.5

--- a/tests/test_grim_deal_survival_mode_death.py
+++ b/tests/test_grim_deal_survival_mode_death.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pyray as rl
 
+from crimson.game_world import GameWorld
 from crimson.gameplay import perk_apply
 from crimson.modes.survival_mode import SurvivalMode
 from crimson.perks import PerkId
@@ -16,11 +18,36 @@ def _make_survival_mode() -> SurvivalMode:
     return SurvivalMode(ctx)
 
 
+def _install_minimal_sim_session(mode: SurvivalMode, monkeypatch) -> None:
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.game_tune_started = False
+            self.elapsed_ms = 0.0
+            self.stage = 0
+            self.spawn_cooldown_ms = 0.0
+            self.detail_preset = 5
+            self.fx_toggle = 0
+
+        def step_tick(self, *, dt_frame: float, inputs):  # noqa: ANN001
+            _ = inputs
+            self.elapsed_ms += float(dt_frame) * 1000.0
+            for player in mode._world.players:
+                if float(player.health) <= 0.0:
+                    player.death_timer -= float(dt_frame) * 20.0
+            step = SimpleNamespace(events=SimpleNamespace(deaths=()), command_hash=0)
+            return SimpleNamespace(step=step, rng_marks={})
+
+    mode._sim_session = _FakeSession()
+    monkeypatch.setattr(GameWorld, "apply_step_result", lambda *_args, **_kwargs: None)
+
+
 def test_survival_mode_enters_game_over_when_grim_deal_kills_player_during_perk_menu_transition(monkeypatch) -> None:
     mode = _make_survival_mode()
     monkeypatch.setattr("crimson.ui.game_over.GameOverUi.open", lambda self: None)  # noqa: ARG005
+    _install_minimal_sim_session(mode, monkeypatch)
 
     assert mode._player.health > 0.0
+    mode._player.death_timer = 0.3
     mode._perk_menu.open = True
     mode._perk_menu.timeline_ms = 100.0
 
@@ -38,4 +65,9 @@ def test_survival_mode_enters_game_over_when_grim_deal_kills_player_during_perk_
     mode.update(1.0 / 60.0)
 
     assert mode._player.health < 0.0
+    assert mode._game_over_active is False
+    for _ in range(120):
+        mode.update(1.0 / 60.0)
+        if mode._game_over_active:
+            break
     assert mode._game_over_active is True

--- a/tests/test_quest_failed_panel.py
+++ b/tests/test_quest_failed_panel.py
@@ -7,7 +7,12 @@ from types import SimpleNamespace
 
 import pyray as rl
 
-from crimson.game import GameState, QUEST_FAILED_PANEL_W, QuestFailedView
+from crimson.game import (
+    GameState,
+    QUEST_FAILED_PANEL_SLIDE_DURATION_MS,
+    QUEST_FAILED_PANEL_W,
+    QuestFailedView,
+)
 from crimson.modes.quest_mode import QuestRunOutcome
 from crimson.persistence import save_status
 from grim.geom import Vec2
@@ -33,7 +38,7 @@ def _make_state(tmp_path: Path) -> GameState:
         session_start=time.monotonic(),
     )
     # Avoid ground/menu asset loading in tests.
-    state.pause_background = object()
+    state.pause_background = SimpleNamespace(draw_pause_background=lambda **_kwargs: None)
     return state
 
 
@@ -229,3 +234,36 @@ def test_quest_failed_score_block_matches_native_fields(monkeypatch, tmp_path: P
     assert not any(text.startswith("Hit %:") for text in drawn_text)
     assert drawn_lines  # vertical separator
     assert any(w == 192 and h == 1 for (_x, _y, w, h) in drawn_rects)  # horizontal separator
+
+
+def test_quest_failed_draw_fades_pause_background_during_close(monkeypatch, tmp_path: Path) -> None:
+    state = _make_state(tmp_path)
+    state.quest_outcome = _failed_outcome()
+    captured_alpha: list[float] = []
+    state.pause_background = SimpleNamespace(
+        draw_pause_background=lambda *, entity_alpha=1.0: captured_alpha.append(float(entity_alpha))
+    )
+
+    class _DummyCache:
+        def get_or_load(self, *_args, **_kwargs):  # noqa: ANN001
+            return SimpleNamespace(texture=None)
+
+    view = QuestFailedView(state)
+    monkeypatch.setattr("crimson.game._ensure_texture_cache", lambda _state: _DummyCache())
+    monkeypatch.setattr("crimson.game.rl.clear_background", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("crimson.game.rl.get_screen_width", lambda: 640)
+    monkeypatch.setattr("crimson.game._draw_screen_fade", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("crimson.game._draw_menu_cursor", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("crimson.game.draw_small_text", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("crimson.game.button_draw", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("crimson.game.button_width", lambda *_args, **_kwargs: 82.0)
+    monkeypatch.setattr(view, "_ensure_small_font", lambda: SimpleNamespace())
+    monkeypatch.setattr(view, "_draw_score_preview", lambda *_args, **_kwargs: None)
+
+    view.open()
+    view._closing = True
+    view._intro_ms = QUEST_FAILED_PANEL_SLIDE_DURATION_MS * 0.5
+    view.draw()
+
+    assert captured_alpha
+    assert captured_alpha[-1] == 0.5

--- a/tests/test_quest_results_layout.py
+++ b/tests/test_quest_results_layout.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pyray as rl
 
 from crimson.persistence.highscores import HighScoreRecord
-from crimson.ui.quest_results import PANEL_SLIDE_START_MS, QuestResultsUi
+from crimson.ui.quest_results import PANEL_SLIDE_END_MS, PANEL_SLIDE_START_MS, QuestResultsUi
 
 
 def _build_ui(tmp_path: Path, *, phase: int) -> QuestResultsUi:
@@ -146,3 +146,24 @@ def test_quest_results_buttons_phase_keeps_weapon_stats_hidden(monkeypatch, tmp_
     assert "Hit %: 23%" not in captured_text
     assert "Shotgun" not in captured_text
     assert texture_draws == []
+
+
+def test_quest_results_world_entity_alpha_tracks_close_timeline(tmp_path: Path) -> None:
+    ui = QuestResultsUi(
+        assets_root=tmp_path,
+        base_dir=tmp_path,
+        config=SimpleNamespace(data={"fx_detail_0": 0}),
+    )
+
+    ui._closing = True
+    ui._intro_ms = PANEL_SLIDE_END_MS
+    assert ui.world_entity_alpha() == 0.0
+
+    ui._intro_ms = (PANEL_SLIDE_START_MS + PANEL_SLIDE_END_MS) * 0.5
+    assert ui.world_entity_alpha() == 0.5
+
+    ui._intro_ms = PANEL_SLIDE_START_MS
+    assert ui.world_entity_alpha() == 1.0
+
+    ui._closing = False
+    assert ui.world_entity_alpha() == 1.0


### PR DESCRIPTION
## Summary
- align survival death flow with the original by waiting for death-timer completion before opening the game-over/high-score transition
- add close-transition timing and background entity fade behavior for end-note, quest-failed, quest-results, high-scores, and game-over overlays
- propagate `entity_alpha` through pause-background draw protocols and all gameplay modes so menu transitions can fade world entities instead of popping
- clean up `ty` diagnostics by aligning `PauseBackground` protocol signatures and removing stale `type: ignore[assignment]` comments
- add regression tests for transition timing, deferred close actions, and world-entity alpha interpolation

## Testing
- `just check`
