### PR TITLE
refactor(input): add movement control enum for mode handling

### DIFF
--- a/src/crimson/frontend/panels/controls_labels.py
+++ b/src/crimson/frontend/panels/controls_labels.py
@@ -27,32 +27,31 @@ def input_configure_for_label(config_id: int) -> str:
     return "Unknown"
 
 
-def input_scheme_label(scheme: int | MovementControlType) -> str:
+def input_scheme_label(scheme: MovementControlType) -> str:
     """Port of `input_scheme_label` (0x00447cf0)."""
 
-    mode_type = movement_control_type_from_value(scheme)
-    if mode_type is None:
-        return "Unknown"
-
     labels = {
+        MovementControlType.UNKNOWN: "Unknown",
         MovementControlType.RELATIVE: "Relative",
         MovementControlType.STATIC: "Static",
         MovementControlType.DUAL_ACTION_PAD: "Dual Action Pad",
         MovementControlType.MOUSE_POINT_CLICK: "Mouse point click",
         MovementControlType.COMPUTER: "Computer",
     }
-    return labels.get(mode_type, "Unknown")
+    return labels.get(scheme, "Unknown")
 
 
-def _read_player_mode_flags(config_data: Mapping[str, object]) -> tuple[int, int, int, int]:
+def _read_player_mode_flags(
+    config_data: Mapping[str, object],
+) -> tuple[MovementControlType, MovementControlType, MovementControlType, MovementControlType]:
     # Defaults from `config_init_defaults`: 2 (Static) for player mode flags.
-    values = [2, 2, 2, 2]
+    values = [MovementControlType.STATIC] * 4
     raw = config_data.get("unknown_1c")
     if isinstance(raw, (bytes, bytearray)) and len(raw) >= 16:
         for idx in range(4):
             value = int(struct.unpack_from("<I", raw, idx * 4)[0])
             if value > 0:
-                values[idx] = value
+                values[idx] = movement_control_type_from_value(value)
     return (values[0], values[1], values[2], values[3])
 
 
@@ -88,11 +87,11 @@ def _read_aim_schemes(config_data: Mapping[str, object]) -> tuple[int, int, int,
     return (values[0], values[1], values[2], values[3])
 
 
-def controls_method_values(config_data: Mapping[str, object], *, player_index: int) -> tuple[int, int]:
+def controls_method_values(config_data: Mapping[str, object], *, player_index: int) -> tuple[int, MovementControlType]:
     player_idx = max(0, min(3, int(player_index)))
     aim_scheme = _read_aim_schemes(config_data)[player_idx]
     move_mode = _read_player_mode_flags(config_data)[player_idx]
-    return int(aim_scheme), int(move_mode)
+    return int(aim_scheme), move_mode
 
 
 def controls_method_labels(config_data: Mapping[str, object], *, player_index: int) -> tuple[str, str]:
@@ -111,7 +110,7 @@ def controls_aim_method_dropdown_ids(current_aim_scheme: int) -> tuple[int, ...]
 def controls_rebind_slot_plan(
     *,
     aim_scheme: int,
-    move_mode: int | MovementControlType,
+    move_mode: MovementControlType,
     player_index: int,
 ) -> tuple[tuple[tuple[str, int], ...], tuple[tuple[str, int], ...], tuple[tuple[str, int], ...]]:
     """Return (aim_rows, move_rows, misc_rows) for `controls_menu_update`."""
@@ -119,7 +118,6 @@ def controls_rebind_slot_plan(
     aim_rows: list[tuple[str, int]] = []
     move_rows: list[tuple[str, int]] = []
     misc_rows: list[tuple[str, int]] = []
-    move_mode_type = movement_control_type_from_value(move_mode)
 
     if int(aim_scheme) == 1:
         aim_rows.append(("Torso left:", 7))
@@ -129,7 +127,7 @@ def controls_rebind_slot_plan(
         aim_rows.append(("Aim Left/Right Axis:", 10))
     aim_rows.append(("Fire:", 4))
 
-    if move_mode_type is MovementControlType.STATIC:
+    if move_mode is MovementControlType.STATIC:
         move_rows.extend(
             (
                 ("Move Up:", 0),
@@ -138,7 +136,7 @@ def controls_rebind_slot_plan(
                 ("Move Right:", 3),
             )
         )
-    elif move_mode_type is MovementControlType.RELATIVE:
+    elif move_mode is MovementControlType.RELATIVE:
         move_rows.extend(
             (
                 ("Forward:", 0),
@@ -147,19 +145,19 @@ def controls_rebind_slot_plan(
                 ("Turn right:", 3),
             )
         )
-    elif move_mode_type is MovementControlType.DUAL_ACTION_PAD:
+    elif move_mode is MovementControlType.DUAL_ACTION_PAD:
         move_rows.extend(
             (
                 ("Up/Down Axis:", 11),
                 ("Left/Right Axis:", 12),
             )
         )
-    elif move_mode_type is MovementControlType.MOUSE_POINT_CLICK:
+    elif move_mode is MovementControlType.MOUSE_POINT_CLICK:
         move_rows.append(("Move to cursor:", RELOAD_BIND_SLOT))
 
     if int(player_index) == 0:
         misc_rows.append(("Level Up:", PICK_PERK_BIND_SLOT))
-        if move_mode_type is not MovementControlType.MOUSE_POINT_CLICK:
+        if move_mode is not MovementControlType.MOUSE_POINT_CLICK:
             misc_rows.append(("Reload:", RELOAD_BIND_SLOT))
 
     return tuple(aim_rows), tuple(move_rows), tuple(misc_rows)

--- a/src/crimson/local_input.py
+++ b/src/crimson/local_input.py
@@ -18,7 +18,7 @@ from .input_codes import (
     input_code_is_down_for_player,
     input_code_is_pressed_for_player,
 )
-from .movement_controls import MovementControlType, movement_control_type_from_value
+from .movement_controls import MovementControlType
 
 _AIM_RADIUS_KEYBOARD = 60.0
 _AIM_RADIUS_PAD_BASE = 42.0
@@ -216,11 +216,11 @@ class LocalInputInterpreter:
         return int(config.data.get("keybind_reload", 0x102) or 0x102)
 
     @staticmethod
-    def _safe_controls_modes(config: CrimsonConfig | None, *, player_index: int) -> tuple[int, int]:
+    def _safe_controls_modes(config: CrimsonConfig | None, *, player_index: int) -> tuple[int, MovementControlType]:
         if config is None:
-            return 0, 2
+            return 0, MovementControlType.STATIC
         aim_scheme, move_mode = controls_method_values(config.data, player_index=int(player_index))
-        return int(aim_scheme), int(move_mode)
+        return int(aim_scheme), move_mode
 
     def build_player_input(
         self,
@@ -237,8 +237,7 @@ class LocalInputInterpreter:
         idx = max(0, min(3, int(player_index)))
         state = self._state_for_player(idx, player=player)
         binds = _load_player_bind_block(config, player_index=idx)
-        aim_scheme, move_mode = self._safe_controls_modes(config, player_index=idx)
-        move_mode_type = movement_control_type_from_value(move_mode)
+        aim_scheme, move_mode_type = self._safe_controls_modes(config, player_index=idx)
         reload_key = self._reload_key(config)
 
         up_key = int(binds[_MOVE_SLOT_UP])

--- a/src/crimson/movement_controls.py
+++ b/src/crimson/movement_controls.py
@@ -6,6 +6,7 @@ from enum import IntEnum
 class MovementControlType(IntEnum):
     """Movement control mode ids from `config_player_mode_flags`."""
 
+    UNKNOWN = 0
     RELATIVE = 1
     STATIC = 2
     DUAL_ACTION_PAD = 3
@@ -14,19 +15,9 @@ class MovementControlType(IntEnum):
 
 
 def movement_control_type_from_value(
-    value: object,
-) -> MovementControlType | None:
-    if isinstance(value, bool):
-        raw = int(value)
-    elif isinstance(value, (int, float, str, bytes, bytearray)):
-        try:
-            raw = int(value)
-        except Exception:
-            return None
-    else:
-        return None
-
+    value: int,
+) -> MovementControlType:
     try:
-        return MovementControlType(raw)
+        return MovementControlType(int(value))
     except Exception:
-        return None
+        return MovementControlType.UNKNOWN

--- a/tests/test_controls_labels.py
+++ b/tests/test_controls_labels.py
@@ -31,7 +31,7 @@ def test_input_scheme_label_mapping() -> None:
     assert input_scheme_label(MovementControlType.DUAL_ACTION_PAD) == "Dual Action Pad"
     assert input_scheme_label(MovementControlType.MOUSE_POINT_CLICK) == "Mouse point click"
     assert input_scheme_label(MovementControlType.COMPUTER) == "Computer"
-    assert input_scheme_label(0) == "Unknown"
+    assert input_scheme_label(MovementControlType.UNKNOWN) == "Unknown"
 
 
 def test_controls_method_labels_reads_player_arrays() -> None:
@@ -48,11 +48,18 @@ def test_controls_method_labels_reads_player_arrays() -> None:
     assert controls_method_labels(config_data, player_index=1) == ("Joystick", "Mouse point click")
     assert controls_method_labels(config_data, player_index=2) == ("Dual Action Pad", "Computer")
     assert controls_method_labels(config_data, player_index=3) == ("Computer", "Relative")
-    assert controls_method_values(config_data, player_index=1) == (2, int(MovementControlType.MOUSE_POINT_CLICK))
+    assert controls_method_values(config_data, player_index=1) == (2, MovementControlType.MOUSE_POINT_CLICK)
 
 
 def test_controls_method_labels_defaults_missing_blob() -> None:
     assert controls_method_labels({}, player_index=0) == ("Mouse", "Static")
+
+
+def test_controls_method_values_unknown_move_mode_maps_to_unknown_enum() -> None:
+    mode_flags = struct.pack("<IIII", 99, 2, 2, 2) + b"\x00" * (40 - 16)
+    config_data = {"unknown_1c": mode_flags}
+
+    assert controls_method_values(config_data, player_index=0) == (0, MovementControlType.UNKNOWN)
 
 
 def test_controls_aim_method_dropdown_ids_hides_computer_unless_loaded() -> None:

--- a/tests/test_local_input.py
+++ b/tests/test_local_input.py
@@ -36,7 +36,7 @@ def test_local_input_computer_aim_auto_fires_without_fire_pressed(monkeypatch: p
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (5, int(MovementControlType.STATIC))),
+        staticmethod(lambda _config, *, player_index: (5, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -65,7 +65,7 @@ def test_local_input_computer_aim_without_target_points_away_from_center(monkeyp
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (5, int(MovementControlType.STATIC))),
+        staticmethod(lambda _config, *, player_index: (5, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -110,7 +110,7 @@ def test_local_input_static_mode_conflict_precedence_matches_native(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (0, int(MovementControlType.STATIC))),
+        staticmethod(lambda _config, *, player_index: (0, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()


### PR DESCRIPTION
## Summary
- add `MovementControlType` (`IntEnum`) and a coercion helper in `src/crimson/movement_controls.py`
- replace raw movement mode integers in controls/input paths with named enum usage
  - `src/crimson/frontend/panels/controls_labels.py`
  - `src/crimson/frontend/panels/controls.py`
  - `src/crimson/local_input.py`
- keep raw config I/O at boundaries while making branch logic readable and explicit
- update movement/control tests to assert against enum-based usage

## Validation
- `uv run pytest tests/test_controls_labels.py`
- `uv run pytest tests/test_local_input.py`
- `just check`
