### PR TITLE
fix(input): align mixed aim scheme update semantics

### DIFF
--- a/src/crimson/aim_schemes.py
+++ b/src/crimson/aim_schemes.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class AimScheme(IntEnum):
+    """Aiming scheme ids from `config_aim_scheme`."""
+
+    UNKNOWN = -1
+    MOUSE = 0
+    KEYBOARD = 1
+    JOYSTICK = 2
+    MOUSE_RELATIVE = 3
+    DUAL_ACTION_PAD = 4
+    COMPUTER = 5
+
+
+def aim_scheme_from_value(
+    value: int,
+) -> AimScheme:
+    try:
+        return AimScheme(int(value))
+    except Exception:
+        return AimScheme.UNKNOWN

--- a/src/crimson/frontend/panels/controls.py
+++ b/src/crimson/frontend/panels/controls.py
@@ -24,6 +24,7 @@ from ..menu import (
 from ...ui.menu_panel import draw_classic_menu_panel
 from .base import PANEL_TIMELINE_END_MS, PANEL_TIMELINE_START_MS, PanelMenuView
 from ...movement_controls import MovementControlType
+from ...aim_schemes import AimScheme
 from .controls_labels import (
     PICK_PERK_BIND_SLOT,
     RELOAD_BIND_SLOT,
@@ -305,7 +306,7 @@ class ControlsMenuView(PanelMenuView):
         self,
         *,
         player_index: int,
-        aim_scheme: int,
+        aim_scheme: AimScheme,
         move_mode: MovementControlType,
     ) -> tuple[tuple[str, tuple[tuple[str, int], ...]], ...]:
         aim_rows, move_rows, misc_rows = controls_rebind_slot_plan(
@@ -438,10 +439,10 @@ class ControlsMenuView(PanelMenuView):
         struct.pack_into("<I", raw, idx * 4, move_mode.value)
         config.data["unknown_1c"] = bytes(raw)
 
-    def _set_player_aim_scheme(self, *, player_index: int, aim_scheme: int) -> None:
+    def _set_player_aim_scheme(self, *, player_index: int, aim_scheme: AimScheme) -> None:
         config = self._state.config
         idx = max(0, min(3, int(player_index)))
-        scheme = int(aim_scheme)
+        scheme = int(aim_scheme.value)
         if idx == 0:
             config.data["unknown_44"] = scheme
             return
@@ -532,8 +533,8 @@ class ControlsMenuView(PanelMenuView):
         aim_scheme, move_mode = controls_method_values(config.data, player_index=player_idx)
         move_mode_ids = self._move_method_ids(move_mode=move_mode)
         move_items = tuple(input_scheme_label(mode) for mode in move_mode_ids)
-        aim_item_ids = controls_aim_method_dropdown_ids(int(aim_scheme))
-        aim_items = tuple(input_configure_for_label(i) for i in aim_item_ids)
+        aim_item_ids = controls_aim_method_dropdown_ids(aim_scheme)
+        aim_items = tuple(input_configure_for_label(scheme) for scheme in aim_item_ids)
         player_items = ("Player 1", "Player 2", "Player 3", "Player 4")
 
         move_layout = self._dropdown_layout(
@@ -646,17 +647,17 @@ class ControlsMenuView(PanelMenuView):
         aim_scheme, move_mode = controls_method_values(config.data, player_index=player_idx)
         move_mode_ids = self._move_method_ids(move_mode=move_mode)
         move_items = tuple(input_scheme_label(mode) for mode in move_mode_ids)
-        aim_item_ids = controls_aim_method_dropdown_ids(int(aim_scheme))
-        aim_items = tuple(input_configure_for_label(i) for i in aim_item_ids)
+        aim_item_ids = controls_aim_method_dropdown_ids(aim_scheme)
+        aim_items = tuple(input_configure_for_label(scheme) for scheme in aim_item_ids)
         player_items = ("Player 1", "Player 2", "Player 3", "Player 4")
         try:
             move_selected = move_mode_ids.index(move_mode)
         except ValueError:
             move_selected = 0
         try:
-            aim_selected = aim_item_ids.index(int(aim_scheme))
+            aim_selected = aim_item_ids.index(aim_scheme)
         except ValueError:
-            aim_selected = max(0, min(len(aim_items) - 1, int(aim_scheme)))
+            aim_selected = 0
         player_selected = max(0, min(len(player_items) - 1, player_idx))
         move_layout = self._dropdown_layout(
             pos=Vec2(left_top_left.x + 214.0 * panel_scale, left_top_left.y + 144.0 * panel_scale),

--- a/src/crimson/frontend/panels/controls_labels.py
+++ b/src/crimson/frontend/panels/controls_labels.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import struct
 from typing import Mapping
 
+from ...aim_schemes import AimScheme, aim_scheme_from_value
 from ...movement_controls import MovementControlType, movement_control_type_from_value
 
 
@@ -10,21 +11,18 @@ PICK_PERK_BIND_SLOT = -1
 RELOAD_BIND_SLOT = -2
 
 
-def input_configure_for_label(config_id: int) -> str:
+def input_configure_for_label(config_id: AimScheme | int) -> str:
     """Port of `input_configure_for_label` (0x00447c90)."""
 
-    labels = (
-        "Mouse",
-        "Keyboard",
-        "Joystick",
-        "Mouse relative",
-        "Dual Action Pad",
-        "Computer",
-    )
-    idx = int(config_id)
-    if 0 <= idx < len(labels):
-        return labels[idx]
-    return "Unknown"
+    labels = {
+        AimScheme.MOUSE: "Mouse",
+        AimScheme.KEYBOARD: "Keyboard",
+        AimScheme.JOYSTICK: "Joystick",
+        AimScheme.MOUSE_RELATIVE: "Mouse relative",
+        AimScheme.DUAL_ACTION_PAD: "Dual Action Pad",
+        AimScheme.COMPUTER: "Computer",
+    }
+    return labels.get(aim_scheme_from_value(int(config_id)), "Unknown")
 
 
 def input_scheme_label(scheme: MovementControlType) -> str:
@@ -55,9 +53,9 @@ def _read_player_mode_flags(
     return (values[0], values[1], values[2], values[3])
 
 
-def _read_aim_schemes(config_data: Mapping[str, object]) -> tuple[int, int, int, int]:
+def _read_aim_schemes(config_data: Mapping[str, object]) -> tuple[AimScheme, AimScheme, AimScheme, AimScheme]:
     # Defaults from `config_init_defaults`: 0 (Mouse) for aim schemes.
-    values = [0, 0, 0, 0]
+    values = [AimScheme.MOUSE] * 4
 
     def _coerce_int(value: object, default: int = 0) -> int:
         if isinstance(value, bool):
@@ -69,29 +67,30 @@ def _read_aim_schemes(config_data: Mapping[str, object]) -> tuple[int, int, int,
                 return default
         return default
 
-    values[0] = _coerce_int(config_data.get("unknown_44"), 0)
-    values[1] = _coerce_int(config_data.get("unknown_48"), 0)
+    values[0] = aim_scheme_from_value(_coerce_int(config_data.get("unknown_44"), 0))
+    values[1] = aim_scheme_from_value(_coerce_int(config_data.get("unknown_48"), 0))
 
     raw = config_data.get("unknown_4c")
     if isinstance(raw, (bytes, bytearray)) and len(raw) >= 8:
-        values[2] = int(struct.unpack_from("<I", raw, 0)[0])
-        values[3] = int(struct.unpack_from("<I", raw, 4)[0])
+        values[2] = aim_scheme_from_value(int(struct.unpack_from("<I", raw, 0)[0]))
+        values[3] = aim_scheme_from_value(int(struct.unpack_from("<I", raw, 4)[0]))
 
     for idx in range(4):
-        value = int(values[idx])
-        if value < 0:
-            values[idx] = 0
-        elif value > 5:
-            values[idx] = 0
+        if values[idx] is AimScheme.UNKNOWN:
+            values[idx] = AimScheme.MOUSE
 
     return (values[0], values[1], values[2], values[3])
 
 
-def controls_method_values(config_data: Mapping[str, object], *, player_index: int) -> tuple[int, MovementControlType]:
+def controls_method_values(
+    config_data: Mapping[str, object],
+    *,
+    player_index: int,
+) -> tuple[AimScheme, MovementControlType]:
     player_idx = max(0, min(3, int(player_index)))
     aim_scheme = _read_aim_schemes(config_data)[player_idx]
     move_mode = _read_player_mode_flags(config_data)[player_idx]
-    return int(aim_scheme), move_mode
+    return aim_scheme, move_mode
 
 
 def controls_method_labels(config_data: Mapping[str, object], *, player_index: int) -> tuple[str, str]:
@@ -99,17 +98,23 @@ def controls_method_labels(config_data: Mapping[str, object], *, player_index: i
     return input_configure_for_label(aim_scheme), input_scheme_label(move_mode)
 
 
-def controls_aim_method_dropdown_ids(current_aim_scheme: int) -> tuple[int, ...]:
-    ids = [0, 1, 2, 3, 4]
-    if int(current_aim_scheme) == 5:
+def controls_aim_method_dropdown_ids(current_aim_scheme: AimScheme | int) -> tuple[AimScheme, ...]:
+    ids = [
+        AimScheme.MOUSE,
+        AimScheme.KEYBOARD,
+        AimScheme.JOYSTICK,
+        AimScheme.MOUSE_RELATIVE,
+        AimScheme.DUAL_ACTION_PAD,
+    ]
+    if aim_scheme_from_value(int(current_aim_scheme)) is AimScheme.COMPUTER:
         # Original menu keeps "Computer" hidden unless loaded from config.
-        ids.append(5)
+        ids.append(AimScheme.COMPUTER)
     return tuple(ids)
 
 
 def controls_rebind_slot_plan(
     *,
-    aim_scheme: int,
+    aim_scheme: AimScheme,
     move_mode: MovementControlType,
     player_index: int,
 ) -> tuple[tuple[tuple[str, int], ...], tuple[tuple[str, int], ...], tuple[tuple[str, int], ...]]:
@@ -119,10 +124,10 @@ def controls_rebind_slot_plan(
     move_rows: list[tuple[str, int]] = []
     misc_rows: list[tuple[str, int]] = []
 
-    if int(aim_scheme) == 1:
+    if aim_scheme is AimScheme.KEYBOARD:
         aim_rows.append(("Torso left:", 7))
         aim_rows.append(("Torso right:", 8))
-    elif int(aim_scheme) == 4:
+    elif aim_scheme is AimScheme.DUAL_ACTION_PAD:
         aim_rows.append(("Aim Up/Down Axis:", 9))
         aim_rows.append(("Aim Left/Right Axis:", 10))
     aim_rows.append(("Fire:", 4))

--- a/tests/test_controls_labels.py
+++ b/tests/test_controls_labels.py
@@ -12,6 +12,7 @@ from crimson.frontend.panels.controls_labels import (
     input_configure_for_label,
     input_scheme_label,
 )
+from crimson.aim_schemes import AimScheme
 from crimson.movement_controls import MovementControlType
 
 
@@ -48,7 +49,7 @@ def test_controls_method_labels_reads_player_arrays() -> None:
     assert controls_method_labels(config_data, player_index=1) == ("Joystick", "Mouse point click")
     assert controls_method_labels(config_data, player_index=2) == ("Dual Action Pad", "Computer")
     assert controls_method_labels(config_data, player_index=3) == ("Computer", "Relative")
-    assert controls_method_values(config_data, player_index=1) == (2, MovementControlType.MOUSE_POINT_CLICK)
+    assert controls_method_values(config_data, player_index=1) == (AimScheme.JOYSTICK, MovementControlType.MOUSE_POINT_CLICK)
 
 
 def test_controls_method_labels_defaults_missing_blob() -> None:
@@ -59,17 +60,30 @@ def test_controls_method_values_unknown_move_mode_maps_to_unknown_enum() -> None
     mode_flags = struct.pack("<IIII", 99, 2, 2, 2) + b"\x00" * (40 - 16)
     config_data = {"unknown_1c": mode_flags}
 
-    assert controls_method_values(config_data, player_index=0) == (0, MovementControlType.UNKNOWN)
+    assert controls_method_values(config_data, player_index=0) == (AimScheme.MOUSE, MovementControlType.UNKNOWN)
 
 
 def test_controls_aim_method_dropdown_ids_hides_computer_unless_loaded() -> None:
-    assert controls_aim_method_dropdown_ids(0) == (0, 1, 2, 3, 4)
-    assert controls_aim_method_dropdown_ids(5) == (0, 1, 2, 3, 4, 5)
+    assert controls_aim_method_dropdown_ids(AimScheme.MOUSE) == (
+        AimScheme.MOUSE,
+        AimScheme.KEYBOARD,
+        AimScheme.JOYSTICK,
+        AimScheme.MOUSE_RELATIVE,
+        AimScheme.DUAL_ACTION_PAD,
+    )
+    assert controls_aim_method_dropdown_ids(AimScheme.COMPUTER) == (
+        AimScheme.MOUSE,
+        AimScheme.KEYBOARD,
+        AimScheme.JOYSTICK,
+        AimScheme.MOUSE_RELATIVE,
+        AimScheme.DUAL_ACTION_PAD,
+        AimScheme.COMPUTER,
+    )
 
 
 def test_controls_rebind_slot_plan_keyboard_static_player1() -> None:
     aim_rows, move_rows, misc_rows = controls_rebind_slot_plan(
-        aim_scheme=1,
+        aim_scheme=AimScheme.KEYBOARD,
         move_mode=MovementControlType.STATIC,
         player_index=0,
     )
@@ -80,7 +94,7 @@ def test_controls_rebind_slot_plan_keyboard_static_player1() -> None:
 
 def test_controls_rebind_slot_plan_dualpad_mouse_cursor_player2() -> None:
     aim_rows, move_rows, misc_rows = controls_rebind_slot_plan(
-        aim_scheme=4,
+        aim_scheme=AimScheme.DUAL_ACTION_PAD,
         move_mode=MovementControlType.MOUSE_POINT_CLICK,
         player_index=1,
     )

--- a/tests/test_local_input.py
+++ b/tests/test_local_input.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from crimson import local_input
+from crimson.aim_schemes import AimScheme
 from crimson.gameplay import PlayerState
 from crimson.movement_controls import MovementControlType
 from grim.geom import Vec2
@@ -38,7 +39,7 @@ def test_local_input_computer_aim_auto_fires_without_fire_pressed(monkeypatch: p
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (5, MovementControlType.STATIC)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.COMPUTER, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -67,7 +68,7 @@ def test_local_input_computer_aim_without_target_points_away_from_center(monkeyp
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (5, MovementControlType.STATIC)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.COMPUTER, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -112,7 +113,7 @@ def test_local_input_static_mode_conflict_precedence_matches_native(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (0, MovementControlType.STATIC)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.MOUSE, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -144,7 +145,7 @@ def test_local_input_relative_mode_single_player_uses_alt_arrow_fallback(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (0, MovementControlType.RELATIVE)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.MOUSE, MovementControlType.RELATIVE)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -178,7 +179,7 @@ def test_local_input_relative_mode_multiplayer_does_not_use_alt_arrow_fallback(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (0, MovementControlType.RELATIVE)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.MOUSE, MovementControlType.RELATIVE)),
     )
     config = SimpleNamespace(data={"player_count": 2})
 
@@ -208,7 +209,7 @@ def test_local_input_computer_move_mode_near_center_heads_toward_target(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (0, MovementControlType.COMPUTER)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.MOUSE, MovementControlType.COMPUTER)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -237,7 +238,7 @@ def test_local_input_computer_move_mode_far_from_center_heads_toward_center(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (0, MovementControlType.COMPUTER)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.MOUSE, MovementControlType.COMPUTER)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -267,7 +268,7 @@ def test_local_input_computer_aim_scheme_forces_computer_movement(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (5, MovementControlType.STATIC)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.COMPUTER, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -301,7 +302,7 @@ def test_local_input_joystick_aim_uses_pov_not_aim_keybinds(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (2, MovementControlType.STATIC)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.JOYSTICK, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -335,7 +336,7 @@ def test_local_input_joystick_aim_turns_with_pov_input(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (2, MovementControlType.STATIC)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.JOYSTICK, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -375,7 +376,7 @@ def test_local_input_dual_action_pad_aim_uses_native_radius_scale(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (4, MovementControlType.STATIC)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.DUAL_ACTION_PAD, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -409,7 +410,7 @@ def test_local_input_keyboard_aim_in_static_mode_reanchors_to_heading(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (1, MovementControlType.STATIC)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.KEYBOARD, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -442,7 +443,7 @@ def test_local_input_keyboard_aim_with_non_relative_move_mode_keeps_world_aim(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (1, MovementControlType.DUAL_ACTION_PAD)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.KEYBOARD, MovementControlType.DUAL_ACTION_PAD)),
     )
 
     interpreter = local_input.LocalInputInterpreter()
@@ -477,7 +478,7 @@ def test_local_input_relative_mouse_aim_centered_keeps_world_aim(
     monkeypatch.setattr(
         local_input.LocalInputInterpreter,
         "_safe_controls_modes",
-        staticmethod(lambda _config, *, player_index: (3, MovementControlType.STATIC)),
+        staticmethod(lambda _config, *, player_index: (AimScheme.MOUSE_RELATIVE, MovementControlType.STATIC)),
     )
 
     interpreter = local_input.LocalInputInterpreter()


### PR DESCRIPTION
## Summary
- audited `player_update` aiming control flow and aligned mixed-scheme no-update behavior in `LocalInputInterpreter`
- for `aim_scheme == 1`, only re-anchor aim from heading when move mode is Relative/Static (native behavior)
- for `aim_scheme == 3`, keep previous world aim when mouse is centered (native no-update branch)
- keep `aim_heading` synchronized from the resulting aim vector after scheme handling
- added regressions for:
  - keyboard aim in static mode still re-anchors
  - keyboard aim + non-relative move mode preserves world aim
  - relative mouse aim with centered mouse preserves world aim

## Validation
- `uv run pytest tests/test_local_input.py tests/test_controls_labels.py`
- `just check`
