### PR TITLE
fix(input): block manual reload for move-to-cursor keypress

### DIFF
--- a/src/crimson/gameplay.py
+++ b/src/crimson/gameplay.py
@@ -1299,7 +1299,7 @@ def player_update(
                 if key is not None:
                     state.sfx_queue.append(key)
             player.shot_cooldown = float(player.shot_cooldown) + 0.1
-        elif player.reload_timer == 0.0:
+        elif player.reload_timer == 0.0 and not input_state.move_to_cursor_pressed:
             player_start_reload(player, state)
 
     player_fire_weapon(

--- a/src/crimson/local_input.py
+++ b/src/crimson/local_input.py
@@ -173,6 +173,7 @@ def clear_input_edges(inputs: Sequence[PlayerInput]) -> list[PlayerInput]:
             fire_down=bool(inp.fire_down),
             fire_pressed=False,
             reload_pressed=False,
+            move_to_cursor_pressed=False,
             move_forward_pressed=inp.move_forward_pressed,
             move_backward_pressed=inp.move_backward_pressed,
             turn_left_pressed=inp.turn_left_pressed,
@@ -305,6 +306,7 @@ class LocalInputInterpreter:
         move_backward_pressed: bool | None = None
         turn_left_pressed: bool | None = None
         turn_right_pressed: bool | None = None
+        move_to_cursor_pressed = False
         computer_target_index: int | None = None
         computer_move_active = (
             move_mode_type is MovementControlType.COMPUTER
@@ -370,7 +372,8 @@ class LocalInputInterpreter:
             axis_x = -input_axis_value_for_player(move_axis_x, player_index=idx)
             move_vec = Vec2(_clamp_unit(axis_x), _clamp_unit(axis_y))
         elif move_mode_type is MovementControlType.MOUSE_POINT_CLICK:
-            if input_code_is_down_for_player(reload_key, player_index=idx):
+            move_to_cursor_pressed = bool(input_code_is_down_for_player(reload_key, player_index=idx))
+            if move_to_cursor_pressed:
                 state.move_target = mouse_world
             if float(state.move_target.x) >= 0.0 and float(state.move_target.y) >= 0.0:
                 delta = state.move_target - player.pos
@@ -501,6 +504,7 @@ class LocalInputInterpreter:
             fire_down=fire_down,
             fire_pressed=fire_pressed,
             reload_pressed=reload_pressed,
+            move_to_cursor_pressed=bool(move_to_cursor_pressed),
             move_forward_pressed=move_forward_pressed,
             move_backward_pressed=move_backward_pressed,
             turn_left_pressed=turn_left_pressed,

--- a/src/crimson/sim/input.py
+++ b/src/crimson/sim/input.py
@@ -12,6 +12,7 @@ class PlayerInput:
     fire_down: bool = False
     fire_pressed: bool = False
     reload_pressed: bool = False
+    move_to_cursor_pressed: bool = False
     move_forward_pressed: bool | None = None
     move_backward_pressed: bool | None = None
     turn_left_pressed: bool | None = None

--- a/tests/test_alternate_weapon_perk.py
+++ b/tests/test_alternate_weapon_perk.py
@@ -54,3 +54,24 @@ def test_alternate_weapon_reload_pressed_swaps_and_adds_cooldown() -> None:
     assert player.weapon_id == 1
     assert player.alt_weapon_id == 2
     assert player.shot_cooldown == pytest.approx(0.1)
+
+
+def test_alternate_weapon_reload_pressed_still_swaps_in_move_to_cursor_mode() -> None:
+    state = GameplayState()
+    player = PlayerState(index=0, pos=Vec2())
+    weapon_assign_player(player, 1)
+    player.perk_counts[int(PerkId.ALTERNATE_WEAPON)] = 1
+    bonus_apply(state, player, BonusId.WEAPON, amount=2)
+
+    player.shot_cooldown = 0.0
+    state.sfx_queue.clear()
+    player_update(
+        player,
+        PlayerInput(reload_pressed=True, move_to_cursor_pressed=True),
+        dt=0.1,
+        state=state,
+    )
+
+    assert player.weapon_id == 1
+    assert player.alt_weapon_id == 2
+    assert player.shot_cooldown == pytest.approx(0.1)

--- a/tests/test_player_update.py
+++ b/tests/test_player_update.py
@@ -68,6 +68,25 @@ def test_player_update_stationary_reloader_tripples_reload_decay() -> None:
     assert math.isclose(player.reload_timer, 0.7, abs_tol=2e-8)
 
 
+def test_player_update_move_to_cursor_reload_key_does_not_start_reload() -> None:
+    state = GameplayState()
+    player = PlayerState(index=0, pos=Vec2(50.0, 50.0), clip_size=10, ammo=10)
+
+    player_update(
+        player,
+        PlayerInput(
+            aim=Vec2(51.0, 50.0),
+            reload_pressed=True,
+            move_to_cursor_pressed=True,
+        ),
+        0.1,
+        state,
+    )
+
+    assert player.reload_active is False
+    assert player.reload_timer == 0.0
+
+
 def test_player_update_speed_bonus_expires_before_player_update_step() -> None:
     state = GameplayState()
     no_bonus = PlayerState(index=0, pos=Vec2(100.0, 100.0))


### PR DESCRIPTION
## Summary
- add an explicit `move_to_cursor_pressed` input flag for mode-4 (mouse point-click) input
- keep reload key edges available for alternate-weapon swapping, but block manual reload starts when the same press is being used to set a move target
- add parity tests for local input + player update behavior in this path

## Why
In native `player_update`, mode-4 uses the reload key to set move targets and explicitly excludes that key path from manual reload starts. The port could start reload on that same press, which diverges from the original behavior.

## Testing
- `uv run pytest tests/test_local_input.py tests/test_player_update.py tests/test_alternate_weapon_perk.py`
- `just check`
