### PR TITLE
fix(input): gate manual reload press to single-player

### DIFF
--- a/src/crimson/local_input.py
+++ b/src/crimson/local_input.py
@@ -496,7 +496,11 @@ class LocalInputInterpreter:
         fire_pressed = bool(input_code_is_pressed_for_player(fire_key, player_index=idx))
         if aim_scheme is AimScheme.COMPUTER and computer_auto_fire:
             fire_down = True
-        reload_pressed = bool(input_code_is_pressed_for_player(reload_key, player_index=idx)) if idx == 0 else False
+        reload_pressed = (
+            bool(input_code_is_pressed_for_player(reload_key, player_index=idx))
+            if _single_player_alt_keys_enabled(config, player_index=idx)
+            else False
+        )
 
         return PlayerInput(
             move=move_vec,

--- a/tests/test_local_input.py
+++ b/tests/test_local_input.py
@@ -202,6 +202,48 @@ def test_local_input_relative_mode_multiplayer_does_not_use_alt_arrow_fallback(
     assert out.move == Vec2()
 
 
+def test_local_input_reload_pressed_allowed_only_for_single_player(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_no_user_input(monkeypatch)
+    monkeypatch.setattr(
+        local_input,
+        "input_code_is_pressed_for_player",
+        lambda key, **_kwargs: int(key) == 0x102,
+    )
+    monkeypatch.setattr(
+        local_input.LocalInputInterpreter,
+        "_safe_controls_modes",
+        staticmethod(lambda _config, *, player_index: (AimScheme.MOUSE, MovementControlType.STATIC)),
+    )
+    interpreter = local_input.LocalInputInterpreter()
+    player = PlayerState(index=0, pos=Vec2(100.0, 100.0), aim=Vec2(160.0, 100.0))
+
+    single_player = interpreter.build_player_input(
+        player_index=0,
+        player=player,
+        config=SimpleNamespace(data={"player_count": 1}),
+        mouse_screen=Vec2(),
+        mouse_world=Vec2(),
+        screen_center=Vec2(),
+        dt_frame=0.1,
+        creatures=[],
+    )
+    multiplayer = interpreter.build_player_input(
+        player_index=0,
+        player=player,
+        config=SimpleNamespace(data={"player_count": 2}),
+        mouse_screen=Vec2(),
+        mouse_world=Vec2(),
+        screen_center=Vec2(),
+        dt_frame=0.1,
+        creatures=[],
+    )
+
+    assert single_player.reload_pressed is True
+    assert multiplayer.reload_pressed is False
+
+
 def test_local_input_mouse_point_click_marks_move_to_cursor_press(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- align reload-key input semantics with native by emitting `reload_pressed` only in true single-player mode
- keep existing per-player movement/aim behavior untouched
- add a focused test that verifies reload press is accepted for `player_count=1` and suppressed for `player_count=2`

## Why
Native `player_update` gates manual reload start on `_config_player_count == 1`. Our input interpreter still surfaced `reload_pressed` for player 0 in multiplayer, which allowed non-native reload starts.

## Testing
- `uv run pytest tests/test_local_input.py`
- `just check`
