### PR TITLE
fix(perks): restore player0 ownership for periodic shared effects

### DIFF
--- a/tests/test_death_clock_perk.py
+++ b/tests/test_death_clock_perk.py
@@ -61,3 +61,27 @@ def test_death_clock_clamps_dead_health_to_zero() -> None:
     perks_update_effects(state, [player], 0.1)
 
     assert player.health == 0.0
+
+
+def test_death_clock_tick_is_gated_by_player0_perk_state() -> None:
+    state = GameplayState()
+    player0 = PlayerState(index=0, pos=Vec2(), health=100.0)
+    player1 = PlayerState(index=1, pos=Vec2(), health=100.0)
+    player1.perk_counts[int(PerkId.DEATH_CLOCK)] = 1
+
+    perks_update_effects(state, [player0, player1], 1.0)
+
+    assert player0.health == 100.0
+    assert player1.health == 100.0
+
+
+def test_death_clock_tick_applies_to_all_players_when_player0_has_perk() -> None:
+    state = GameplayState()
+    player0 = PlayerState(index=0, pos=Vec2(), health=100.0)
+    player1 = PlayerState(index=1, pos=Vec2(), health=100.0)
+    player0.perk_counts[int(PerkId.DEATH_CLOCK)] = 1
+
+    perks_update_effects(state, [player0, player1], 1.0)
+
+    assert player0.health == pytest.approx(96.6666667)
+    assert player1.health == pytest.approx(96.6666667)

--- a/tests/test_lean_mean_exp_machine.py
+++ b/tests/test_lean_mean_exp_machine.py
@@ -22,3 +22,18 @@ def test_perks_update_effects_lean_mean_exp_machine_ticks_xp_without_double_xp()
     perks_update_effects(state, [player], 0.1)
     assert player.experience == 20
     assert math.isclose(state.lean_mean_exp_timer, 0.25, abs_tol=1e-9)
+
+
+def test_lean_mean_exp_machine_tick_awards_only_player0_in_multiplayer() -> None:
+    state = GameplayState()
+    state.lean_mean_exp_timer = 0.05
+
+    player0 = PlayerState(index=0, pos=Vec2(10.0, 20.0))
+    player1 = PlayerState(index=1, pos=Vec2(30.0, 40.0))
+    player0.perk_counts[int(PerkId.LEAN_MEAN_EXP_MACHINE)] = 2
+    player1.perk_counts[int(PerkId.LEAN_MEAN_EXP_MACHINE)] = 2
+
+    perks_update_effects(state, [player0, player1], 0.1)
+
+    assert player0.experience == 20
+    assert player1.experience == 0


### PR DESCRIPTION
## Summary
- carry forward the remaining unmerged parity fix for perk periodic effects
- align Lean Mean EXP Machine tick ownership with native behavior (`player_experience[0]` only)
- align Death Clock tick gating/targeting with native behavior (gate by primary perk state, apply drain across active players)
- add regression tests for multiplayer ownership semantics

## Testing
- `just check`
