### PR TITLE
fix: regenerate gameplay terrain on mode start

### DIFF
--- a/docs/rewrite/index.md
+++ b/docs/rewrite/index.md
@@ -32,7 +32,7 @@ Code lives in `src/crimson/` (game) and `src/grim/` (engine), exercised via the
 - Statistics panel (Summary/Weapons/Quests pages; playtime + weapon usage + quest counters).
 - Menu terrain persists between screens (no regen on Options/Stats/etc navigation).
 - Menu terrain selection matches original unlock-gated random variants (`(0,1,0)`, `(2,3,2)`, `(4,5,4)`, `(6,7,6)`).
-- Survival/Rush adopt the existing menu ground on start (same generated terrain variant carries into gameplay).
+- Survival/Rush regenerate terrain on start (menu terrain does not carry into a fresh gameplay run).
 - Menu sign shadow pass matches the original when `fx_detail` is enabled.
 - Demo/attract mode: idle trigger + variant sequencing; upsell overlay + trial overlay + purchase screen flow in demo builds.
 

--- a/src/crimson/game.py
+++ b/src/crimson/game.py
@@ -3576,16 +3576,13 @@ class GameLoopView:
 
         return True
 
-    def _maybe_adopt_menu_ground(self, action: str, view: FrontView) -> None:
+    def _maybe_adopt_menu_ground(self, action: str, _view: FrontView) -> None:
         if action not in {"start_survival", "start_rush"}:
             return
-        ground = self._state.menu_ground
-        if ground is None:
-            return
-        adopter = getattr(view, "adopt_menu_ground", None)
-        if not callable(adopter):
-            return
-        adopter(ground)
+        # Native `game_state_set(9)` always calls `gameplay_reset_state()`, which
+        # runs `terrain_generate_random()`. Menu terrain should carry back to menu,
+        # but entering a fresh gameplay run must regenerate terrain instead of
+        # reusing the captured menu render target.
 
     @staticmethod
     def _steal_ground_from_view(view: FrontView | None) -> GroundRenderer | None:

--- a/tests/test_game_loop_ground_persistence.py
+++ b/tests/test_game_loop_ground_persistence.py
@@ -169,7 +169,7 @@ def test_regenerate_menu_ground_unlock_branch_selects_q4_variant(tmp_path: Path)
     assert ground.overlay_detail is cache.texture("ter_q4_base")
 
 
-def test_start_survival_adopts_existing_menu_ground(tmp_path: Path) -> None:
+def test_start_survival_does_not_adopt_existing_menu_ground(tmp_path: Path) -> None:
     state = _build_state(tmp_path)
     loop = GameLoopView(state)
     menu_ground = GroundRenderer(texture=rl.Texture())
@@ -178,4 +178,4 @@ def test_start_survival_adopts_existing_menu_ground(tmp_path: Path) -> None:
 
     loop._maybe_adopt_menu_ground("start_survival", cast(Any, adopter))
 
-    assert adopter.adopted is menu_ground
+    assert adopter.adopted is None


### PR DESCRIPTION
## Summary
- stop carrying `menu_ground` into new Survival/Rush runs
- keep capturing gameplay ground when returning to menu so menu background still persists there
- update the ground persistence test to assert non-adoption on Survival start
- correct rewrite docs to state gameplay terrain regenerates on mode start

## Why
Native `game_state_set(9)` calls `gameplay_reset_state()`, and that path regenerates terrain (`terrain_generate_random()`), so a fresh gameplay run should not reuse the menu render target.

## Testing
- `just check`
- `uv run pytest tests/test_game_loop_ground_persistence.py`
- `uv run pytest tests/test_game_start_routes_smoke.py`
