### PR TITLE
feat(frida): trace blood splatter rng attribution

### DIFF
--- a/docs/frida/gameplay-diff-capture.md
+++ b/docs/frida/gameplay-diff-capture.md
@@ -141,6 +141,7 @@ Without extra env vars, the script captures full per-tick detail:
 - samples for `creatures`, `projectiles`, `secondary_projectiles`, `bonuses`
 - unlimited head budgets by default (`-1` limits)
 - RNG per-draw stream rows (`value/state_before/state_after/branch_id`), caller diagnostics, mirror tracking, outside-tick carry
+- blood-splatter effect diagnostics (`effect_spawn_blood_splatter`) with per-tick caller and RNG-draw attribution
 - perk-apply diagnostics and input query/key snapshots
 
 ## Optional env knobs
@@ -158,6 +159,7 @@ Without extra env vars, the script captures full per-tick detail:
 - `CRIMSON_FRIDA_MAX_EVENTS_PER_TICK=-1`
 - `CRIMSON_FRIDA_INPUT_HOOKS=0`
 - `CRIMSON_FRIDA_RNG_HOOKS=0`
+- `CRIMSON_FRIDA_EFFECTS=0`
 - `CRIMSON_FRIDA_SPAWNS=0`
 - `CRIMSON_FRIDA_CREATURE_SPAWN_HOOK=0`
 - `CRIMSON_FRIDA_CREATURE_DEATH_HOOK=0`

--- a/src/crimson/original/schema.py
+++ b/src/crimson/original/schema.py
@@ -36,6 +36,7 @@ class CaptureConfig(msgspec.Struct):
     enable_rng_hooks: bool = True
     enable_sfx_hooks: bool = True
     enable_damage_hooks: bool = True
+    enable_effect_hooks: bool = True
     creature_damage_projectile_only: bool = True
     enable_spawn_hooks: bool = True
     enable_creature_spawn_hook: bool = True


### PR DESCRIPTION
## Summary
- add Frida hook coverage for `effect_spawn_blood_splatter` in gameplay differential capture
- record per-tick blood-splatter call count, RNG draws, and caller attribution in spawn diagnostics
- expose capture config knob `CRIMSON_FRIDA_EFFECTS` and document it in capture docs

## Why
Late-run investigation showed native RNG tail attribution clustering around blood-splatter paths. This adds direct telemetry so future captures can localize those gaps without relying only on coarse `rand_callers` aggregation.

## Validation
- `just check`
