### PR TITLE
fix: align streaming music transitions with original exclusive behavior

### DIFF
--- a/src/crimson/frontend/menu.py
+++ b/src/crimson/frontend/menu.py
@@ -263,6 +263,9 @@ class MenuView:
 
     def update(self, dt: float) -> None:
         if self._state.audio is not None:
+            if not self._closing:
+                theme = "crimsonquest" if self._state.demo_enabled else "crimson_theme"
+                play_music(self._state.audio, theme)
             update_audio(self._state.audio, dt)
         if self._ground is not None:
             self._ground.process_pending()

--- a/src/crimson/frontend/panels/stats.py
+++ b/src/crimson/frontend/panels/stats.py
@@ -181,6 +181,8 @@ class StatisticsMenuView:
 
     def update(self, dt: float) -> None:
         if self._state.audio is not None:
+            if not self._closing:
+                play_music(self._state.audio, "shortie_monk")
             update_audio(self._state.audio, dt)
         if self._ground is not None:
             self._ground.process_pending()

--- a/tests/test_grim_music.py
+++ b/tests/test_grim_music.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import grim.music as music
+
+
+def test_play_music_does_not_unmute_track_mid_fade(monkeypatch) -> None:
+    state = music.init_music_state(ready=True, enabled=True, volume=1.0)
+    track = object()
+    state.tracks["crimson_theme"] = track
+    state.playbacks["crimson_theme"] = music.TrackPlayback(music=track, volume=0.6, muted=True)
+
+    play_calls: list[object] = []
+    set_calls: list[tuple[object, float]] = []
+    monkeypatch.setattr(music.rl, "play_music_stream", lambda m: play_calls.append(m))
+    monkeypatch.setattr(music.rl, "set_music_volume", lambda m, v: set_calls.append((m, float(v))))
+
+    music.play_music(state, "crimson_theme")
+
+    playback = state.playbacks["crimson_theme"]
+    assert playback.muted is True
+    assert playback.volume == 0.6
+    assert state.active_track == "crimson_theme"
+    assert play_calls == []
+    assert set_calls == []
+
+
+def test_play_music_starts_silent_track_and_mutes_other_active_tracks(monkeypatch) -> None:
+    state = music.init_music_state(ready=True, enabled=True, volume=0.8)
+    theme = object()
+    game_tune = object()
+    state.tracks["crimson_theme"] = theme
+    state.tracks["gt1_ingame"] = game_tune
+    state.playbacks["crimson_theme"] = music.TrackPlayback(music=theme, volume=0.0, muted=True)
+    state.playbacks["gt1_ingame"] = music.TrackPlayback(music=game_tune, volume=0.7, muted=False)
+
+    play_calls: list[object] = []
+    set_calls: list[tuple[object, float]] = []
+    monkeypatch.setattr(music.rl, "play_music_stream", lambda m: play_calls.append(m))
+    monkeypatch.setattr(music.rl, "set_music_volume", lambda m, v: set_calls.append((m, float(v))))
+
+    music.play_music(state, "crimson_theme")
+
+    theme_pb = state.playbacks["crimson_theme"]
+    game_pb = state.playbacks["gt1_ingame"]
+    assert theme_pb.muted is False
+    assert theme_pb.volume == 0.8
+    assert game_pb.muted is True
+    assert state.active_track == "crimson_theme"
+    assert play_calls == [theme]
+    assert set_calls == [(theme, 0.8)]


### PR DESCRIPTION
## Summary
- align `play_music` exclusive behavior with original `sfx_play_exclusive` mute/fade semantics
- prevent re-arming a requested track while it is still mid-fade, which could cause overlapping menu/game music
- request menu/statistics music each frame while view is active so playback starts as soon as fade-out reaches silence
- add regression tests for mid-fade behavior and exclusive handoff behavior

## Validation
- `just check`
- manual test: menu/game transitions no longer produce overlapping music
