### PR TITLE
fix(parity): align reload boundary and weapon-swap fire synthesis

### DIFF
--- a/docs/frida/differential-sessions.md
+++ b/docs/frida/differential-sessions.md
@@ -665,6 +665,14 @@ When the capture SHA is unchanged, append updates to the same session.
     - `player_fire.top_player_projectile_spawns_by_player`
   - changed `input_player_keys` fire/reload tracking to **sticky true** within a tick (once true, stays true for that tick),
   - mapped mouse primary queries (`grim_is_mouse_button_down`, `grim_was_mouse_button_pressed`) to player 0 `fire_down`/`fire_pressed`.
+- Updated replay conversion to handle same-tick weapon swaps in computer-aim synthesis:
+  - `src/crimson/original/capture.py` now checks both current and previous checkpoint weapon id hints when inferring `fire_down` from player-owned projectile spawns.
+  - Added regression coverage in `tests/test_original_capture_conversion.py` for weapon-bonus swap ticks (`1 -> 14`) where the spawned projectile type still matches the pre-swap weapon.
+- Updated reload boundary parity in `src/crimson/gameplay.py`:
+  - added underflow epsilon guard to avoid premature preload on tiny float32 underflow,
+  - kept `reload_active` latched until ammo is actually available,
+  - mirrored native "top up on next fire tick after reload completion" behavior for empty clips.
+  - Added regressions in `tests/test_player_update.py`.
 
 ### Validation
 

--- a/tests/test_original_capture_conversion.py
+++ b/tests/test_original_capture_conversion.py
@@ -1566,3 +1566,35 @@ def test_convert_capture_to_replay_does_not_synthesize_unknown_mode_without_weap
     assert fire_down1 is False
     assert fire_pressed1 is False
     assert reload_pressed1 is False
+
+
+def test_convert_capture_to_replay_synthesizes_unknown_mode_fire_when_weapon_switches_in_tick(tmp_path: Path) -> None:
+    tick0 = _base_tick(tick_index=0, elapsed_ms=16)
+    tick0["checkpoint"]["players"][0]["weapon_id"] = 1
+    tick0["checkpoint"]["players"][0]["ammo"] = 2.0
+    tick0["input_player_keys"] = [{"player_index": 0, "fire_down": False, "fire_pressed": False}]
+    tick0["input_approx"] = [{"player_index": 0, "aim_x": 512.0, "aim_y": 512.0, "weapon_id": 1}]
+
+    tick1 = _base_tick(tick_index=1, elapsed_ms=32)
+    tick1["checkpoint"]["players"][0]["weapon_id"] = 14
+    tick1["checkpoint"]["players"][0]["ammo"] = 8.0
+    tick1["input_player_keys"] = [{"player_index": 0, "fire_down": False, "fire_pressed": False}]
+    tick1["input_approx"] = [{"player_index": 0, "aim_x": 520.0, "aim_y": 500.0, "weapon_id": 14}]
+    tick1["event_heads"] = [
+        {"kind": "bonus_apply", "data": {"player_index": 0, "bonus_id": 3, "amount_i32": 14}},
+        {"kind": "weapon_assign", "data": {"player_index": 0, "weapon_id": 14}},
+        {"kind": "projectile_spawn", "data": {"owner_id": -100, "requested_type_id": 1, "actual_type_id": 1}},
+    ]
+
+    obj = _capture_obj(ticks=[tick0, tick1])
+    path = tmp_path / "capture.json"
+    _write_capture(path, obj)
+
+    capture = load_capture(path)
+    replay = convert_capture_to_replay(capture)
+
+    flags1 = int(replay.inputs[1][0][3])
+    fire_down1, fire_pressed1, reload_pressed1 = unpack_input_flags(flags1)
+    assert fire_down1 is True
+    assert fire_pressed1 is False
+    assert reload_pressed1 is False

--- a/tests/test_player_update.py
+++ b/tests/test_player_update.py
@@ -106,6 +106,50 @@ def test_player_update_does_not_preload_ammo_when_reload_timer_is_zero() -> None
     assert math.isclose(player.ammo, -1.0, abs_tol=1e-9)
 
 
+def test_player_update_does_not_preload_ammo_on_tiny_underflow() -> None:
+    state = GameplayState()
+    player = PlayerState(
+        index=0,
+        pos=Vec2(50.0, 50.0),
+        weapon_id=int(WeaponId.ION_CANNON),
+        clip_size=6,
+        ammo=-1.0,
+        reload_active=True,
+        reload_timer=0.03199996426701546,
+        reload_timer_max=3.0,
+        shot_cooldown=0.5,
+    )
+
+    player_update(player, PlayerInput(aim=Vec2(51.0, 50.0)), 0.03200000151991844, state)
+
+    assert math.isclose(player.ammo, -1.0, abs_tol=1e-9)
+
+
+def test_player_update_tops_up_empty_reload_on_next_fire_tick() -> None:
+    state = GameplayState()
+    player = PlayerState(
+        index=0,
+        pos=Vec2(50.0, 50.0),
+        weapon_id=int(WeaponId.ION_CANNON),
+        clip_size=6,
+        ammo=0.0,
+        reload_active=True,
+        reload_timer=0.0,
+        reload_timer_max=3.0,
+        shot_cooldown=0.0,
+    )
+
+    player_update(
+        player,
+        PlayerInput(aim=Vec2(51.0, 50.0), fire_down=True),
+        0.03100000135600567,
+        state,
+    )
+
+    assert math.isclose(player.ammo, 5.0, abs_tol=1e-9)
+    assert player.reload_active is False
+
+
 def test_player_update_move_to_cursor_reload_key_does_not_start_reload() -> None:
     state = GameplayState()
     player = PlayerState(index=0, pos=Vec2(50.0, 50.0), clip_size=10, ammo=10)


### PR DESCRIPTION
## Summary
- align `player_update` reload edge behavior with native float32 timing at the preload boundary
- preserve reload latch until ammo exists and top up on next fire tick when reload completed empty
- improve computer-aim replay fire synthesis for same-tick weapon swaps by checking previous checkpoint weapon id
- add regressions in `tests/test_player_update.py` and `tests/test_original_capture_conversion.py`
- append Session 11 notes in `docs/frida/differential-sessions.md`

## Details
- `src/crimson/gameplay.py`
  - add `_RELOAD_PRELOAD_UNDERFLOW_EPS` guard to avoid tiny-underflow preload jitter
  - gate reload latch clear on `player.ammo > 0.0`
  - when `reload_active && reload_timer == 0 && ammo <= 0 && fire_down`, top up clip before shot path
- `src/crimson/original/capture.py`
  - thread `previous_weapon_id_hint` into `_should_synthesize_computer_fire_down`
  - accept player projectile spawns matching either current or previous checkpoint weapon id

## Validation
- `uv run pytest tests/test_player_update.py tests/test_original_capture_conversion.py -q`
- `just check`
