### PR TITLE
refactor: cut over projectiles into package modules

### DIFF
--- a/src/crimson/original/diagnostics_cache.py
+++ b/src/crimson/original/diagnostics_cache.py
@@ -15,7 +15,7 @@ from typing import Any, cast
 import msgspec
 from platformdirs import PlatformDirs
 
-import crimson.projectiles as projectiles_mod
+import crimson.projectiles.pools as projectiles_mod
 import crimson.sim.presentation_step as presentation_step_mod
 from crimson.bonuses import bonus_label
 from crimson.game_modes import GameMode

--- a/src/crimson/original/divergence_report.py
+++ b/src/crimson/original/divergence_report.py
@@ -91,12 +91,12 @@ NATIVE_FUNCTION_TO_PORT_PATHS: dict[str, tuple[str, ...]] = {
         "src/crimson/creatures/runtime.py",
     ),
     "creature_find_in_radius": (
-        "src/crimson/projectiles.py",
+        "src/crimson/projectiles/pools.py",
         "src/crimson/creatures/runtime.py",
     ),
     "creature_handle_death": ("src/crimson/creatures/runtime.py",),
     "projectile_update": (
-        "src/crimson/projectiles.py",
+        "src/crimson/projectiles/pools.py",
         "src/crimson/sim/world_state.py",
     ),
     "player_update": (
@@ -125,8 +125,8 @@ NATIVE_FUNCTION_TO_PORT_PATHS: dict[str, tuple[str, ...]] = {
 
 RNG_STAGE_TO_PORT_PATHS: dict[str, tuple[str, ...]] = {
     "creatures": ("src/crimson/creatures/runtime.py", "src/crimson/creatures/ai.py"),
-    "projectiles": ("src/crimson/projectiles.py", "src/crimson/sim/world_state.py"),
-    "secondary_projectiles": ("src/crimson/projectiles.py", "src/crimson/sim/world_state.py"),
+    "projectiles": ("src/crimson/projectiles/pools.py", "src/crimson/sim/world_state.py"),
+    "secondary_projectiles": ("src/crimson/projectiles/pools.py", "src/crimson/sim/world_state.py"),
     "death_sfx_preplan": ("src/crimson/sim/world_state.py", "src/crimson/sim/presentation_step.py"),
     "world_step_tail": ("src/crimson/sim/world_state.py",),
     "survival_stage_spawns": ("src/crimson/creatures/spawn.py", "src/crimson/sim/sessions.py"),
@@ -2250,7 +2250,7 @@ def _build_investigation_leads(
                 code_paths=_merge_paths(
                     _port_paths_for_native_functions(effective_native),
                     (
-                        "src/crimson/projectiles.py",
+                        "src/crimson/projectiles/pools.py",
                         "src/crimson/sim/presentation_step.py",
                         "src/crimson/effects.py",
                     ),
@@ -2353,7 +2353,7 @@ def _build_investigation_leads(
                 code_paths=_merge_paths(
                     _port_paths_for_native_functions(effective_native),
                     (
-                        "src/crimson/projectiles.py",
+                        "src/crimson/projectiles/pools.py",
                         "src/crimson/sim/world_state.py",
                         "scripts/frida/gameplay_diff_capture.js",
                     ),

--- a/src/crimson/original/focus_trace.py
+++ b/src/crimson/original/focus_trace.py
@@ -13,7 +13,7 @@ from typing import Any
 import msgspec
 from grim.geom import Vec2
 
-import crimson.projectiles as projectiles_mod
+import crimson.projectiles.pools as projectiles_mod
 import crimson.sim.presentation_step as presentation_step_mod
 from crimson.game_modes import GameMode
 from crimson.gameplay import PlayerInput

--- a/src/crimson/projectiles/__init__.py
+++ b/src/crimson/projectiles/__init__.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from .pools import (
+    PROJECTILE_BEHAVIOR_BY_TYPE_ID,
+    ProjectileBehavior,
+    ProjectilePool,
+    SecondaryProjectilePool,
+    _within_native_find_radius,
+)
+from .types import (
+    CreatureDamageApplier,
+    Damageable,
+    FxQueueLike,
+    MAIN_PROJECTILE_POOL_SIZE,
+    PlayerDamageable,
+    Projectile,
+    ProjectileHit,
+    ProjectileRuntimeState,
+    ProjectileTypeId,
+    SecondaryDetonationKillHandler,
+    SECONDARY_PROJECTILE_POOL_SIZE,
+    SecondaryProjectile,
+    SecondaryProjectileTypeId,
+)
+
+__all__ = [
+    "CreatureDamageApplier",
+    "Damageable",
+    "FxQueueLike",
+    "MAIN_PROJECTILE_POOL_SIZE",
+    "PlayerDamageable",
+    "PROJECTILE_BEHAVIOR_BY_TYPE_ID",
+    "Projectile",
+    "ProjectileBehavior",
+    "ProjectileHit",
+    "ProjectilePool",
+    "ProjectileRuntimeState",
+    "ProjectileTypeId",
+    "SECONDARY_PROJECTILE_POOL_SIZE",
+    "SecondaryDetonationKillHandler",
+    "SecondaryProjectile",
+    "SecondaryProjectilePool",
+    "SecondaryProjectileTypeId",
+    "_within_native_find_radius",
+]

--- a/src/crimson/projectiles/effects.py
+++ b/src/crimson/projectiles/effects.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import math
+from typing import Callable, MutableSequence
+
+from grim.color import RGBA
+from grim.geom import Vec2
+
+from ..effects_atlas import EffectId
+from .types import ProjectileTypeId, _EffectsLike
+
+
+def _spawn_shrinkifier_hit_effects(
+    effects: _EffectsLike | None,
+    *,
+    pos: Vec2,
+    rng: Callable[[], int],
+    detail_preset: int,
+) -> None:
+    """Port of `effect_spawn_shrinkifier_hit` (0x0042f080)."""
+
+    if effects is None:
+        return
+
+    detail = int(detail_preset)
+
+    # Core pulse (effect_id=1).
+    effects.spawn(
+        effect_id=int(EffectId.RING),
+        pos=pos,
+        vel=Vec2(),
+        rotation=0.0,
+        scale=1.0,
+        half_width=36.0,
+        half_height=36.0,
+        age=0.0,
+        lifetime=0.3,
+        flags=0x19,
+        color=RGBA(0.3, 0.6, 0.9, 1.0),
+        rotation_step=0.0,
+        scale_step=-4.0,
+        detail_preset=detail,
+    )
+
+    # Debris puffs (effect_id=0), detail-scaled count.
+    count = 2 if detail < 3 else 4
+    for _ in range(count):
+        rotation = float(int(rng()) & 0x7F) * 0.049087387
+        velocity = Vec2(
+            float((int(rng()) & 0x7F) - 0x40) * 1.4,
+            float((int(rng()) & 0x7F) - 0x40) * 1.4,
+        )
+        scale_step = float(int(rng()) % 100) * 0.01 + 0.1
+        effects.spawn(
+            effect_id=int(EffectId.BURST),
+            pos=pos,
+            vel=velocity,
+            rotation=rotation,
+            scale=1.0,
+            half_width=32.0,
+            half_height=32.0,
+            age=0.0,
+            lifetime=0.3,
+            flags=0x1D,
+            color=RGBA(0.4, 0.5, 1.0, 0.5),
+            rotation_step=0.0,
+            scale_step=scale_step,
+            detail_preset=detail,
+        )
+
+
+def _spawn_ion_hit_effects(
+    effects: _EffectsLike | None,
+    sfx_queue: MutableSequence[str] | None,
+    *,
+    type_id: int,
+    pos: Vec2,
+    rng: Callable[[], int],
+    detail_preset: int,
+) -> None:
+    if effects is None:
+        return
+
+    ring_scale = 0.0
+    ring_strength = 0.0
+    burst_scale = 0.0
+    if type_id == int(ProjectileTypeId.ION_MINIGUN):
+        ring_scale = 1.5
+        ring_strength = 0.1
+        burst_scale = 0.8
+    elif type_id == int(ProjectileTypeId.ION_RIFLE):
+        ring_scale = 1.2
+        ring_strength = 0.4
+        burst_scale = 1.2
+    elif type_id == int(ProjectileTypeId.ION_CANNON):
+        ring_scale = 1.0
+        ring_strength = 1.0
+        burst_scale = 2.2
+        if sfx_queue is not None:
+            sfx_queue.append("sfx_shockwave")
+    else:
+        return
+
+    detail = int(detail_preset)
+
+    # Port of `FUN_0042f270(pos, ring_scale, ring_strength)`: ring burst (effect_id=1).
+    effects.spawn(
+        effect_id=int(EffectId.RING),
+        pos=pos,
+        vel=Vec2(),
+        rotation=0.0,
+        scale=1.0,
+        half_width=4.0,
+        half_height=4.0,
+        age=0.0,
+        lifetime=float(ring_strength) * 0.8,
+        flags=0x19,
+        color=RGBA(0.6, 0.6, 0.9, 1.0),
+        rotation_step=0.0,
+        scale_step=float(ring_scale) * 45.0,
+        detail_preset=detail,
+    )
+
+    # Port of `FUN_0042f540(pos, burst_scale)`: burst cloud (effect_id=0).
+    burst = float(burst_scale) * 0.8
+    lifetime = min(burst * 0.7, 1.1)
+    half = burst * 32.0
+    # Native loop count is `__ftol(scale * 5.0)` after the local `scale *= 0.8`.
+    count = int(burst * 5.0)
+    if detail < 3:
+        count //= 2
+
+    for _ in range(max(0, count)):
+        rotation = float(int(rng()) & 0x7F) * 0.049087387
+        velocity = Vec2(
+            float((int(rng()) & 0x7F) - 0x40) * burst * 1.4,
+            float((int(rng()) & 0x7F) - 0x40) * burst * 1.4,
+        )
+        scale_step = (float(int(rng()) % 100) * 0.01 + 0.1) * burst
+        effects.spawn(
+            effect_id=int(EffectId.BURST),
+            pos=pos,
+            vel=velocity,
+            rotation=rotation,
+            scale=1.0,
+            half_width=half,
+            half_height=half,
+            age=0.0,
+            lifetime=float(lifetime),
+            flags=0x1D,
+            color=RGBA(0.4, 0.5, 1.0, 0.5),
+            rotation_step=0.0,
+            scale_step=scale_step,
+            detail_preset=detail,
+        )
+
+
+def _spawn_plasma_cannon_hit_effects(
+    effects: _EffectsLike | None,
+    sfx_queue: MutableSequence[str] | None,
+    *,
+    pos: Vec2,
+    detail_preset: int,
+) -> None:
+    """Port of `projectile_update` Plasma Cannon hit extras.
+
+    Native does:
+    - `sfx_play_panned(sfx_explosion_medium)`
+    - `sfx_play_panned(sfx_shockwave)`
+    - `FUN_0042f330(pos, 1.5, 1.0)`
+    - `FUN_0042f330(pos, 1.0, 1.0)`
+    """
+
+    if effects is None:
+        return
+
+    if sfx_queue is not None:
+        sfx_queue.append("sfx_explosion_medium")
+        sfx_queue.append("sfx_shockwave")
+
+    detail = int(detail_preset)
+
+    def _spawn_ring(*, scale: float) -> None:
+        effects.spawn(
+            effect_id=int(EffectId.RING),
+            pos=pos,
+            vel=Vec2(),
+            rotation=0.0,
+            scale=1.0,
+            half_width=4.0,
+            half_height=4.0,
+            age=0.1,
+            lifetime=1.0,
+            flags=0x19,
+            color=RGBA(0.9, 0.6, 0.3, 1.0),
+            rotation_step=0.0,
+            scale_step=float(scale) * 45.0,
+            detail_preset=detail,
+        )
+
+    _spawn_ring(scale=1.5)
+    _spawn_ring(scale=1.0)
+
+
+def _spawn_splitter_hit_effects(
+    effects: _EffectsLike | None,
+    *,
+    pos: Vec2,
+    rng: Callable[[], int],
+    detail_preset: int,
+) -> None:
+    """Port of `FUN_0042f3f0(pos, 26.0, 3)` from the Splitter Gun hit branch."""
+
+    if effects is None:
+        return
+
+    detail = int(detail_preset)
+    for _ in range(3):
+        angle = float(int(rng()) & 0x1FF) * (math.tau / 512.0)
+        radius = float(int(rng()) % 26)
+        jitter_age = -float(int(rng()) & 0xFF) * 0.0012
+        lifetime = 0.1 - jitter_age
+
+        offset = Vec2.from_angle(angle) * radius
+        effects.spawn(
+            effect_id=int(EffectId.BURST),
+            pos=pos + offset,
+            vel=Vec2(),
+            rotation=0.0,
+            scale=1.0,
+            half_width=4.0,
+            half_height=4.0,
+            age=jitter_age,
+            lifetime=lifetime,
+            flags=0x19,
+            color=RGBA(1.0, 0.9, 0.1, 1.0),
+            rotation_step=0.0,
+            scale_step=55.0,
+            detail_preset=detail,
+        )
+
+
+__all__ = [
+    "_spawn_ion_hit_effects",
+    "_spawn_plasma_cannon_hit_effects",
+    "_spawn_shrinkifier_hit_effects",
+    "_spawn_splitter_hit_effects",
+]

--- a/src/crimson/projectiles/types.py
+++ b/src/crimson/projectiles/types.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+from typing import Callable, MutableSequence, Protocol
+
+from grim.color import RGBA
+from grim.geom import Vec2
+
+from ..creatures.spawn import CreatureFlags
+
+
+class Damageable(Protocol):
+    active: bool
+    pos: Vec2
+    hp: float
+    hitbox_size: float
+    size: float
+    flags: CreatureFlags
+    plague_infected: bool
+
+
+class PlayerDamageable(Protocol):
+    pos: Vec2
+    health: float
+    shield_timer: float
+    size: float
+    perk_counts: list[int]
+
+
+class _SizeLike(Protocol):
+    size: float
+
+
+class _RngLike(Protocol):
+    def rand(self) -> int: ...
+
+
+class _BonusesLike(Protocol):
+    freeze: float
+
+
+class _EffectsLike(Protocol):
+    def spawn(
+        self,
+        *,
+        effect_id: int,
+        pos: Vec2,
+        vel: Vec2,
+        rotation: float,
+        scale: float,
+        half_width: float,
+        half_height: float,
+        age: float,
+        lifetime: float,
+        flags: int,
+        color: RGBA,
+        rotation_step: float,
+        scale_step: float,
+        detail_preset: int,
+    ) -> int | None: ...
+
+    def spawn_freeze_shard(self, *, pos: Vec2, angle: float, rand: Callable[[], int], detail_preset: int) -> None: ...
+
+    def spawn_explosion_burst(self, *, pos: Vec2, scale: float, rand: Callable[[], int], detail_preset: int) -> None: ...
+
+
+class _SpriteEffectsLike(Protocol):
+    def spawn(self, *, pos: Vec2, vel: Vec2, scale: float = 1.0, color: RGBA | None = None) -> int: ...
+
+
+class ProjectileRuntimeState(Protocol):
+    bonus_spawn_guard: bool
+    camera_shake_pulses: int
+    shock_chain_links_left: int
+    shock_chain_projectile_id: int
+
+    @property
+    def effects(self) -> _EffectsLike: ...
+
+    @property
+    def sprite_effects(self) -> _SpriteEffectsLike: ...
+
+    @property
+    def rng(self) -> _RngLike: ...
+
+    @property
+    def bonuses(self) -> _BonusesLike: ...
+
+    @property
+    def sfx_queue(self) -> MutableSequence[str]: ...
+
+    @property
+    def shots_hit(self) -> MutableSequence[int]: ...
+
+
+class FxQueueLike(Protocol):
+    def add(
+        self,
+        *,
+        effect_id: int,
+        pos: Vec2,
+        width: float,
+        height: float,
+        rotation: float,
+        rgba: RGBA,
+    ) -> bool: ...
+
+    def add_random(self, *, pos: Vec2, rand: Callable[[], int]) -> bool: ...
+
+
+MAIN_PROJECTILE_POOL_SIZE = 0x60
+SECONDARY_PROJECTILE_POOL_SIZE = 0x40
+
+
+class ProjectileTypeId(IntEnum):
+    # Values are projectile type ids (not weapon ids). Based on the decompile
+    # for `player_fire_weapon` and `projectile_update`.
+    PISTOL = 0x01
+    MEAN_MINIGUN = 0x01
+    ASSAULT_RIFLE = 0x02
+    SHOTGUN = 0x03
+    SAWED_OFF_SHOTGUN = 0x03
+    JACKHAMMER = 0x03
+    SUBMACHINE_GUN = 0x05
+    GAUSS_GUN = 0x06
+    GAUSS_SHOTGUN = 0x06
+    PLASMA_RIFLE = 0x09
+    MULTI_PLASMA = 0x09
+    PLASMA_MINIGUN = 0x0B
+    PLASMA_SHOTGUN = 0x0B
+    PULSE_GUN = 0x13
+    ION_RIFLE = 0x15
+    ION_MINIGUN = 0x16
+    ION_CANNON = 0x17
+    SHRINKIFIER = 0x18
+    BLADE_GUN = 0x19
+    SPIDER_PLASMA = 0x1A
+    PLASMA_CANNON = 0x1C
+    SPLITTER_GUN = 0x1D
+    PLAGUE_SPREADER = 0x29
+    RAINBOW_GUN = 0x2B
+    FIRE_BULLETS = 0x2D
+
+
+class SecondaryProjectileTypeId(IntEnum):
+    NONE = 0
+    ROCKET = 1
+    HOMING_ROCKET = 2
+    DETONATION = 3
+    ROCKET_MINIGUN = 4
+
+
+_CREATURE_HITBOX_ALIVE = 16.0
+
+
+def _rng_zero() -> int:
+    return 0
+
+
+CreatureDamageApplier = Callable[[int, float, int, Vec2, int], None]
+SecondaryDetonationKillHandler = Callable[[int], None]
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectileHit:
+    type_id: int
+    origin: Vec2
+    hit: Vec2
+    target: Vec2
+
+
+@dataclass(slots=True)
+class Projectile:
+    active: bool = False
+    angle: float = 0.0
+    pos: Vec2 = field(default_factory=Vec2)
+    origin: Vec2 = field(default_factory=Vec2)
+    type_id: int = 0
+    life_timer: float = 0.0
+    reserved: float = 0.0
+    speed_scale: float = 1.0
+    damage_pool: float = 1.0
+    hit_radius: float = 1.0
+    base_damage: float = 0.0
+    owner_id: int = 0
+    hits_players: bool = False
+
+
+@dataclass(slots=True)
+class SecondaryProjectile:
+    active: bool = False
+    angle: float = 0.0
+    speed: float = 0.0
+    pos: Vec2 = field(default_factory=Vec2)
+    vel: Vec2 = field(default_factory=Vec2)
+    detonation_t: float = 0.0
+    detonation_scale: float = 1.0
+    type_id: int = 0
+    owner_id: int = -100
+    trail_timer: float = 0.0
+    target_id: int = -1
+    # Compatibility fallback for contexts that cannot supply creature snapshots at spawn time.
+    target_hint_active: bool = False
+    target_hint: Vec2 = field(default_factory=Vec2)
+
+
+__all__ = [
+    "CreatureDamageApplier",
+    "Damageable",
+    "FxQueueLike",
+    "MAIN_PROJECTILE_POOL_SIZE",
+    "PlayerDamageable",
+    "Projectile",
+    "ProjectileHit",
+    "ProjectileRuntimeState",
+    "ProjectileTypeId",
+    "SecondaryDetonationKillHandler",
+    "SECONDARY_PROJECTILE_POOL_SIZE",
+    "SecondaryProjectile",
+    "SecondaryProjectileTypeId",
+    "_CREATURE_HITBOX_ALIVE",
+    "_EffectsLike",
+    "_rng_zero",
+    "_SizeLike",
+    "_SpriteEffectsLike",
+]


### PR DESCRIPTION
## Summary
- cut over `crimson.projectiles` from a single module file into a package
- split projectile internals into focused modules:
  - `src/crimson/projectiles/types.py` for data models and protocols
  - `src/crimson/projectiles/effects.py` for hit-effect helpers
  - `src/crimson/projectiles/pools.py` for update/runtime logic (renamed from the old module)
- add `src/crimson/projectiles/__init__.py` as the package API surface used by existing imports
- update diagnostics tooling to patch/import from `crimson.projectiles.pools` so monkeypatch hooks continue to target the runtime implementation
- update divergence report code-path hints from `src/crimson/projectiles.py` to `src/crimson/projectiles/pools.py`

## Validation
- `uv run ruff check .`
- `uv run pytest tests/test_projectiles.py tests/test_projectile_behavior_registry.py tests/test_projectile_hit_effects.py tests/test_death_timing.py`
- `just check`
