### PR TITLE
refactor: cut over gameplay facade imports

### DIFF
--- a/src/crimson/bonuses/selection.py
+++ b/src/crimson/bonuses/selection.py
@@ -10,7 +10,8 @@ from .ids import BONUS_BY_ID, BonusId
 
 if TYPE_CHECKING:
     from .pool import BonusPool
-    from ..gameplay import GameplayState, PlayerState
+    from ..gameplay import GameplayState
+    from ..sim.state_types import PlayerState
     from grim.rand import Crand
 
 

--- a/src/crimson/creatures/runtime.py
+++ b/src/crimson/creatures/runtime.py
@@ -18,7 +18,11 @@ from grim.color import RGBA
 from grim.geom import Vec2
 from grim.rand import Crand
 from ..effects import FxQueue, FxQueueRotated
-from ..gameplay import award_experience, award_experience_from_reward, survival_record_recent_death
+from ..gameplay import (
+    award_experience,
+    award_experience_from_reward,
+    survival_record_recent_death,
+)
 from ..math_parity import (
     NATIVE_PI,
     NATIVE_TAU,

--- a/src/crimson/demo.py
+++ b/src/crimson/demo.py
@@ -19,7 +19,9 @@ from grim.math import clamp
 from grim.rand import Crand
 from .creatures.spawn import RANDOM_HEADING_SENTINEL
 from .game_world import GameWorld
-from .gameplay import PlayerInput, PlayerState, weapon_assign_player
+from .sim.input import PlayerInput
+from .sim.state_types import PlayerState
+from .weapon_runtime import weapon_assign_player
 from .ui.cursor import draw_menu_cursor
 from .ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
 from .weapons import weapon_display_name

--- a/src/crimson/frontend/panels/databases.py
+++ b/src/crimson/frontend/panels/databases.py
@@ -511,7 +511,10 @@ class UnlockedWeaponsDatabaseView(_DatabaseBaseView):
         available: list[bool] | None = None
         weapon_refresh_available: Callable[..., None] | None = None
         try:
-            from ...gameplay import WEAPON_COUNT_SIZE, weapon_refresh_available as refresh_available
+            from ...gameplay import WEAPON_COUNT_SIZE
+            from ...weapon_runtime import (
+                weapon_refresh_available as refresh_available,
+            )
             weapon_refresh_available = cast(Callable[..., None], refresh_available)
         except Exception:
             WEAPON_COUNT_SIZE = max(int(entry.weapon_id) for entry in WEAPON_TABLE) + 1

--- a/src/crimson/game_world.py
+++ b/src/crimson/game_world.py
@@ -18,12 +18,10 @@ from .creatures.anim import creature_corpse_frame_for_type
 from .creatures.runtime import CreaturePool
 from .creatures.spawn import SpawnEnv
 from .effects import FxQueue, FxQueueRotated
-from .gameplay import (
-    GameplayState,
-    PlayerInput,
-    PlayerState,
-    weapon_assign_player,
-)
+from .gameplay import GameplayState
+from .sim.input import PlayerInput
+from .sim.state_types import PlayerState
+from .weapon_runtime import weapon_assign_player
 from .render.terrain_fx import FxQueueTextures, bake_fx_queues
 from .render.frame import RenderFrame
 from .render.world_renderer import WorldRenderer

--- a/src/crimson/local_input.py
+++ b/src/crimson/local_input.py
@@ -11,7 +11,8 @@ from grim.config import CrimsonConfig, default_player_keybind_block
 from grim.geom import Vec2
 
 from .frontend.panels.controls_labels import controls_method_values
-from .gameplay import PlayerInput, PlayerState
+from .sim.input import PlayerInput
+from .sim.state_types import PlayerState
 from .input_codes import (
     config_keybinds_for_player,
     input_axis_value_for_player,

--- a/src/crimson/modes/base_gameplay_mode.py
+++ b/src/crimson/modes/base_gameplay_mode.py
@@ -15,7 +15,7 @@ from grim.geom import Vec2
 from grim.terrain_render import GroundRenderer
 from grim.view import ViewContext
 
-from ..gameplay import PlayerInput
+from ..sim.input import PlayerInput
 from ..perks.runtime.effects import _creature_find_in_radius
 from ..perks.helpers import perk_count_get
 from ..game_world import GameWorld

--- a/src/crimson/modes/components/highscore_record_builder.py
+++ b/src/crimson/modes/components/highscore_record_builder.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from ...gameplay import GameplayState, PlayerState, most_used_weapon_id_for_player
+from ...gameplay import GameplayState
+from ...sim.state_types import PlayerState
+from ...weapon_runtime import most_used_weapon_id_for_player
 from ...persistence.highscores import HighScoreRecord
 
 

--- a/src/crimson/modes/components/perk_menu_controller.py
+++ b/src/crimson/modes/components/perk_menu_controller.py
@@ -8,7 +8,8 @@ import pyray as rl
 from grim.fonts.small import SmallFontData, measure_small_text_width
 from grim.math import clamp
 
-from ...gameplay import GameplayState, PlayerState
+from ...gameplay import GameplayState
+from ...sim.state_types import PlayerState
 from ...perks import PerkId, perk_display_description, perk_display_name
 from ...perks.selection import perk_selection_current_choices, perk_selection_pick
 from ...perks.state import CreatureForPerks, PerkSelectionState

--- a/src/crimson/modes/quest_mode.py
+++ b/src/crimson/modes/quest_mode.py
@@ -17,7 +17,10 @@ from grim.view import ViewContext
 
 from ..debug import debug_enabled
 from ..game_modes import GameMode
-from ..gameplay import most_used_weapon_id_for_player, weapon_assign_player
+from ..weapon_runtime import (
+    most_used_weapon_id_for_player,
+    weapon_assign_player,
+)
 from ..input_codes import (
     config_keybinds_for_player,
     input_code_is_down_for_player,

--- a/src/crimson/modes/replay_playback_mode.py
+++ b/src/crimson/modes/replay_playback_mode.py
@@ -11,10 +11,8 @@ from grim.view import ViewContext
 
 from ..game_modes import GameMode
 from ..game_world import GameWorld
-from ..gameplay import (
-    PlayerInput,
-    weapon_assign_player,
-)
+from ..sim.input import PlayerInput
+from ..weapon_runtime import weapon_assign_player
 from ..perks.state import CreatureForPerks
 from ..perks.selection import perk_selection_current_choices, perk_selection_pick
 from ..replay import (

--- a/src/crimson/modes/rush_mode.py
+++ b/src/crimson/modes/rush_mode.py
@@ -16,7 +16,7 @@ from grim.geom import Vec2
 from grim.view import ViewContext
 
 from ..game_modes import GameMode
-from ..gameplay import weapon_assign_player
+from ..weapon_runtime import weapon_assign_player
 from ..ui.cursor import draw_aim_cursor, draw_menu_cursor
 from ..ui.hud import draw_hud_overlay, hud_flags_for_game_mode
 from ..ui.perk_menu import load_perk_menu_assets

--- a/src/crimson/modes/survival_mode.py
+++ b/src/crimson/modes/survival_mode.py
@@ -19,10 +19,8 @@ from grim.view import ViewContext
 
 from ..debug import debug_enabled
 from ..game_modes import GameMode
-from ..gameplay import (
-    survival_check_level_up,
-    weapon_assign_player,
-)
+from ..gameplay import survival_check_level_up
+from ..weapon_runtime import weapon_assign_player
 from ..perks.state import CreatureForPerks
 from ..ui.cursor import draw_aim_cursor, draw_menu_cursor
 from ..ui.hud import draw_hud_overlay, hud_flags_for_game_mode

--- a/src/crimson/modes/tutorial_mode.py
+++ b/src/crimson/modes/tutorial_mode.py
@@ -16,7 +16,9 @@ from grim.view import ViewContext
 
 from ..creatures.runtime import CreatureFlags
 from ..game_modes import GameMode
-from ..gameplay import PlayerInput, survival_check_level_up, weapon_assign_player
+from ..gameplay import survival_check_level_up
+from ..sim.input import PlayerInput
+from ..weapon_runtime import weapon_assign_player
 from ..input_codes import config_keybinds, input_code_is_down, input_code_is_pressed, player_move_fire_binds
 from ..perks.state import CreatureForPerks
 from ..tutorial.timeline import TutorialFrameActions, TutorialState, tick_tutorial_timeline

--- a/src/crimson/oracle.py
+++ b/src/crimson/oracle.py
@@ -14,7 +14,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .gameplay import PlayerInput, PlayerState
+from .sim.input import PlayerInput
+from .sim.state_types import PlayerState
 from .sim.runners.common import build_damage_scale_by_type
 from .sim.sessions import SurvivalDeterministicSession
 from .sim.world_state import WorldState
@@ -296,7 +297,8 @@ def run_headless(config: OracleConfig) -> None:
     # Set up player at center
     players = world_state.players
     if not players:
-        from .gameplay import PlayerState, weapon_assign_player
+        from .sim.state_types import PlayerState
+        from .weapon_runtime import weapon_assign_player
 
         player = PlayerState(index=0, pos=Vec2(512.0, 512.0))
         weapon_assign_player(player, 1)

--- a/src/crimson/original/capture.py
+++ b/src/crimson/original/capture.py
@@ -1051,7 +1051,7 @@ def apply_capture_bootstrap_payload(
     state: object,
     players: list[object],
 ) -> int | None:
-    from ..gameplay import weapon_assign_player
+    from ..weapon_runtime import weapon_assign_player
 
     elapsed_ms: int | None = None
     elapsed_raw = _coerce_int_like(payload.get("elapsed_ms"))

--- a/src/crimson/original/capture_visualizer.py
+++ b/src/crimson/original/capture_visualizer.py
@@ -17,7 +17,7 @@ from grim.geom import Vec2
 from crimson.bonuses import BonusId
 from crimson.bonuses.pool import BonusEntry, bonus_label_for_entry
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput
+from crimson.sim.input import PlayerInput
 from crimson.original.capture import (
     CAPTURE_BOOTSTRAP_EVENT_KIND,
     CAPTURE_PERK_APPLY_EVENT_KIND,

--- a/src/crimson/original/creature_trajectory.py
+++ b/src/crimson/original/creature_trajectory.py
@@ -11,7 +11,7 @@ import msgspec
 from grim.geom import Vec2
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput
+from crimson.sim.input import PlayerInput
 from crimson.original.capture import (
     build_capture_dt_frame_overrides,
     build_capture_dt_frame_ms_i32_overrides,

--- a/src/crimson/original/focus_trace.py
+++ b/src/crimson/original/focus_trace.py
@@ -16,7 +16,7 @@ from grim.geom import Vec2
 import crimson.projectiles.pools as projectiles_mod
 import crimson.sim.presentation_step as presentation_step_mod
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput
+from crimson.sim.input import PlayerInput
 from crimson.original.capture import (
     CAPTURE_BOOTSTRAP_EVENT_KIND,
     build_capture_dt_frame_overrides,

--- a/src/crimson/render/frame.py
+++ b/src/crimson/render/frame.py
@@ -10,7 +10,8 @@ from grim.geom import Vec2
 from grim.terrain_render import GroundRenderer
 
 from ..creatures.runtime import CreaturePool
-from ..gameplay import GameplayState, PlayerState
+from ..gameplay import GameplayState
+from ..sim.state_types import PlayerState
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/crimson/render/world_renderer.py
+++ b/src/crimson/render/world_renderer.py
@@ -40,7 +40,8 @@ if TYPE_CHECKING:
 
     from ..creatures.runtime import CreaturePool
     from ..game_world import GameWorld
-    from ..gameplay import GameplayState, PlayerState
+    from ..gameplay import GameplayState
+    from ..sim.state_types import PlayerState
     from ..projectiles import Projectile, SecondaryProjectile
 
 _RAD_TO_DEG = 57.29577951308232

--- a/src/crimson/sim/runners/common.py
+++ b/src/crimson/sim/runners/common.py
@@ -7,7 +7,10 @@ import math
 from pathlib import Path
 
 from ...effects import FxQueue, FxQueueRotated
-from ...gameplay import most_used_weapon_id_for_player, weapon_assign_player
+from ...weapon_runtime import (
+    most_used_weapon_id_for_player,
+    weapon_assign_player,
+)
 from ...persistence.save_status import WEAPON_USAGE_COUNT, GameStatus, default_status_data
 from ...weapons import WEAPON_TABLE
 from ..step_pipeline import time_scale_reflex_boost_bonus as _time_scale_reflex_boost_bonus

--- a/src/crimson/sim/runners/rush.py
+++ b/src/crimson/sim/runners/rush.py
@@ -5,7 +5,7 @@ import math
 from grim.geom import Vec2
 
 from ...game_modes import GameMode
-from ...gameplay import weapon_assign_player
+from ...weapon_runtime import weapon_assign_player
 from ...replay import Replay, UnknownEvent, unpack_packed_player_input, unpack_input_flags, warn_on_game_version_mismatch
 from ...replay.checkpoints import ReplayCheckpoint, build_checkpoint
 from ...original.capture import (

--- a/src/crimson/sim/step_pipeline.py
+++ b/src/crimson/sim/step_pipeline.py
@@ -6,7 +6,7 @@ import json
 from typing import Callable
 
 from ..effects import FxQueue, FxQueueRotated
-from ..gameplay import weapon_refresh_available
+from ..weapon_runtime import weapon_refresh_available
 from ..math_parity import f32
 from ..perks.availability import perks_rebuild_available
 from .input import PlayerInput

--- a/src/crimson/typo/player.py
+++ b/src/crimson/typo/player.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from ..gameplay import PlayerInput, PlayerState, weapon_assign_player
+from ..sim.input import PlayerInput
+from ..sim.state_types import PlayerState
+from ..weapon_runtime import weapon_assign_player
 
 TYPO_WEAPON_ID = 4
 

--- a/src/crimson/ui/hud.py
+++ b/src/crimson/ui/hud.py
@@ -12,7 +12,8 @@ from grim.fonts.small import SmallFontData, draw_small_text
 from grim.geom import Vec2
 from ..bonuses.hud import BonusHudState
 from ..game_modes import GameMode
-from ..gameplay import PlayerState, survival_level_threshold
+from ..gameplay import survival_level_threshold
+from ..sim.state_types import PlayerState
 from ..weapons import WEAPON_BY_ID, weapon_display_name
 
 HUD_TEXT_COLOR = rl.Color(220, 220, 220, 255)

--- a/src/crimson/views/aim_debug.py
+++ b/src/crimson/views/aim_debug.py
@@ -9,7 +9,7 @@ from grim.math import clamp
 from grim.view import ViewContext
 
 from ..game_world import GameWorld
-from ..gameplay import PlayerInput
+from ..sim.input import PlayerInput
 from ..paths import default_runtime_dir
 from ..ui.cursor import draw_cursor_glow
 from ._ui_helpers import draw_ui_text, ui_line_height

--- a/src/crimson/views/arsenal_debug.py
+++ b/src/crimson/views/arsenal_debug.py
@@ -15,7 +15,8 @@ from ..bonuses import BONUS_TABLE, BonusId
 from ..creatures.spawn import SpawnId
 from ..game_modes import GameMode
 from ..game_world import GameWorld
-from ..gameplay import PlayerInput, weapon_assign_player
+from ..sim.input import PlayerInput
+from ..weapon_runtime import weapon_assign_player
 from ..projectiles import ProjectileTypeId
 from ..ui.cursor import draw_aim_cursor
 from ..weapon_sfx import resolve_weapon_sfx_ref

--- a/src/crimson/views/camera_shake.py
+++ b/src/crimson/views/camera_shake.py
@@ -14,7 +14,7 @@ from ..bonuses import BonusId
 from ..bonuses.apply import bonus_apply
 from ..creatures.spawn import CreatureInit, CreatureTypeId
 from ..game_world import GameWorld
-from ..gameplay import PlayerInput
+from ..sim.input import PlayerInput
 from ..paths import default_runtime_dir
 from ._ui_helpers import draw_ui_text, ui_line_height
 from .registry import register_view

--- a/src/crimson/views/decals_debug.py
+++ b/src/crimson/views/decals_debug.py
@@ -20,7 +20,8 @@ from crimson.creatures.runtime import CreaturePool
 from crimson.creatures.spawn import CreatureFlags, CreatureInit, CreatureTypeId, SpawnEnv
 from crimson.effects import FxQueue, FxQueueRotated
 from crimson.effects_atlas import EffectId
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.render.terrain_fx import FxQueueTextures, bake_fx_queues
 from grim.assets import resolve_asset_path
 from grim.config import ensure_crimson_cfg

--- a/src/crimson/views/lighting_debug.py
+++ b/src/crimson/views/lighting_debug.py
@@ -18,7 +18,7 @@ from grim.view import ViewContext
 
 from ..creatures.spawn import CreatureInit, CreatureTypeId
 from ..game_world import GameWorld
-from ..gameplay import PlayerInput
+from ..sim.input import PlayerInput
 from ..paths import default_runtime_dir
 from ._ui_helpers import draw_ui_text, ui_line_height
 from .registry import register_view

--- a/src/crimson/views/perks.py
+++ b/src/crimson/views/perks.py
@@ -9,9 +9,9 @@ from grim.view import ViewContext
 from ..game_modes import GameMode
 from ..gameplay import (
     GameplayState,
-    PlayerState,
     survival_check_level_up,
 )
+from ..sim.state_types import PlayerState
 from ..perks import PERK_BY_ID, PerkId, perk_display_description, perk_display_name
 from ..perks.selection import perk_selection_current_choices, perk_selection_pick
 from ..ui.menu_panel import draw_classic_menu_panel

--- a/src/crimson/views/player.py
+++ b/src/crimson/views/player.py
@@ -17,11 +17,11 @@ from ..bonuses.hud import bonus_hud_update
 from ..creatures.spawn import CreatureFlags
 from ..gameplay import (
     GameplayState,
-    PlayerInput,
-    PlayerState,
     player_update,
-    weapon_assign_player,
 )
+from ..sim.input import PlayerInput
+from ..sim.state_types import PlayerState
+from ..weapon_runtime import weapon_assign_player
 from ..perks import PerkId
 from ..ui.hud import HudAssets, HudState, draw_hud_overlay, hud_ui_scale, load_hud_assets
 from ..weapons import WEAPON_TABLE, weapon_display_name

--- a/src/crimson/views/projectile_fx.py
+++ b/src/crimson/views/projectile_fx.py
@@ -15,7 +15,8 @@ from ..bonuses import BonusId
 from ..bonuses.apply import bonus_apply
 from ..creatures.spawn import CreatureFlags
 from ..effects_atlas import EffectId, effect_src_rect
-from ..gameplay import GameplayState, PlayerState
+from ..gameplay import GameplayState
+from ..sim.state_types import PlayerState
 from ..projectiles import ProjectileTypeId
 from ..weapons import (
     WEAPON_BY_ID,

--- a/src/crimson/views/projectile_render_debug.py
+++ b/src/crimson/views/projectile_render_debug.py
@@ -14,7 +14,9 @@ from grim.view import View, ViewContext
 
 from ..creatures.spawn import CreatureFlags
 from ..game_world import GameWorld
-from ..gameplay import PlayerInput, player_update, weapon_assign_player
+from ..gameplay import player_update
+from ..sim.input import PlayerInput
+from ..weapon_runtime import weapon_assign_player
 from ..sim.world_defs import BEAM_TYPES
 from ..ui.cursor import draw_aim_cursor
 from ..weapons import WEAPON_TABLE

--- a/tests/test_alternate_weapon_perk.py
+++ b/tests/test_alternate_weapon_perk.py
@@ -6,7 +6,13 @@ import pytest
 
 from crimson.bonuses import BonusId
 from crimson.bonuses.apply import bonus_apply
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_update, weapon_assign_player
+from crimson.gameplay import (
+    GameplayState,
+    player_update,
+)
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import weapon_assign_player
 from crimson.perks import PerkId
 
 

--- a/tests/test_ammo_maniac_perk.py
+++ b/tests/test_ammo_maniac_perk.py
@@ -4,7 +4,8 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 from crimson.projectiles import ProjectileTypeId

--- a/tests/test_ammunition_within_perk.py
+++ b/tests/test_ammunition_within_perk.py
@@ -4,7 +4,10 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_fire_weapon
+from crimson.gameplay import GameplayState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import player_fire_weapon
 from crimson.perks import PerkId
 
 

--- a/tests/test_antiperk_perk.py
+++ b/tests/test_antiperk_perk.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from grim.geom import Vec2
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.availability import perk_can_offer
 

--- a/tests/test_anxious_loader_perk.py
+++ b/tests/test_anxious_loader_perk.py
@@ -4,7 +4,12 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_update
+from crimson.gameplay import (
+    GameplayState,
+    player_update,
+)
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_bandage_perk.py
+++ b/tests/test_bandage_perk.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 

--- a/tests/test_barrel_greaser_perk.py
+++ b/tests/test_barrel_greaser_perk.py
@@ -8,7 +8,7 @@ import pytest
 
 from crimson.creatures.damage import creature_apply_damage
 from crimson.creatures.runtime import CreatureState
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.projectiles import ProjectilePool, ProjectileTypeId
 from crimson.weapons import WEAPON_BY_ID

--- a/tests/test_bloody_mess_quick_learner_perk.py
+++ b/tests/test_bloody_mess_quick_learner_perk.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from grim.geom import Vec2
 
 from crimson.creatures.runtime import CREATURE_HITBOX_ALIVE, CreaturePool
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId, perk_display_description, perk_display_name
 
 

--- a/tests/test_bonus_economist_perk.py
+++ b/tests/test_bonus_economist_perk.py
@@ -4,7 +4,8 @@ from grim.geom import Vec2
 
 from crimson.bonuses import BonusId
 from crimson.bonuses.apply import bonus_apply
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_bonus_magnet_perk.py
+++ b/tests/test_bonus_magnet_perk.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from grim.geom import Vec2
 
 from crimson.bonuses.pool import BonusPool
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.weapons import WeaponId
 

--- a/tests/test_bonus_pick_random_type_quest_suppression.py
+++ b/tests/test_bonus_pick_random_type_quest_suppression.py
@@ -5,7 +5,8 @@ from grim.geom import Vec2
 from crimson.bonuses import BonusId
 from crimson.bonuses.selection import bonus_pick_random_type
 from crimson.game_modes import GameMode
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 
 
 class _SeqRng:

--- a/tests/test_bonus_pistol_rules.py
+++ b/tests/test_bonus_pistol_rules.py
@@ -4,7 +4,8 @@ from grim.geom import Vec2
 
 from crimson.bonuses import BonusId
 from crimson.bonuses.pool import BonusPool
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.weapons import WeaponId
 
 

--- a/tests/test_bonus_spawn_suppression.py
+++ b/tests/test_bonus_spawn_suppression.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from grim.geom import Vec2
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 
 
 def test_bonus_try_spawn_on_kill_suppressed_in_typo_mode() -> None:

--- a/tests/test_breathing_room_perk.py
+++ b/tests/test_breathing_room_perk.py
@@ -5,7 +5,8 @@ from grim.geom import Vec2
 import math
 
 from crimson.creatures.runtime import CREATURE_HITBOX_ALIVE, CreatureState
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 

--- a/tests/test_camera_shake.py
+++ b/tests/test_camera_shake.py
@@ -10,7 +10,9 @@ from crimson.bonuses import BonusId
 from crimson.bonuses.apply import bonus_apply
 from crimson.camera import camera_shake_update
 from crimson.game_world import GameWorld
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.sim.runners.common import build_damage_scale_by_type, build_empty_fx_queues, reset_players
 from crimson.sim.sessions import RushDeterministicSession, SurvivalDeterministicSession
 from crimson.sim.world_state import WorldState

--- a/tests/test_creature_damage.py
+++ b/tests/test_creature_damage.py
@@ -7,7 +7,7 @@ import pytest
 from crimson.creatures.damage import creature_apply_damage
 from crimson.creatures.runtime import CreatureState
 from crimson.creatures.spawn import CreatureFlags
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_creature_runtime.py
+++ b/tests/test_creature_runtime.py
@@ -8,7 +8,8 @@ import pytest
 
 from crimson.effects import FxQueue
 from crimson.game_modes import GameMode
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.creatures.runtime import CREATURE_HITBOX_ALIVE, CreaturePool
 from crimson.creatures.spawn import CreatureFlags, CreatureInit, CreatureTypeId, SpawnEnv, SpawnSlotInit, build_spawn_plan
 from crimson.weapons import WeaponId

--- a/tests/test_death_clock_perk.py
+++ b/tests/test_death_clock_perk.py
@@ -4,7 +4,8 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 from crimson.perks.runtime.effects import perks_update_effects

--- a/tests/test_death_timing.py
+++ b/tests/test_death_timing.py
@@ -7,7 +7,8 @@ from crimson.creatures.runtime import CreatureUpdateResult
 from crimson.creatures.spawn import CreatureFlags
 from crimson.effects import FxQueue, FxQueueRotated
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput, PlayerState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.projectiles import ProjectileHit, ProjectileTypeId, SecondaryProjectileTypeId
 import crimson.sim.world_state as world_state_mod
 from crimson.sim.world_state import WorldState

--- a/tests/test_demo_mode_movement_deadzone.py
+++ b/tests/test_demo_mode_movement_deadzone.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_update
+from crimson.gameplay import (
+    GameplayState,
+    player_update,
+)
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 
 
 def test_demo_mode_does_not_apply_movement_deadzone() -> None:

--- a/tests/test_doctor_perk.py
+++ b/tests/test_doctor_perk.py
@@ -6,7 +6,7 @@ import pytest
 
 from crimson.creatures.damage import creature_apply_damage
 from crimson.creatures.runtime import CreatureState
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_double_xp_bonus.py
+++ b/tests/test_double_xp_bonus.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from grim.geom import Vec2
 
 from crimson.creatures.runtime import CREATURE_HITBOX_ALIVE, CreaturePool
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 
 
 def test_creature_handle_death_doubles_xp_when_double_xp_bonus_active() -> None:

--- a/tests/test_energizer_bonus.py
+++ b/tests/test_energizer_bonus.py
@@ -6,7 +6,8 @@ import math
 
 from crimson.creatures.runtime import CreaturePool
 from crimson.creatures.spawn import CreatureFlags
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 
 
 def _wrap_angle(angle: float) -> float:

--- a/tests/test_evil_eyes_perk.py
+++ b/tests/test_evil_eyes_perk.py
@@ -6,7 +6,8 @@ import math
 
 from crimson.effects import FxQueue, FxQueueRotated
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput, PlayerState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.sim.world_state import WorldState
 

--- a/tests/test_fastloader_perk.py
+++ b/tests/test_fastloader_perk.py
@@ -4,7 +4,9 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerState, player_start_reload
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import player_start_reload
 from crimson.perks import PerkId
 from crimson.projectiles import ProjectileTypeId
 from crimson.weapons import WEAPON_BY_ID

--- a/tests/test_fastshot_perk.py
+++ b/tests/test_fastshot_perk.py
@@ -4,7 +4,10 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_fire_weapon
+from crimson.gameplay import GameplayState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import player_fire_weapon
 from crimson.perks import PerkId
 
 

--- a/tests/test_fatal_lottery_perk.py
+++ b/tests/test_fatal_lottery_perk.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 

--- a/tests/test_final_revenge_perk.py
+++ b/tests/test_final_revenge_perk.py
@@ -7,7 +7,8 @@ import pytest
 from crimson.creatures.runtime import CREATURE_HITBOX_ALIVE
 from crimson.effects import FxQueue, FxQueueRotated
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput, PlayerState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.sim.world_state import WorldState
 

--- a/tests/test_freeze_bonus.py
+++ b/tests/test_freeze_bonus.py
@@ -7,7 +7,8 @@ from crimson.bonuses.apply import bonus_apply
 from crimson.creatures.runtime import CreaturePool
 from crimson.effects import FxQueue, FxQueueRotated
 from crimson.game_modes import GameMode
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.sim.world_state import WorldState
 
 

--- a/tests/test_game_mode_ids.py
+++ b/tests/test_game_mode_ids.py
@@ -5,7 +5,8 @@ from grim.geom import Vec2
 from pathlib import Path
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.persistence.highscores import HighScoreRecord, rank_index, scores_path_for_config, sort_highscores
 from crimson.perks import PERK_BY_ID, PerkFlags, PerkId
 from crimson.perks.availability import perk_can_offer

--- a/tests/test_game_world_audio.py
+++ b/tests/test_game_world_audio.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import random
 
 from crimson.bonuses import BonusId
-from crimson.gameplay import PlayerInput, player_update
+from crimson.gameplay import player_update
+from crimson.sim.input import PlayerInput
 from crimson.game_world import GameWorld
 from crimson.perks import PerkId
 from grim.geom import Vec2

--- a/tests/test_grim_deal_perk.py
+++ b/tests/test_grim_deal_perk.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 

--- a/tests/test_highlander_perk.py
+++ b/tests/test_highlander_perk.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.player_damage import player_take_damage
 

--- a/tests/test_highscore_record_builder.py
+++ b/tests/test_highscore_record_builder.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.modes.components.highscore_record_builder import (
     build_highscore_record_for_game_over,
     clamp_shots,

--- a/tests/test_hud_multiplayer.py
+++ b/tests/test_hud_multiplayer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.ui.hud import HudAssets, HudState, draw_hud_overlay
 
 

--- a/tests/test_infernal_contract_perk.py
+++ b/tests/test_infernal_contract_perk.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks.runtime.apply import perk_apply
 from crimson.perks import PerkId
 from crimson.perks.state import PerkSelectionState

--- a/tests/test_input_frame_contract.py
+++ b/tests/test_input_frame_contract.py
@@ -4,7 +4,8 @@ import pytest
 from grim.geom import Vec2
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput, PlayerState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.replay import ReplayGameVersionWarning, ReplayHeader, ReplayRecorder
 from crimson.sim.input_frame import normalize_input_frame
 from crimson.sim.runners import run_survival_replay

--- a/tests/test_instant_winner_perk.py
+++ b/tests/test_instant_winner_perk.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 

--- a/tests/test_ion_gun_master_perk.py
+++ b/tests/test_ion_gun_master_perk.py
@@ -6,7 +6,7 @@ import pytest
 
 from crimson.creatures.damage import creature_apply_damage
 from crimson.creatures.runtime import CreatureState
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.projectiles import ProjectilePool, ProjectileTypeId
 

--- a/tests/test_jinxed_perk.py
+++ b/tests/test_jinxed_perk.py
@@ -6,7 +6,8 @@ import math
 
 from crimson.creatures.runtime import CreatureState
 from crimson.effects import FxQueue
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.effects import perks_update_effects
 

--- a/tests/test_lean_mean_exp_machine.py
+++ b/tests/test_lean_mean_exp_machine.py
@@ -4,7 +4,8 @@ from grim.geom import Vec2
 
 import math
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.effects import perks_update_effects
 

--- a/tests/test_lifeline_50_50_perk.py
+++ b/tests/test_lifeline_50_50_perk.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from grim.geom import Vec2
 
 from crimson.creatures.runtime import CreatureState
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 

--- a/tests/test_living_fortress_perk.py
+++ b/tests/test_living_fortress_perk.py
@@ -6,7 +6,7 @@ import pytest
 
 from crimson.creatures.damage import creature_apply_damage
 from crimson.creatures.runtime import CreatureState
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_local_input.py
+++ b/tests/test_local_input.py
@@ -6,7 +6,7 @@ import pytest
 
 from crimson import local_input
 from crimson.aim_schemes import AimScheme
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.movement_controls import MovementControlType
 from grim.geom import Vec2
 

--- a/tests/test_long_distance_runner_perk.py
+++ b/tests/test_long_distance_runner_perk.py
@@ -4,7 +4,12 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_update
+from crimson.gameplay import (
+    GameplayState,
+    player_update,
+)
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_monster_vision_perk.py
+++ b/tests/test_monster_vision_perk.py
@@ -4,7 +4,7 @@ from grim.geom import Vec2
 
 import math
 
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.helpers import perk_active
 from crimson.render.world_renderer import monster_vision_fade_alpha

--- a/tests/test_mr_melee_perk.py
+++ b/tests/test_mr_melee_perk.py
@@ -5,7 +5,8 @@ from grim.geom import Vec2
 import pytest
 
 from crimson.creatures.runtime import CREATURE_HITBOX_ALIVE, CreaturePool
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_multiplayer_wiring.py
+++ b/tests/test_multiplayer_wiring.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from crimson.gameplay import PlayerInput
+from crimson.sim.input import PlayerInput
 from crimson.game_world import GameWorld
 from crimson.modes.quest_mode import QuestMode
 from crimson.modes.survival_mode import SurvivalMode

--- a/tests/test_my_favourite_weapon_perk.py
+++ b/tests/test_my_favourite_weapon_perk.py
@@ -4,7 +4,9 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerState, weapon_assign_player
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import weapon_assign_player
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 from crimson.projectiles import ProjectileTypeId

--- a/tests/test_nuke_bonus.py
+++ b/tests/test_nuke_bonus.py
@@ -7,7 +7,8 @@ import math
 from crimson.bonuses import BonusId
 from crimson.bonuses.apply import bonus_apply
 from crimson.creatures.runtime import CreaturePool
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.projectiles import ProjectileTypeId
 
 

--- a/tests/test_original_bug_amount_weapon_id_suppression.py
+++ b/tests/test_original_bug_amount_weapon_id_suppression.py
@@ -4,7 +4,8 @@ from grim.geom import Vec2
 
 from crimson.bonuses import BonusId
 from crimson.bonuses.pool import BonusPool
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.weapons import WeaponId
 
 

--- a/tests/test_original_capture_verify.py
+++ b/tests/test_original_capture_verify.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 from grim.geom import Vec2
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput
+from crimson.sim.input import PlayerInput
 from crimson.original.capture import convert_capture_to_replay
 from crimson.original.diff import ReplayFieldDiff
 from crimson.original.schema import (

--- a/tests/test_particle_weapons.py
+++ b/tests/test_particle_weapons.py
@@ -5,7 +5,13 @@ from grim.geom import Vec2
 import math
 
 from crimson.creatures.runtime import CreatureState
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_fire_weapon, weapon_assign_player
+from crimson.gameplay import GameplayState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import (
+    player_fire_weapon,
+    weapon_assign_player,
+)
 
 
 class _FixedRng:

--- a/tests/test_perk_choice_generation_rules.py
+++ b/tests/test_perk_choice_generation_rules.py
@@ -6,7 +6,8 @@ import pytest
 from pathlib import Path
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.persistence import save_status
 from crimson.perks import PerkId
 from crimson.perks.availability import perks_rebuild_available

--- a/tests/test_perk_expert_perk.py
+++ b/tests/test_perk_expert_perk.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.selection import perk_choice_count
 

--- a/tests/test_perk_master_perk.py
+++ b/tests/test_perk_master_perk.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.selection import perk_choice_count
 

--- a/tests/test_perk_selection.py
+++ b/tests/test_perk_selection.py
@@ -5,7 +5,8 @@ from grim.geom import Vec2
 import pytest
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.selection import (
     perk_auto_pick,

--- a/tests/test_plaguebearer_perk.py
+++ b/tests/test_plaguebearer_perk.py
@@ -6,7 +6,8 @@ import math
 
 from crimson.creatures.runtime import CREATURE_HITBOX_ALIVE, CreaturePool
 from crimson.creatures.spawn import CreatureFlags
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 

--- a/tests/test_player_damage.py
+++ b/tests/test_player_damage.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.player_damage import player_take_damage
 

--- a/tests/test_player_update.py
+++ b/tests/test_player_update.py
@@ -9,7 +9,16 @@ from grim.rand import Crand
 from crimson.bonuses import BonusId
 from crimson.bonuses.apply import bonus_apply
 from crimson.bonuses.hud import bonus_hud_update
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_fire_weapon, player_update, weapon_assign_player
+from crimson.gameplay import (
+    GameplayState,
+    player_update,
+)
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import (
+    player_fire_weapon,
+    weapon_assign_player,
+)
 from crimson.perks import PerkId
 from crimson.perks.runtime.effects import perks_update_effects
 from crimson.projectiles import ProjectilePool, ProjectileTypeId

--- a/tests/test_poison_bullets_perk.py
+++ b/tests/test_poison_bullets_perk.py
@@ -6,7 +6,8 @@ from crimson.bonuses import BonusId
 from crimson.creatures.spawn import CreatureFlags
 from crimson.effects import FxQueue, FxQueueRotated
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput, PlayerState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.projectiles import ProjectileTypeId
 from crimson.sim.world_state import WorldState

--- a/tests/test_presentation_step.py
+++ b/tests/test_presentation_step.py
@@ -5,7 +5,8 @@ from types import SimpleNamespace
 from crimson.creatures.spawn import CreatureTypeId
 from crimson.effects import FxQueue
 from crimson.game_modes import GameMode
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.projectiles import ProjectileHit, ProjectileTypeId
 from crimson.sim.presentation_step import (
     apply_world_presentation_step,

--- a/tests/test_projectile_hit_effects.py
+++ b/tests/test_projectile_hit_effects.py
@@ -5,7 +5,8 @@ from grim.geom import Vec2
 import pytest
 
 from crimson.creatures.runtime import CreatureState
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.projectiles import ProjectilePool, ProjectileTypeId
 
 

--- a/tests/test_projectiles.py
+++ b/tests/test_projectiles.py
@@ -6,7 +6,8 @@ from grim.geom import Vec2
 from dataclasses import dataclass
 import math
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.effects import FxQueue
 from crimson.projectiles import ProjectileHit, ProjectilePool, SecondaryProjectilePool
 from crimson.projectiles import ProjectileTypeId

--- a/tests/test_pyrokinetic_perk.py
+++ b/tests/test_pyrokinetic_perk.py
@@ -6,7 +6,8 @@ import math
 
 from crimson.creatures.runtime import CreatureState
 from crimson.effects import FxQueue
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.effects import perks_update_effects
 

--- a/tests/test_pyromaniac_damage_perk.py
+++ b/tests/test_pyromaniac_damage_perk.py
@@ -6,7 +6,7 @@ import pytest
 
 from crimson.creatures.damage import creature_apply_damage
 from crimson.creatures.runtime import CreatureState
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_radioactive_perk.py
+++ b/tests/test_radioactive_perk.py
@@ -7,7 +7,8 @@ import math
 from crimson.creatures.runtime import CREATURE_HITBOX_ALIVE, CreaturePool
 from crimson.creatures.spawn import CreatureFlags
 from crimson.effects import FxQueue
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_random_weapon_perk.py
+++ b/tests/test_random_weapon_perk.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.apply import perk_apply
 

--- a/tests/test_ranged_attacks.py
+++ b/tests/test_ranged_attacks.py
@@ -6,7 +6,8 @@ import math
 
 from crimson.creatures.runtime import CreaturePool
 from crimson.creatures.spawn import CreatureFlags, CreatureInit
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 
 
 def _wrap_angle(angle: float) -> float:

--- a/tests/test_reflex_boosted_perk.py
+++ b/tests/test_reflex_boosted_perk.py
@@ -6,7 +6,8 @@ import pytest
 
 from crimson.effects import FxQueue, FxQueueRotated
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput, PlayerState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.sim.world_state import WorldState
 

--- a/tests/test_regeneration_perk.py
+++ b/tests/test_regeneration_perk.py
@@ -4,7 +4,8 @@ from grim.geom import Vec2
 
 import math
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.perks.runtime.effects import perks_update_effects
 

--- a/tests/test_regression_bullets_perk.py
+++ b/tests/test_regression_bullets_perk.py
@@ -4,7 +4,10 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_fire_weapon
+from crimson.gameplay import GameplayState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import player_fire_weapon
 from crimson.perks import PerkId
 
 

--- a/tests/test_replay_checkpoints.py
+++ b/tests/test_replay_checkpoints.py
@@ -5,7 +5,7 @@ from grim.geom import Vec2
 import gzip
 import json
 
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.replay.checkpoints import (
     FORMAT_VERSION,
     ReplayCheckpoints,

--- a/tests/test_replay_codec.py
+++ b/tests/test_replay_codec.py
@@ -6,7 +6,7 @@ import json
 import pytest
 from grim.geom import Vec2
 
-from crimson.gameplay import PlayerInput
+from crimson.sim.input import PlayerInput
 from crimson.replay import (
     PerkMenuOpenEvent,
     PerkPickEvent,

--- a/tests/test_replay_diff.py
+++ b/tests/test_replay_diff.py
@@ -4,7 +4,7 @@ from dataclasses import replace
 
 from grim.geom import Vec2
 
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.replay.checkpoints import (
     ReplayDeathLedgerEntry,
     ReplayEventSummary,

--- a/tests/test_replay_perk_menu_open_event.py
+++ b/tests/test_replay_perk_menu_open_event.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import weapon_refresh_available
+from crimson.weapon_runtime import weapon_refresh_available
 from crimson.perks import PerkId
 from crimson.perks.availability import perks_rebuild_available
 from crimson.perks.helpers import perk_count_get

--- a/tests/test_replay_runners.py
+++ b/tests/test_replay_runners.py
@@ -4,7 +4,7 @@ import pytest
 from grim.geom import Vec2
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput
+from crimson.sim.input import PlayerInput
 from crimson.replay import ReplayGameVersionWarning, ReplayHeader, ReplayRecorder, UnknownEvent
 from crimson.original.capture import CAPTURE_BOOTSTRAP_EVENT_KIND
 from crimson.sim.runners import ReplayRunnerError, run_rush_replay, run_survival_replay

--- a/tests/test_rocket_minigun_weapon.py
+++ b/tests/test_rocket_minigun_weapon.py
@@ -4,7 +4,13 @@ from grim.geom import Vec2
 
 import math
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_fire_weapon, weapon_assign_player
+from crimson.gameplay import GameplayState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import (
+    player_fire_weapon,
+    weapon_assign_player,
+)
 
 
 class _FixedRng:

--- a/tests/test_sharpshooter_perk.py
+++ b/tests/test_sharpshooter_perk.py
@@ -4,7 +4,13 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_fire_weapon, player_update
+from crimson.gameplay import (
+    GameplayState,
+    player_update,
+)
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import player_fire_weapon
 from crimson.perks import PerkId
 from crimson.projectiles import ProjectilePool, ProjectileTypeId
 from crimson.weapons import WEAPON_BY_ID

--- a/tests/test_shot_stats.py
+++ b/tests/test_shot_stats.py
@@ -4,7 +4,13 @@ from grim.geom import Vec2
 
 from dataclasses import dataclass
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_fire_weapon, weapon_assign_player
+from crimson.gameplay import GameplayState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import (
+    player_fire_weapon,
+    weapon_assign_player,
+)
 
 
 @dataclass(slots=True)

--- a/tests/test_spawn_signatures.py
+++ b/tests/test_spawn_signatures.py
@@ -6,7 +6,12 @@ from collections import Counter
 
 from crimson.bonuses import BonusId
 from crimson.bonuses.apply import bonus_apply
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_update
+from crimson.gameplay import (
+    GameplayState,
+    player_update,
+)
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.projectiles import ProjectilePool, ProjectileTypeId
 

--- a/tests/test_speed_bonus_scaling.py
+++ b/tests/test_speed_bonus_scaling.py
@@ -4,7 +4,12 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_update
+from crimson.gameplay import (
+    GameplayState,
+    player_update,
+)
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 
 
 def test_speed_bonus_adds_one_to_speed_multiplier() -> None:

--- a/tests/test_stationary_reloader_perk.py
+++ b/tests/test_stationary_reloader_perk.py
@@ -4,7 +4,12 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_update
+from crimson.gameplay import (
+    GameplayState,
+    player_update,
+)
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_step_pipeline_parity.py
+++ b/tests/test_step_pipeline_parity.py
@@ -7,7 +7,8 @@ from grim.geom import Vec2
 
 from crimson.creatures.spawn import advance_survival_spawn_stage, tick_rush_mode_spawns, tick_survival_wave_spawns
 from crimson.game_modes import GameMode
-from crimson.gameplay import PlayerInput, weapon_assign_player
+from crimson.sim.input import PlayerInput
+from crimson.weapon_runtime import weapon_assign_player
 from crimson.game_world import GameWorld
 from crimson.replay import Replay, ReplayGameVersionWarning, ReplayHeader, ReplayRecorder, unpack_input_flags, unpack_packed_player_input
 from crimson.replay.checkpoints import ReplayCheckpoint, build_checkpoint

--- a/tests/test_survival_weapon_handouts.py
+++ b/tests/test_survival_weapon_handouts.py
@@ -5,11 +5,11 @@ from grim.geom import Vec2
 from crimson.creatures.runtime import CreaturePool
 from crimson.gameplay import (
     GameplayState,
-    PlayerState,
     survival_enforce_reward_weapon_guard,
     survival_update_weapon_handouts,
-    weapon_assign_player,
 )
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import weapon_assign_player
 from crimson.weapons import WeaponId
 
 

--- a/tests/test_telekinetic_perk.py
+++ b/tests/test_telekinetic_perk.py
@@ -8,7 +8,8 @@ from crimson.bonuses import BonusId
 from crimson.bonuses.pool import BonusPool
 from crimson.bonuses.update import bonus_telekinetic_update
 from crimson.creatures.runtime import CreaturePool
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_tough_reloader_perk.py
+++ b/tests/test_tough_reloader_perk.py
@@ -4,7 +4,8 @@ from grim.geom import Vec2
 
 import pytest
 
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.player_damage import player_take_damage
 

--- a/tests/test_toxic_avenger_perk.py
+++ b/tests/test_toxic_avenger_perk.py
@@ -6,7 +6,8 @@ import math
 
 from crimson.creatures.runtime import CREATURE_HITBOX_ALIVE, CreaturePool
 from crimson.creatures.spawn import CreatureFlags
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_typo_player.py
+++ b/tests/test_typo_player.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import PlayerState, weapon_assign_player
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import weapon_assign_player
 from crimson.typo.player import TYPO_WEAPON_ID, build_typo_player_input, enforce_typo_player_frame
 
 

--- a/tests/test_unstoppable_perk.py
+++ b/tests/test_unstoppable_perk.py
@@ -4,7 +4,12 @@ from grim.geom import Vec2
 
 import math
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_update
+from crimson.gameplay import (
+    GameplayState,
+    player_update,
+)
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 from crimson.player_damage import player_take_damage
 

--- a/tests/test_uranium_filled_bullets_perk.py
+++ b/tests/test_uranium_filled_bullets_perk.py
@@ -6,7 +6,7 @@ import pytest
 
 from crimson.creatures.damage import creature_apply_damage
 from crimson.creatures.runtime import CreatureState
-from crimson.gameplay import PlayerState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_veins_of_poison_perk.py
+++ b/tests/test_veins_of_poison_perk.py
@@ -4,7 +4,8 @@ from grim.geom import Vec2
 
 from crimson.creatures.runtime import CREATURE_HITBOX_ALIVE, CreaturePool
 from crimson.creatures.spawn import CreatureFlags
-from crimson.gameplay import GameplayState, PlayerState
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
 from crimson.perks import PerkId
 
 

--- a/tests/test_weapon_assign_side_effects.py
+++ b/tests/test_weapon_assign_side_effects.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import GameplayState, PlayerState, weapon_assign_player
+from crimson.gameplay import GameplayState
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import weapon_assign_player
 from crimson.weapons import WeaponId
 
 

--- a/tests/test_weapon_drops.py
+++ b/tests/test_weapon_drops.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 from crimson.game_modes import GameMode
-from crimson.gameplay import GameplayState, weapon_pick_random_available, weapon_refresh_available
+from crimson.gameplay import GameplayState
+from crimson.weapon_runtime import (
+    weapon_pick_random_available,
+    weapon_refresh_available,
+)
 from crimson.persistence import save_status
 from crimson.weapons import WeaponId
 

--- a/tests/test_weapon_fire_patterns.py
+++ b/tests/test_weapon_fire_patterns.py
@@ -4,7 +4,13 @@ from grim.geom import Vec2
 
 import math
 
-from crimson.gameplay import GameplayState, PlayerInput, PlayerState, player_fire_weapon, weapon_assign_player
+from crimson.gameplay import GameplayState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import (
+    player_fire_weapon,
+    weapon_assign_player,
+)
 from crimson.projectiles import ProjectileTypeId
 
 

--- a/tests/test_weapon_usage.py
+++ b/tests/test_weapon_usage.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from grim.geom import Vec2
 
-from crimson.gameplay import (
-    GameplayState,
-    PlayerInput,
-    PlayerState,
+from crimson.gameplay import GameplayState
+from crimson.sim.input import PlayerInput
+from crimson.sim.state_types import PlayerState
+from crimson.weapon_runtime import (
     most_used_weapon_id_for_player,
     player_fire_weapon,
     weapon_assign_player,


### PR DESCRIPTION
## Summary
- remove gameplay-module facade exports for weapon runtime and sim state/input types
- keep `crimson.gameplay` focused on gameplay-owned behavior (`GameplayState`, progression helpers, `player_update`)
- migrate call sites to direct imports:
  - `PlayerInput` from `crimson.sim.input`
  - `PlayerState` from `crimson.sim.state_types`
  - weapon/runtime helpers from `crimson.weapon_runtime`
- update `crimson.gameplay` internals to use private aliases for weapon-runtime calls
- clean up all src/tests imports so no moved symbols are imported from `crimson.gameplay`

## Validation
- `uv run ruff check . --fix`
- `uv run pytest tests/test_player_update.py tests/test_weapon_drops.py tests/test_step_pipeline_parity.py tests/test_game_world_audio.py tests/test_replay_perk_menu_open_event.py tests/test_original_capture_verify.py`
- `just check`
- `just ast-grep-scan`
- `just ast-grep-test`
