### PR TITLE
ci: add ast-grep scan and test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,14 @@ jobs:
             do_sync: false
             command: uv run --no-sync python scripts/check_docs.py
             sync_args: ""
+          - task: ast-grep-scan
+            do_sync: false
+            command: sg scan
+            sync_args: ""
+          - task: ast-grep-test
+            do_sync: false
+            command: sg test
+            sync_args: ""
           - task: ty
             do_sync: true
             command: uv run --no-sync ty check src
@@ -52,6 +60,14 @@ jobs:
         with:
           python-version: "3.13"
           enable-cache: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install ast-grep
+        run: npm install --global @ast-grep/cli
 
       - name: Install dependencies
         if: matrix.do_sync

--- a/docs/contributor/setup.md
+++ b/docs/contributor/setup.md
@@ -21,5 +21,5 @@ just docs-build
 
 ## Useful commands
 
-- `just check` — lint, type-check, and tests
+- `just check` — lint, type-check, docs checks, ast-grep scan/tests, and pytest
 - `just docs-build` — build docs site

--- a/justfile
+++ b/justfile
@@ -24,6 +24,8 @@ check *args:
     uv run lint-imports
     uv run ty check src
     uv run scripts/check_docs.py
+    sg scan
+    sg test
     uv run pytest {{args}}
 
 ty:

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,8 @@ See [docs/contributor/project-tracking/provenance.md](docs/contributor/project-t
 uv run pytest              # test suite
 uv run ruff check .        # lint
 uv run ty check src        # type check
+sg scan                    # ast-grep code scan
+sg test                    # ast-grep rule tests
 just check                 # all of the above
 ```
 


### PR DESCRIPTION
## Summary
- add `sg scan` and `sg test` to `just check`
- add `ast-grep-scan` and `ast-grep-test` matrix tasks in CI
- install ast-grep CLI in CI via Node + `@ast-grep/cli`
- update contributor docs and README command list to reflect the new checks

## Testing
- `just check`
