### PR TITLE
feat(frontend): add March 3 stats easter egg text gate

### DIFF
--- a/src/crimson/frontend/panels/stats.py
+++ b/src/crimson/frontend/panels/stats.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import datetime as dt
+import random
+
 import pyray as rl
 
 from grim.audio import play_music, play_sfx, stop_music, update_audio
@@ -55,6 +58,21 @@ _BACK_BUTTON_Y = 290.0
 
 _PLAYTIME_X = 204.0
 _PLAYTIME_Y = 334.0
+
+_STATS_EASTER_ROLL_UNSET = -1
+_STATS_EASTER_TRIGGER_ROLL = 3
+_STATS_EASTER_TEXT = "Orbes Volantes Exstare"
+_STATS_EASTER_TEXT_Y = 5.0
+
+
+def _stats_menu_easter_roll(current_roll: int, *, rng: random.Random) -> int:
+    if int(current_roll) != _STATS_EASTER_ROLL_UNSET:
+        return int(current_roll)
+    return int(rng.randrange(32))
+
+
+def _is_orbes_volantes_day(today: dt.date) -> bool:
+    return int(today.month) == 3 and int(today.day) == 3
 
 
 class StatisticsMenuView:
@@ -192,6 +210,10 @@ class StatisticsMenuView:
             if not self._closing:
                 play_music(self.state.audio, "shortie_monk")
             update_audio(self.state.audio, dt)
+        self.state.stats_menu_easter_egg_roll = _stats_menu_easter_roll(
+            self.state.stats_menu_easter_egg_roll,
+            rng=self.state.rng,
+        )
         if self._ground is not None:
             self._ground.process_pending()
         self._cursor_pulse_time += min(float(dt), 0.1) * 1.1
@@ -338,6 +360,17 @@ class StatisticsMenuView:
             1.0 * scale,
             rl.Color(255, 255, 255, int(255 * 0.8)),
         )
+
+        if _is_orbes_volantes_day(dt.date.today()) and int(self.state.stats_menu_easter_egg_roll) == _STATS_EASTER_TRIGGER_ROLL:
+            self.state.stats_menu_easter_egg_roll = _STATS_EASTER_ROLL_UNSET
+            x = float(self.state.rng.randrange(64) + 16)
+            draw_small_text(
+                font,
+                _STATS_EASTER_TEXT,
+                Vec2(x, _STATS_EASTER_TEXT_Y),
+                1.0,
+                rl.Color(51, 255, 153, 128),
+            )
 
         # Buttons.
         textures = self._button_textures

--- a/src/crimson/frontend/types.py
+++ b/src/crimson/frontend/types.py
@@ -33,6 +33,8 @@ class GameState(Protocol):
     skip_intro: bool
     menu_sign_locked: bool
 
+    stats_menu_easter_egg_roll: int
+
     quit_requested: bool
     screen_fade_alpha: float
     screen_fade_ramp: bool

--- a/src/crimson/game/types.py
+++ b/src/crimson/game/types.py
@@ -77,6 +77,7 @@ class GameState:
     menu_ground: GroundRenderer | None = None
     menu_ground_camera: Vec2 | None = None
     menu_sign_locked: bool = False
+    stats_menu_easter_egg_roll: int = -1
     pause_background: PauseBackground | None = None
     pending_quest_level: str | None = None
     pending_high_scores: HighScoresRequest | None = None

--- a/tests/test_stats_easter_egg.py
+++ b/tests/test_stats_easter_egg.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import datetime as dt
+import random
+
+from crimson.frontend.panels.stats import (
+    _is_orbes_volantes_day,
+    _stats_menu_easter_roll,
+)
+
+
+def test_stats_menu_easter_roll_keeps_existing_value() -> None:
+    rng = random.Random(123)
+    assert _stats_menu_easter_roll(7, rng=rng) == 7
+
+
+def test_stats_menu_easter_roll_generates_0_to_31_when_unset() -> None:
+    rng = random.Random(123)
+    roll = _stats_menu_easter_roll(-1, rng=rng)
+    assert 0 <= roll < 32
+
+
+def test_is_orbes_volantes_day_requires_march_third() -> None:
+    assert _is_orbes_volantes_day(dt.date(2026, 3, 3)) is True
+    assert _is_orbes_volantes_day(dt.date(2026, 3, 2)) is False
+    assert _is_orbes_volantes_day(dt.date(2026, 4, 3)) is False


### PR DESCRIPTION
## Summary
- port the decompiled Statistics-menu March-3 easter egg gate (`stats_menu_easter_egg_roll`)
- persist the one-shot/random roll in game state (`-1` sentinel, roll `0..31`)
- render `Orbes Volantes Exstare` at y=5 with randomized x when date is March 3 and roll is 3
- reset roll back to `-1` after draw so the gate can re-roll like native flow
- add focused unit tests for roll/day helper behavior

## Decompile parity anchor
- `analysis/ghidra/raw/crimsonland.exe_decompiled.c:7751-7771`

## Validation
- `uv run pytest tests/test_stats_easter_egg.py`
- `just check`
