### PR TITLE
feat(frontend): load balloon texture on easter-egg dates

### DIFF
--- a/src/crimson/frontend/boot.py
+++ b/src/crimson/frontend/boot.py
@@ -192,6 +192,8 @@ class BootView:
         self._menu_prepped = True
 
     def _load_balloon_easter_egg_texture(self) -> None:
+        # Native 1.9.93 date-gates a one-shot balloon texture preload in startup prelude.
+        # No executable draw path references the "balloon" texture name in this build.
         if not _is_balloon_easter_egg_day(dt.date.today()):
             return
         cache = self.state.texture_cache
@@ -233,8 +235,8 @@ class BootView:
                         total = len(self.state.texture_cache.textures)
                         self.state.console.log.log(f"boot textures loaded: {loaded}/{total}")
                         self.state.console.log.flush()
-                    self._load_balloon_easter_egg_texture()
                     self._load_company_logos()
+                    self._load_balloon_easter_egg_texture()
                     self._prepare_menu_assets()
                     self._fade_out_ready = True
                     self._loading_hold_remaining = _debug_loading_hold_seconds()

--- a/tests/test_boot_easter_eggs.py
+++ b/tests/test_boot_easter_eggs.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import datetime as dt
+from types import SimpleNamespace
 
-from crimson.frontend.boot import _is_balloon_easter_egg_day
+from crimson.frontend.boot import TEXTURE_LOAD_STAGES, BootView, _is_balloon_easter_egg_day
 
 
 def test_balloon_easter_egg_day_matches_three_known_dates() -> None:
@@ -14,3 +15,19 @@ def test_balloon_easter_egg_day_matches_three_known_dates() -> None:
 def test_balloon_easter_egg_day_rejects_other_dates() -> None:
     assert _is_balloon_easter_egg_day(dt.date(2026, 3, 3)) is False
     assert _is_balloon_easter_egg_day(dt.date(2026, 9, 11)) is False
+
+
+def test_boot_stage_completion_loads_company_logos_before_balloon(monkeypatch) -> None:
+    state = SimpleNamespace(audio=None, texture_cache=None)
+    view = BootView(state)
+    calls: list[str] = []
+
+    monkeypatch.setattr(view, "_load_texture_stage", lambda stage: calls.append(f"stage:{stage}"))
+    monkeypatch.setattr(view, "_load_company_logos", lambda: calls.append("company"))
+    monkeypatch.setattr(view, "_load_balloon_easter_egg_texture", lambda: calls.append("balloon"))
+    monkeypatch.setattr(view, "_prepare_menu_assets", lambda: calls.append("menu"))
+
+    view._texture_stage = len(TEXTURE_LOAD_STAGES) - 1
+    view.update(1.0 / 60.0)
+
+    assert calls == [f"stage:{len(TEXTURE_LOAD_STAGES) - 1}", "company", "balloon", "menu"]


### PR DESCRIPTION
## Summary
- port the startup date gate from `game_startup_init_prelude` for the hidden `balloon` texture path
- add `_is_balloon_easter_egg_day` with the three native dates:
  - Sep 12
  - Nov 8
  - Dec 18
- keep the native startup finalization order by loading company logos before the balloon preload
- add a boot-stage completion test that asserts `company -> balloon -> menu` ordering
- annotate the preload helper with the decompile finding that this build has no executable draw-path reference to `"balloon"`

## Decompile parity anchors
- `analysis/ghidra/raw/crimsonland.exe_decompiled.c:23806`
- `analysis/ghidra/raw/crimsonland.exe_decompiled.c:23816`
- `analysis/binary_ninja/raw/crimsonland.exe.bndb_hlil.txt` (`game_startup_init_prelude`)

## Validation
- `uv run pytest tests/test_boot_easter_eggs.py`
- `just check`
