### PR TITLE
fix: stationary reloader empty reload loop

### DIFF
--- a/tests/test_player_update.py
+++ b/tests/test_player_update.py
@@ -161,8 +161,35 @@ def test_player_update_empty_reload_fire_tick_keeps_underflow_and_restarts_reloa
     assert math.isclose(player.reload_timer, player.reload_timer_max, abs_tol=1e-9)
 
 
-def test_player_update_does_not_top_up_when_reload_finishes_same_tick() -> None:
+def test_player_update_tops_up_when_stationary_reload_finishes_same_tick() -> None:
     state = GameplayState()
+    player = PlayerState(
+        index=0,
+        pos=Vec2(50.0, 50.0),
+        weapon_id=int(WeaponId.ION_CANNON),
+        clip_size=6,
+        ammo=0.0,
+        reload_active=True,
+        reload_timer=0.06,
+        reload_timer_max=3.0,
+        shot_cooldown=0.5,
+    )
+    player.perk_counts[int(PerkId.STATIONARY_RELOADER)] = 1
+
+    player_update(
+        player,
+        PlayerInput(aim=Vec2(51.0, 50.0), fire_down=True),
+        0.03100000135600567,
+        state,
+    )
+
+    assert math.isclose(player.reload_timer, 0.0, abs_tol=1e-9)
+    assert math.isclose(player.ammo, 6.0, abs_tol=1e-9)
+    assert player.reload_active is True
+
+
+def test_player_update_preserve_bugs_keeps_empty_reload_loop() -> None:
+    state = GameplayState(preserve_bugs=True)
     player = PlayerState(
         index=0,
         pos=Vec2(50.0, 50.0),


### PR DESCRIPTION
## Summary
Fixes an original `crimsonland.exe` quirk where **Stationary Reloader** can complete a reload without ever refilling ammo, producing a “one shot + forced reload” loop.

## Evidence (Decompile)
In the decompile, `player_update`:
- preloads ammo on `reload_timer - frame_dt < 0` (unscaled `frame_dt`), then
- applies Stationary Reloader by decrementing `reload_timer -= reload_scale * frame_dt` (with `reload_scale = 3` when stationary).

So when `reload_timer` is in `(frame_dt, 3*frame_dt)`, the reload underflows in one tick but the preload check never triggers.

## Change
- Default: use the scaled decrement (`reload_scale * frame_dt`) for the preload-underflow check.
- `--preserve-bugs`: keep the native unscaled preload check (and the empty-reload loop).

## Tests
- `just check`
