### PR TITLE
refactor: simplify startup asset loading

### DIFF
--- a/asset_loading_memo.md
+++ b/asset_loading_memo.md
@@ -1,0 +1,163 @@
+# Asset Loading Memo
+
+## Goal
+
+Simplify asset ownership without changing visible behavior or RNG behavior.
+
+The hard constraint is strict parity. Asset loading must not introduce new randomness, and it must not move any gameplay RNG consumption. Startup work is acceptable because the shipped archives are small enough to load eagerly on modern hardware.
+
+## Studied Paq Surface
+
+The actual `.paq` files are not checked into this workspace, so this shape is inferred from the code paths and load maps the runtime uses.
+
+- `crimson.paq`: mostly `ui/`, plus smaller `load/`, `game/`, and `ter/` groups
+- `music.paq`: 6 named tracks
+- `sfx.paq`: 72 native-load-order samples plus 3 extra present-but-unreferenced samples
+
+Referenced `crimson.paq` paths cluster roughly like this:
+
+- `ui/`: 39
+- `load/`: 13
+- `game/`: 11
+- `ter/`: 8
+
+That shape matters. Most of the runtime is borrowing from a small, stable asset surface, not browsing a large dynamic content tree.
+
+## Problems In The Old Design
+
+- `crimson.paq` was read once for boot, then re-read by `TextureLoader.from_assets_root()`, `load_small_font()`, and `load_grim_mono_font()`.
+- `BootView` only preloaded a staged subset of textures. The rest of the UI still loaded textures on demand.
+- music was eager, but SFX was still first-use decoded.
+- screens and debug views owned font textures ad hoc and manually called `rl.unload_texture(...)`.
+- ownership was implicit. The same run mixed shared cache textures, per-view loaders, per-view fonts, and lazy SFX samples.
+
+The result was more code, more lifetime ambiguity, and more “first use” behavior than the game actually needs.
+
+## Previous Architecture
+
+```mermaid
+flowchart TD
+    Start["Startup"] --> Boot["BootView"]
+    Start --> Audio["init_audio_state()"]
+
+    Boot --> ResourceEntries["load crimson.paq entries"]
+    ResourceEntries --> TextureCache["state.texture_cache<br/>lazy decode cache"]
+    Boot --> BootStages["stage-load selected textures"]
+    Boot --> FontsPerView["views call load_small_font()<br/>and load_grim_mono_font() later"]
+
+    Audio --> Music["load all music tracks"]
+    Audio --> SfxIndex["index sfx only"]
+    SfxIndex --> FirstUse["first play_sfx() decodes sample"]
+
+    Screens["screens / modes / debug views"] --> TextureCache
+    Screens --> OneOffLoader["TextureLoader.from_assets_root()<br/>fresh archive read"]
+    Screens --> FontsPerView
+```
+
+## Implemented Design
+
+This branch moves startup loading to a single shared ownership model while keeping the boot sequence visuals unchanged.
+
+### 1. Startup-owned resource Paq cache
+
+`BootView.open()` now:
+
+- loads `crimson.paq` once
+- eagerly decodes all texture-bearing entries once
+- builds one shared `PaqTextureCache`
+- stores shared logo assets from that cache
+
+The staged boot logic still runs, but it now walks a warm cache instead of performing real decode work frame by frame. That preserves the current presentation while removing runtime texture churn.
+
+### 2. Shared startup-owned UI fonts
+
+`smallWhite` and `default_font_courier` are now borrowed from the same preloaded resource Paq cache.
+
+The code now has explicit helpers for:
+
+- preloading shared small and grim-mono fonts at startup
+- borrowing those shared font handles later
+- releasing per-view fallback fonts without unloading shared startup textures
+
+That removes the old “every screen owns the font texture” rule.
+
+### 3. Eager SFX decode at audio init
+
+`init_audio_state()` now:
+
+- indexes SFX
+- eagerly decodes all samples at startup
+- preserves native `SFX_LOAD_ORDER` first
+- then loads the 3 known extra entries
+- then loads any remaining keys
+
+Playback behavior is otherwise unchanged. Variant choice, per-play pitch scaling, and all RNG consumption still happen at play time, not at startup.
+
+### 4. Shutdown is explicit
+
+App shutdown now:
+
+- closes views and console first
+- clears shared font registries
+- unloads the shared preloaded resource Paq textures once
+
+That gives the branch one clear owner for startup-loaded textures.
+
+## Current Architecture On This Branch
+
+```mermaid
+flowchart TD
+    Start["Startup"] --> Boot["BootView.open()"]
+    Start --> Audio["init_audio_state()"]
+
+    Boot --> ResourcePaq["preload_paq_resources()<br/>read crimson.paq once"]
+    ResourcePaq --> SharedTextures["shared PaqTextureCache<br/>all decoded textures"]
+    SharedTextures --> SharedFonts["preload_small_font()<br/>preload_grim_mono_font()"]
+    SharedTextures --> Logos["shared logo assets"]
+    Boot --> BootStages["existing staged boot sequence<br/>hits warm cache only"]
+
+    Audio --> SfxIndex["load_sfx_index()"]
+    SfxIndex --> SfxPreload["preload_sfx_samples()<br/>native order first"]
+    Audio --> Music["load_music_tracks()"]
+
+    SharedTextures --> Screens["screens / modes / debug views borrow shared textures"]
+    SharedFonts --> Screens
+    SfxPreload --> Screens
+    Music --> Screens
+
+    Shutdown["GameLoopView.close()"] --> ClearFonts["clear shared font registries"]
+    ClearFonts --> UnloadTextures["unload_preloaded_paq_resources()"]
+```
+
+## Parity Notes
+
+- No gameplay RNG calls were moved into startup loading.
+- Boot visuals were intentionally left alone. The old staged sequence still advances the same way; the cache is simply hot underneath it.
+- SFX eager loading preserves native order first so startup sample creation is deterministic and easy to reason about.
+- music was already startup-loaded, so this branch does not change its policy.
+
+## What Is Still Worth Cleaning Up
+
+The ownership model is much better, but the API surface is still more path-oriented than it should be.
+
+Remaining worthwhile cleanup:
+
+- replace remaining raw `\"ui/...\"` and `\"game/...\"` lookups with typed bundles
+- make `TextureLoader.from_assets_root()` a thin compatibility layer over the shared startup cache, then gradually remove it from UI code
+- collapse screen-local asset bundle builders into a few app-owned classic UI bundles
+- eventually remove the old distinction between “boot preload” and “normal runtime texture access”, because they are now the same resource set
+
+## Recommended Direction
+
+Keep the current ownership model and continue simplifying on top of it.
+
+The right next step is not another loader. It is fewer call sites that know archive paths at all.
+
+That means:
+
+1. keep one startup-owned Paq-backed texture cache
+2. keep shared startup-owned fonts
+3. keep eager SFX and eager music
+4. move UI code toward typed shared bundles instead of path strings
+
+That gets the codebase smaller without risking parity.

--- a/src/crimson/debug_views/arsenal_debug.py
+++ b/src/crimson/debug_views/arsenal_debug.py
@@ -5,7 +5,7 @@ import random
 
 from grim.audio import AudioState, shutdown_audio, update_audio
 from grim.console import ConsoleState
-from grim.fonts.small import SmallFontData, load_small_font
+from grim.fonts.small import SmallFontData, load_small_font, unload_small_font
 from grim.geom import Vec2
 from grim.raylib_api import rl
 from grim.view import View, ViewContext
@@ -352,7 +352,7 @@ class ArsenalDebugView:
         rl.show_cursor()
         self._reset_tick_runner()
         if self._small is not None:
-            rl.unload_texture(self._small.texture)
+            unload_small_font(self._small)
             self._small = None
         if self._audio is not None:
             shutdown_audio(self._audio)

--- a/src/crimson/debug_views/fonts.py
+++ b/src/crimson/debug_views/fonts.py
@@ -5,12 +5,14 @@ from grim.fonts.grim_mono import (
     draw_grim_mono_text,
     load_grim_mono_font,
     measure_grim_mono_text_height,
+    unload_grim_mono_font,
 )
 from grim.fonts.small import (
     SmallFontData,
     draw_small_text,
     load_small_font,
     measure_small_text_height,
+    unload_small_font,
 )
 from grim.geom import Vec2
 from grim.raylib_api import rl
@@ -46,9 +48,11 @@ class FontView:
 
     def close(self) -> None:
         if self._small is not None:
-            rl.unload_texture(self._small.texture)
+            unload_small_font(self._small)
+            self._small = None
         if self._grim_mono is not None:
-            rl.unload_texture(self._grim_mono.texture)
+            unload_grim_mono_font(self._grim_mono)
+            self._grim_mono = None
 
     def open(self) -> None:
         self._missing_assets.clear()

--- a/src/crimson/debug_views/lighting_debug.py
+++ b/src/crimson/debug_views/lighting_debug.py
@@ -10,7 +10,7 @@ import msgspec
 
 from grim.audio import AudioState, shutdown_audio, update_audio
 from grim.console import ConsoleState
-from grim.fonts.small import SmallFontData, load_small_font
+from grim.fonts.small import SmallFontData, load_small_font, unload_small_font
 from grim.geom import Vec2
 from grim.raylib_api import rl
 from grim.view import View, ViewContext
@@ -2385,7 +2385,7 @@ class LightingDebugView:
         self._release_shadow_resources()
 
         if self._small is not None:
-            rl.unload_texture(self._small.texture)
+            unload_small_font(self._small)
             self._small = None
         if self._audio is not None:
             shutdown_audio(self._audio)

--- a/src/crimson/debug_views/perk_menu_debug.py
+++ b/src/crimson/debug_views/perk_menu_debug.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from grim.fonts.small import SmallFontData, load_small_font, measure_small_text_width
+from grim.fonts.small import SmallFontData, load_small_font, measure_small_text_width, unload_small_font
 from grim.geom import Rect, Vec2
 from grim.math import clamp
 from grim.raylib_api import rl
@@ -85,7 +85,7 @@ class PerkMenuDebugView:
         if self._assets is not None:
             self._assets = None
         if self._small is not None:
-            rl.unload_texture(self._small.texture)
+            unload_small_font(self._small)
             self._small = None
 
     def _choices(self) -> list[PerkId]:

--- a/src/crimson/debug_views/small_font_debug.py
+++ b/src/crimson/debug_views/small_font_debug.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from grim.fonts.small import SmallFontData, load_small_font
+from grim.fonts.small import SmallFontData, load_small_font, unload_small_font
 from grim.geom import Vec2
 from grim.raylib_api import rl
 from grim.view import View, ViewContext
@@ -80,7 +80,7 @@ class SmallFontDebugView:
 
     def close(self) -> None:
         if self._small is not None:
-            rl.unload_texture(self._small.texture)
+            unload_small_font(self._small)
             self._small = None
         if self._vector_font is not None:
             rl.unload_font(self._vector_font)

--- a/src/crimson/debug_views/spawn_plan.py
+++ b/src/crimson/debug_views/spawn_plan.py
@@ -4,7 +4,7 @@ import math
 
 import msgspec
 
-from grim.fonts.small import SmallFontData, load_small_font, measure_small_text_width
+from grim.fonts.small import SmallFontData, load_small_font, measure_small_text_width, unload_small_font
 from grim.geom import Vec2
 from grim.rand import Crand
 from grim.raylib_api import rl
@@ -89,7 +89,7 @@ class SpawnPlanView:
 
     def close(self) -> None:
         if self._small is not None:
-            rl.unload_texture(self._small.texture)
+            unload_small_font(self._small)
             self._small = None
 
     def _draw_ui_label(self, label: str, value: str, pos: Vec2) -> None:

--- a/src/crimson/demo.py
+++ b/src/crimson/demo.py
@@ -5,8 +5,14 @@ import webbrowser
 
 from grim.assets import PaqTextureCache, load_paq_entries
 from grim.audio import update_audio
-from grim.fonts.grim_mono import GrimMonoFont, draw_grim_mono_text, load_grim_mono_font
-from grim.fonts.small import SmallFontData, draw_small_text, load_small_font, measure_small_text_width
+from grim.fonts.grim_mono import GrimMonoFont, draw_grim_mono_text, load_grim_mono_font, unload_grim_mono_font
+from grim.fonts.small import (
+    SmallFontData,
+    draw_small_text,
+    load_small_font,
+    measure_small_text_width,
+    unload_small_font,
+)
 from grim.geom import Vec2
 from grim.math import clamp
 from grim.rand import Crand
@@ -160,10 +166,10 @@ class DemoView:
         self._runtime.reset_tick_runner()
         self._close_world_runtime()
         if self._upsell_font is not None:
-            rl.unload_texture(self._upsell_font.texture)
+            unload_grim_mono_font(self._upsell_font)
             self._upsell_font = None
         if self._small_font is not None:
-            rl.unload_texture(self._small_font.texture)
+            unload_small_font(self._small_font)
             self._small_font = None
 
     def is_finished(self) -> bool:

--- a/src/crimson/game/loop_view.py
+++ b/src/crimson/game/loop_view.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import webbrowser
 
 from crimson.quests.level import QuestLevel
+from grim.assets import unload_preloaded_paq_resources
 from grim.audio import stop_music
 from grim.geom import Vec2
 from grim.raylib_api import rl
@@ -1098,4 +1099,7 @@ class GameLoopView:
             self.state.menu_ground.render_target = None
         self._boot.close()
         self.state.console.close()
+        unload_preloaded_paq_resources(self.state.assets_dir)
+        self.state.texture_cache = None
+        self.state.logos = None
         rl.show_cursor()

--- a/src/crimson/game/loop_view.py
+++ b/src/crimson/game/loop_view.py
@@ -5,6 +5,8 @@ import webbrowser
 from crimson.quests.level import QuestLevel
 from grim.assets import unload_preloaded_paq_resources
 from grim.audio import stop_music
+from grim.fonts.grim_mono import clear_preloaded_grim_mono_font
+from grim.fonts.small import clear_preloaded_small_font
 from grim.geom import Vec2
 from grim.raylib_api import rl
 from grim.terrain_render import GroundRenderer
@@ -1099,6 +1101,8 @@ class GameLoopView:
             self.state.menu_ground.render_target = None
         self._boot.close()
         self.state.console.close()
+        clear_preloaded_small_font(self.state.assets_dir)
+        clear_preloaded_grim_mono_font(self.state.assets_dir)
         unload_preloaded_paq_resources(self.state.assets_dir)
         self.state.texture_cache = None
         self.state.logos = None

--- a/src/crimson/modes/base_gameplay_mode.py
+++ b/src/crimson/modes/base_gameplay_mode.py
@@ -14,7 +14,13 @@ from grim.assets import PaqTextureCache
 from grim.audio import AudioState, stop_music, update_audio
 from grim.config import CrimsonConfig, default_crimson_cfg_data
 from grim.console import ConsoleState
-from grim.fonts.small import SmallFontData, draw_small_text, load_small_font, measure_small_text_width
+from grim.fonts.small import (
+    SmallFontData,
+    draw_small_text,
+    load_small_font,
+    measure_small_text_width,
+    unload_small_font,
+)
 from grim.geom import Vec2
 from grim.raylib_api import rl
 from grim.terrain_render import GroundRenderer
@@ -1289,7 +1295,7 @@ class BaseGameplayMode:
     def close(self) -> None:
         self._game_over_ui.close()
         if self._small is not None:
-            rl.unload_texture(self._small.texture)
+            unload_small_font(self._small)
             self._small = None
         self._hud_assets = None
         self._reset_tick_runner_state()

--- a/src/crimson/modes/quest_mode.py
+++ b/src/crimson/modes/quest_mode.py
@@ -12,7 +12,7 @@ from grim.config import (
     CrimsonConfig,
 )
 from grim.console import ConsoleState
-from grim.fonts.grim_mono import GrimMonoFont, load_grim_mono_font
+from grim.fonts.grim_mono import GrimMonoFont, load_grim_mono_font, unload_grim_mono_font
 from grim.geom import Vec2
 from grim.math import clamp
 from grim.raylib_api import rl
@@ -175,7 +175,7 @@ class QuestMode(BaseGameplayMode):
 
     def close(self) -> None:
         if self._grim_mono is not None:
-            rl.unload_texture(self._grim_mono.texture)
+            unload_grim_mono_font(self._grim_mono)
             self._grim_mono = None
         self._quest_complete_texture = None
         self._perk_menu_assets = None

--- a/src/crimson/modes/replay_playback_mode.py
+++ b/src/crimson/modes/replay_playback_mode.py
@@ -8,8 +8,14 @@ from grim.assets import PaqTextureCache, TextureLoader
 from grim.audio import AudioState, init_audio_state, play_music, shutdown_audio, update_audio
 from grim.config import CrimsonConfig
 from grim.console import ConsoleState
-from grim.fonts.grim_mono import GrimMonoFont, load_grim_mono_font
-from grim.fonts.small import SmallFontData, draw_small_text, load_small_font, measure_small_text_width
+from grim.fonts.grim_mono import GrimMonoFont, load_grim_mono_font, unload_grim_mono_font
+from grim.fonts.small import (
+    SmallFontData,
+    draw_small_text,
+    load_small_font,
+    measure_small_text_width,
+    unload_small_font,
+)
 from grim.geom import Vec2
 from grim.raylib_api import rl
 from grim.view import ViewContext
@@ -310,7 +316,7 @@ class ReplayPlaybackMode:
         self._hud_assets = load_hud_assets(self._ctx.assets_dir)
         self._hud_state = HudState()
         if self._grim_mono is not None:
-            rl.unload_texture(self._grim_mono.texture)
+            unload_grim_mono_font(self._grim_mono)
         self._grim_mono = None
         self._quest_complete_texture = None
         self._quest_title = ""
@@ -457,10 +463,10 @@ class ReplayPlaybackMode:
 
     def close(self) -> None:
         if self._small is not None:
-            rl.unload_texture(self._small.texture)
+            unload_small_font(self._small)
             self._small = None
         if self._grim_mono is not None:
-            rl.unload_texture(self._grim_mono.texture)
+            unload_grim_mono_font(self._grim_mono)
             self._grim_mono = None
         self._quest_complete_texture = None
         self._hud_assets = None

--- a/src/crimson/screens/assets.py
+++ b/src/crimson/screens/assets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import msgspec
 
-from grim.assets import PaqTextureCache, TextureLoader, load_paq_entries_from_path
+from grim.assets import PaqTextureCache, TextureLoader, load_paq_entries_from_path, preloaded_paq_resources
 from grim.raylib_api import rl
 
 from ..game.types import GameState
@@ -16,14 +16,21 @@ class MenuAssets(msgspec.Struct):
 
 
 def _load_resource_entries(state: GameState) -> dict[str, bytes]:
+    shared = preloaded_paq_resources(state.assets_dir)
+    if shared is not None:
+        return shared.resource_paq.entries
     return load_paq_entries_from_path(state.resource_paq)
 
 
 def _ensure_texture_cache(state: GameState) -> PaqTextureCache:
     cache = state.texture_cache
     if cache is None:
-        entries = _load_resource_entries(state)
-        cache = PaqTextureCache(entries=entries, textures={})
+        shared = preloaded_paq_resources(state.assets_dir)
+        if shared is not None:
+            cache = shared.resource_paq.texture_cache
+        else:
+            entries = _load_resource_entries(state)
+            cache = PaqTextureCache(entries=entries, textures={})
         state.texture_cache = cache
     return cache
 

--- a/src/crimson/screens/assets.py
+++ b/src/crimson/screens/assets.py
@@ -6,6 +6,7 @@ from grim.assets import PaqTextureCache, TextureLoader, load_paq_entries_from_pa
 from grim.raylib_api import rl
 
 from ..game.types import GameState
+from ..ui.perk_menu import UiButtonTextureSet
 
 
 class MenuAssets(msgspec.Struct):
@@ -13,6 +14,19 @@ class MenuAssets(msgspec.Struct):
     item: rl.Texture
     panel: rl.Texture
     labels: rl.Texture
+
+
+class ClassicUiAssets(msgspec.Struct):
+    button_sm: rl.Texture | None
+    button_md: rl.Texture | None
+    button_textures: UiButtonTextureSet
+    check_on: rl.Texture | None
+    check_off: rl.Texture | None
+    rect_on: rl.Texture | None
+    rect_off: rl.Texture | None
+    drop_on: rl.Texture | None
+    drop_off: rl.Texture | None
+    arrow: rl.Texture | None
 
 
 def _load_resource_entries(state: GameState) -> dict[str, bytes]:
@@ -61,4 +75,23 @@ def load_menu_assets(state: GameState) -> MenuAssets:
             loader.get(name="ui_itemTexts", paq_rel="ui/ui_itemTexts.jaz"),
             rel_path="ui/ui_itemTexts.jaz",
         ),
+    )
+
+
+def load_classic_ui_assets(state: GameState, *, cache: PaqTextureCache | None = None) -> ClassicUiAssets:
+    if cache is None:
+        cache = _ensure_texture_cache(state)
+    button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
+    button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
+    return ClassicUiAssets(
+        button_sm=button_sm,
+        button_md=button_md,
+        button_textures=UiButtonTextureSet(button_sm=button_sm, button_md=button_md),
+        check_on=cache.get_or_load("ui_checkOn", "ui/ui_checkOn.jaz").texture,
+        check_off=cache.get_or_load("ui_checkOff", "ui/ui_checkOff.jaz").texture,
+        rect_on=cache.get_or_load("ui_rectOn", "ui/ui_rectOn.jaz").texture,
+        rect_off=cache.get_or_load("ui_rectOff", "ui/ui_rectOff.jaz").texture,
+        drop_on=cache.get_or_load("ui_dropOn", "ui/ui_dropDownOn.jaz").texture,
+        drop_off=cache.get_or_load("ui_dropOff", "ui/ui_dropDownOff.jaz").texture,
+        arrow=cache.get_or_load("ui_arrow", "ui/ui_arrow.jaz").texture,
     )

--- a/src/crimson/screens/boot.py
+++ b/src/crimson/screens/boot.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import datetime as dt
 import os
 
-from grim.assets import LogoAssets, PaqTextureCache, load_logo_assets
+from grim.assets import LogoAssets, preload_paq_resources
 from grim.audio import init_audio_state, play_music, shutdown_audio, stop_music, update_audio
 from grim.raylib_api import rl
 
 from ..game.types import GameState
-from .assets import _load_resource_entries
 
 TEXTURE_LOAD_STAGES: dict[int, tuple[tuple[str, str], ...]] = {
     0: (
@@ -209,12 +208,12 @@ class BootView:
 
     def open(self) -> None:
         if self.state.logos is None:
-            entries = _load_resource_entries(self.state)
-            logos = load_logo_assets(self.state.assets_dir, entries=entries)
+            resources = preload_paq_resources(self.state.assets_dir, paq_path=self.state.resource_paq)
+            logos = resources.logos
             self.state.console.log.log(f"logo assets: {logos.loaded_count()}/{len(logos.all())} loaded")
             self.state.console.log.flush()
             self.state.logos = logos
-            self.state.texture_cache = PaqTextureCache(entries=entries, textures={})
+            self.state.texture_cache = resources.resource_paq.texture_cache
         if self.state.audio is None:
             self.state.audio = init_audio_state(self.state.config, self.state.assets_dir, self.state.console)
             self.state.console.exec_line("exec music/game_tunes.txt")

--- a/src/crimson/screens/boot.py
+++ b/src/crimson/screens/boot.py
@@ -5,6 +5,8 @@ import os
 
 from grim.assets import LogoAssets, preload_paq_resources
 from grim.audio import init_audio_state, play_music, shutdown_audio, stop_music, update_audio
+from grim.fonts.grim_mono import preload_grim_mono_font
+from grim.fonts.small import preload_small_font
 from grim.raylib_api import rl
 
 from ..game.types import GameState
@@ -209,6 +211,8 @@ class BootView:
     def open(self) -> None:
         if self.state.logos is None:
             resources = preload_paq_resources(self.state.assets_dir, paq_path=self.state.resource_paq)
+            preload_small_font(self.state.assets_dir)
+            preload_grim_mono_font(self.state.assets_dir)
             logos = resources.logos
             self.state.console.log.log(f"logo assets: {logos.loaded_count()}/{len(logos.all())} loaded")
             self.state.console.log.flush()

--- a/src/crimson/screens/high_scores_view/view.py
+++ b/src/crimson/screens/high_scores_view/view.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from crimson.quests.level import QuestLevel
 from grim.audio import play_sfx, update_audio
-from grim.fonts.small import SmallFontData, load_small_font, measure_small_text_width
+from grim.fonts.small import SmallFontData, load_small_font, measure_small_text_width, unload_small_font
 from grim.geom import Rect, Vec2
 from grim.raylib_api import rl
 from grim.terrain_render import GroundRenderer
@@ -160,7 +160,7 @@ class HighScoresView:
     def close(self) -> None:
         self._is_open = False
         if self._small_font is not None:
-            rl.unload_texture(self._small_font.texture)
+            unload_small_font(self._small_font)
             self._small_font = None
         self._wicons_tex = None
         self._clock_table_tex = None

--- a/src/crimson/screens/high_scores_view/view.py
+++ b/src/crimson/screens/high_scores_view/view.py
@@ -13,7 +13,7 @@ from ...persistence.highscores import HighScoreRecord
 from ...ui.layout import DropdownLayoutBase
 from ...ui.menu_panel import draw_classic_menu_panel
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_update, button_width
-from ..assets import MenuAssets, _ensure_texture_cache, load_menu_assets
+from ..assets import MenuAssets, _ensure_texture_cache, load_classic_ui_assets, load_menu_assets
 from ..high_scores_layout import (
     HS_BACK_BUTTON_X,
     HS_BACK_BUTTON_Y,
@@ -138,14 +138,14 @@ class HighScoresView:
         self._score_list_open = False
 
         cache = _ensure_texture_cache(self.state)
-        self._button_tex = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=button_sm, button_md=self._button_tex)
-        self._check_on = cache.get_or_load("ui_checkOn", "ui/ui_checkOn.jaz").texture
-        self._check_off = cache.get_or_load("ui_checkOff", "ui/ui_checkOff.jaz").texture
-        self._drop_on = cache.get_or_load("ui_dropOn", "ui/ui_dropDownOn.jaz").texture
-        self._drop_off = cache.get_or_load("ui_dropOff", "ui/ui_dropDownOff.jaz").texture
-        self._arrow_tex = cache.get_or_load("ui_arrow", "ui/ui_arrow.jaz").texture
+        widgets = load_classic_ui_assets(self.state, cache=cache)
+        self._button_tex = widgets.button_md
+        self._button_textures = widgets.button_textures
+        self._check_on = widgets.check_on
+        self._check_off = widgets.check_off
+        self._drop_on = widgets.drop_on
+        self._drop_off = widgets.drop_off
+        self._arrow_tex = widgets.arrow
         self._wicons_tex = cache.get_or_load("ui_wicons", "ui/ui_wicons.jaz").texture
         self._clock_table_tex = cache.get_or_load("ui_clockTable", "ui/ui_clockTable.jaz").texture
         self._clock_pointer_tex = cache.get_or_load("ui_clockPointer", "ui/ui_clockPointer.jaz").texture

--- a/src/crimson/screens/panels/alien_zookeeper.py
+++ b/src/crimson/screens/panels/alien_zookeeper.py
@@ -18,7 +18,7 @@ from grim.terrain_render import GroundRenderer
 from ...game.types import GameState
 from ...ui.menu_panel import draw_classic_menu_panel
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
-from ..assets import MenuAssets, _ensure_texture_cache, load_menu_assets
+from ..assets import MenuAssets, _ensure_texture_cache, load_classic_ui_assets, load_menu_assets
 from ..menu import (
     MENU_PANEL_WIDTH,
     MENU_SCALE_SMALL_THRESHOLD,
@@ -162,9 +162,7 @@ class AlienZooKeeperView:
         self._small_font = None
 
         cache = _ensure_texture_cache(self.state)
-        button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=button_sm, button_md=button_md)
+        self._button_textures = load_classic_ui_assets(self.state, cache=cache).button_textures
         self._alien_texture = cache.get_or_load("alien", "game/alien.jaz").texture
 
         self._cursor_pulse_time = 0.0

--- a/src/crimson/screens/panels/alien_zookeeper.py
+++ b/src/crimson/screens/panels/alien_zookeeper.py
@@ -9,6 +9,7 @@ from grim.fonts.small import (
     SmallFontData,
     draw_small_text,
     load_small_font,
+    unload_small_font,
 )
 from grim.geom import Vec2
 from grim.raylib_api import rl
@@ -184,7 +185,7 @@ class AlienZooKeeperView:
     def close(self) -> None:
         self._is_open = False
         if self._small_font is not None:
-            rl.unload_texture(self._small_font.texture)
+            unload_small_font(self._small_font)
             self._small_font = None
         self._button_textures = None
         self._assets = None

--- a/src/crimson/screens/panels/controls.py
+++ b/src/crimson/screens/panels/controls.py
@@ -16,6 +16,7 @@ from ...input_codes import INPUT_CODE_UNBOUND, capture_first_pressed_input_code,
 from ...movement_controls import MovementControlType
 from ...ui.layout import DropdownLayoutBase
 from ...ui.menu_panel import draw_classic_menu_panel
+from ..assets import load_classic_ui_assets
 from ..menu import (
     MENU_PANEL_HEIGHT,
     MENU_PANEL_WIDTH,
@@ -138,12 +139,13 @@ class ControlsMenuView(PanelMenuView):
     def open(self) -> None:
         super().open()
         cache = self._ensure_cache()
+        widgets = load_classic_ui_assets(self.state, cache=cache)
         # UI elements used by the classic controls screen.
         self._text_controls = cache.get_or_load("ui_textControls", "ui/ui_textControls.jaz").texture
-        self._drop_on = cache.get_or_load("ui_dropOn", "ui/ui_dropDownOn.jaz").texture
-        self._drop_off = cache.get_or_load("ui_dropOff", "ui/ui_dropDownOff.jaz").texture
-        self._check_on = cache.get_or_load("ui_checkOn", "ui/ui_checkOn.jaz").texture
-        self._check_off = cache.get_or_load("ui_checkOff", "ui/ui_checkOff.jaz").texture
+        self._drop_on = widgets.drop_on
+        self._drop_off = widgets.drop_off
+        self._check_on = widgets.check_on
+        self._check_off = widgets.check_off
         self._config_player = max(1, min(4, int(self._config_player)))
         self._move_method_open = False
         self._aim_method_open = False

--- a/src/crimson/screens/panels/credits.py
+++ b/src/crimson/screens/panels/credits.py
@@ -8,6 +8,7 @@ from grim.fonts.small import (
     draw_small_text,
     load_small_font,
     measure_small_text_width,
+    unload_small_font,
 )
 from grim.geom import Vec2
 from grim.raylib_api import rl
@@ -287,7 +288,7 @@ class CreditsView:
     def close(self) -> None:
         self._is_open = False
         if self._small_font is not None:
-            rl.unload_texture(self._small_font.texture)
+            unload_small_font(self._small_font)
             self._small_font = None
         self._button_textures = None
         self._assets = None

--- a/src/crimson/screens/panels/credits.py
+++ b/src/crimson/screens/panels/credits.py
@@ -18,7 +18,7 @@ from ...debug import debug_enabled
 from ...game.types import GameState
 from ...ui.menu_panel import draw_classic_menu_panel
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
-from ..assets import MenuAssets, _ensure_texture_cache, load_menu_assets
+from ..assets import MenuAssets, _ensure_texture_cache, load_classic_ui_assets, load_menu_assets
 from ..menu import (
     MENU_PANEL_OFFSET_X,
     MENU_PANEL_OFFSET_Y,
@@ -275,9 +275,7 @@ class CreditsView:
         self._scroll_line_end_index = 0
 
         cache = _ensure_texture_cache(self.state)
-        button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=button_sm, button_md=button_md)
+        self._button_textures = load_classic_ui_assets(self.state, cache=cache).button_textures
         self._back_button = UiButtonState("Back", force_wide=False)
         self._secret_button = UiButtonState("Secret", force_wide=False)
 

--- a/src/crimson/screens/panels/databases_base.py
+++ b/src/crimson/screens/panels/databases_base.py
@@ -9,7 +9,7 @@ from grim.terrain_render import GroundRenderer
 from ...game.types import GameState
 from ...ui.menu_panel import draw_classic_menu_panel
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
-from ..assets import MenuAssets, _ensure_texture_cache, load_menu_assets
+from ..assets import MenuAssets, _ensure_texture_cache, load_classic_ui_assets, load_menu_assets
 from ..high_scores_layout import hs_left_panel_pos_x, hs_right_panel_pos_x
 from ..menu import (
     MENU_PANEL_OFFSET_X,
@@ -74,9 +74,7 @@ class _DatabaseBaseView:
         self._action = None
 
         cache = _ensure_texture_cache(self.state)
-        button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=button_sm, button_md=button_md)
+        self._button_textures = load_classic_ui_assets(self.state, cache=cache).button_textures
         self._back_button = UiButtonState("Back", force_wide=False)
 
         if self.state.audio is not None:

--- a/src/crimson/screens/panels/databases_base.py
+++ b/src/crimson/screens/panels/databases_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from grim.audio import play_sfx, update_audio
-from grim.fonts.small import SmallFontData, load_small_font
+from grim.fonts.small import SmallFontData, load_small_font, unload_small_font
 from grim.geom import Vec2
 from grim.raylib_api import rl
 from grim.terrain_render import GroundRenderer
@@ -86,7 +86,7 @@ class _DatabaseBaseView:
     def close(self) -> None:
         self._is_open = False
         if self._small_font is not None:
-            rl.unload_texture(self._small_font.texture)
+            unload_small_font(self._small_font)
             self._small_font = None
         self._button_textures = None
         self._assets = None

--- a/src/crimson/screens/panels/network_lobby.py
+++ b/src/crimson/screens/panels/network_lobby.py
@@ -15,6 +15,7 @@ from ...net.lockstep_runtime import LockstepRuntime
 from ...net.relay_protocol import RoomState
 from ...net.rollback_runtime import RollbackRuntime
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
+from ..assets import load_classic_ui_assets
 from ..menu import MENU_PANEL_OFFSET_Y, MENU_PANEL_WIDTH, MenuEntry, MenuView
 from .base import PANEL_TIMELINE_END_MS, PANEL_TIMELINE_START_MS, PanelMenuView
 
@@ -43,10 +44,7 @@ class NetworkLobbyPanelView(PanelMenuView):
 
     def open(self) -> None:
         super().open()
-        cache = self._ensure_cache()
-        button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=button_sm, button_md=button_md)
+        self._button_textures = load_classic_ui_assets(self.state).button_textures
         self._back_button = UiButtonState("Back", force_wide=False)
         self._error = ""
 

--- a/src/crimson/screens/panels/network_session.py
+++ b/src/crimson/screens/panels/network_session.py
@@ -20,6 +20,7 @@ from ...game.types import (
 from ...net.relay_protocol import ROOM_CODE_LENGTH
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
 from ...ui.text_input import poll_text_input
+from ..assets import load_classic_ui_assets
 from ..menu import MENU_PANEL_OFFSET_Y, MENU_PANEL_WIDTH, MenuEntry, MenuView
 from .base import PANEL_TIMELINE_END_MS, PANEL_TIMELINE_START_MS, PanelMenuView
 
@@ -62,10 +63,7 @@ class NetworkSessionPanelView(PanelMenuView):
     def open(self) -> None:
         super().open()
 
-        cache = self._ensure_cache()
-        button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=button_sm, button_md=button_md)
+        self._button_textures = load_classic_ui_assets(self.state).button_textures
         self._back_button = UiButtonState("Back", force_wide=False)
 
         pending = self.state.pending_network_session

--- a/src/crimson/screens/panels/options.py
+++ b/src/crimson/screens/panels/options.py
@@ -10,6 +10,7 @@ from grim.raylib_api import rl
 
 from ...game.types import GameState
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
+from ..assets import load_classic_ui_assets
 from ..menu import (
     MENU_LABEL_ROW_HEIGHT,
     MENU_LABEL_ROW_OPTIONS,
@@ -63,14 +64,13 @@ class OptionsMenuView(PanelMenuView):
 
     def open(self) -> None:
         super().open()
-        cache = self._ensure_cache()
-        self._rect_on = cache.get_or_load("ui_rectOn", "ui/ui_rectOn.jaz").texture
-        self._rect_off = cache.get_or_load("ui_rectOff", "ui/ui_rectOff.jaz").texture
-        self._check_on = cache.get_or_load("ui_checkOn", "ui/ui_checkOn.jaz").texture
-        self._check_off = cache.get_or_load("ui_checkOff", "ui/ui_checkOff.jaz").texture
-        self._button_tex = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=button_sm, button_md=self._button_tex)
+        widgets = load_classic_ui_assets(self.state)
+        self._rect_on = widgets.rect_on
+        self._rect_off = widgets.rect_off
+        self._check_on = widgets.check_on
+        self._check_off = widgets.check_off
+        self._button_tex = widgets.button_md
+        self._button_textures = widgets.button_textures
         self._controls_button = UiButtonState("Controls", force_wide=True)
         self._active_slider = None
         self._dirty = False

--- a/src/crimson/screens/panels/play_game.py
+++ b/src/crimson/screens/panels/play_game.py
@@ -11,6 +11,7 @@ from ...debug import debug_enabled
 from ...game.types import GameState
 from ...game_modes import GameMode
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
+from ..assets import load_classic_ui_assets
 from ..menu import (
     MENU_LABEL_ROW_HEIGHT,
     MENU_LABEL_ROW_PLAY_GAME,
@@ -82,12 +83,12 @@ class PlayGameMenuView(PanelMenuView):
 
     def open(self) -> None:
         super().open()
-        cache = self._ensure_cache()
-        self._button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        self._button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=self._button_sm, button_md=self._button_md)
-        self._drop_on = cache.get_or_load("ui_dropOn", "ui/ui_dropDownOn.jaz").texture
-        self._drop_off = cache.get_or_load("ui_dropOff", "ui/ui_dropDownOff.jaz").texture
+        widgets = load_classic_ui_assets(self.state)
+        self._button_sm = widgets.button_sm
+        self._button_md = widgets.button_md
+        self._button_textures = widgets.button_textures
+        self._drop_on = widgets.drop_on
+        self._drop_off = widgets.drop_off
         self._player_list_open = False
         self._dirty = False
         self._tooltip_ms.clear()

--- a/src/crimson/screens/panels/stats.py
+++ b/src/crimson/screens/panels/stats.py
@@ -12,7 +12,7 @@ from grim.terrain_render import GroundRenderer
 from ...game.types import GameState
 from ...ui.menu_panel import draw_classic_menu_panel
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
-from ..assets import MenuAssets, _ensure_texture_cache, load_menu_assets
+from ..assets import MenuAssets, _ensure_texture_cache, load_classic_ui_assets, load_menu_assets
 from ..menu import (
     MENU_LABEL_ROW_HEIGHT,
     MENU_LABEL_ROW_STATISTICS,
@@ -133,9 +133,7 @@ class StatisticsMenuView:
         self._pending_action = None
 
         cache = _ensure_texture_cache(self.state)
-        button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=button_sm, button_md=button_md)
+        self._button_textures = load_classic_ui_assets(self.state, cache=cache).button_textures
 
         self._btn_high_scores = UiButtonState("High scores", force_wide=True)
         self._btn_weapons = UiButtonState("Weapons", force_wide=True)

--- a/src/crimson/screens/panels/stats.py
+++ b/src/crimson/screens/panels/stats.py
@@ -4,7 +4,7 @@ import datetime as dt
 import random
 
 from grim.audio import play_music, play_sfx, stop_music, update_audio
-from grim.fonts.small import SmallFontData, draw_small_text, load_small_font
+from grim.fonts.small import SmallFontData, draw_small_text, load_small_font, unload_small_font
 from grim.geom import Vec2
 from grim.raylib_api import rl
 from grim.terrain_render import GroundRenderer
@@ -153,7 +153,7 @@ class StatisticsMenuView:
     def close(self) -> None:
         self._is_open = False
         if self._small_font is not None:
-            rl.unload_texture(self._small_font.texture)
+            unload_small_font(self._small_font)
             self._small_font = None
         self._button_textures = None
         self._assets = None

--- a/src/crimson/screens/quest_views/end_note.py
+++ b/src/crimson/screens/quest_views/end_note.py
@@ -10,7 +10,7 @@ from ...game.types import GameState
 from ...game_modes import GameMode
 from ...ui.menu_panel import draw_classic_menu_panel
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
-from ..assets import _ensure_texture_cache
+from ..assets import _ensure_texture_cache, load_classic_ui_assets
 from ..menu import MenuView, _draw_menu_cursor, ensure_menu_ground, menu_ground_camera
 from ..panels.base import PANEL_TIMELINE_END_MS, PANEL_TIMELINE_START_MS
 from ..transitions import _draw_screen_fade
@@ -70,9 +70,7 @@ class EndNoteView:
 
         cache = _ensure_texture_cache(self.state)
         self._panel_tex = cache.get_or_load("ui_menuPanel", "ui/ui_menuPanel.jaz").texture
-        button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=button_sm, button_md=button_md)
+        self._button_textures = load_classic_ui_assets(self.state, cache=cache).button_textures
         self._small_font = None
 
     def close(self) -> None:

--- a/src/crimson/screens/quest_views/quest_failed.py
+++ b/src/crimson/screens/quest_views/quest_failed.py
@@ -13,7 +13,7 @@ from ...game.types import GameState
 from ...game_modes import GameMode
 from ...ui.menu_panel import draw_classic_menu_panel
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
-from ..assets import _ensure_texture_cache
+from ..assets import _ensure_texture_cache, load_classic_ui_assets
 from ..menu import MenuView, _draw_menu_cursor, ensure_menu_ground, menu_ground_camera
 from ..transitions import _draw_screen_fade
 from .shared import (
@@ -93,9 +93,7 @@ class QuestFailedView:
         cache = _ensure_texture_cache(self.state)
         self._panel_tex = cache.get_or_load("ui_menuPanel", "ui/ui_menuPanel.jaz").texture
         self._reaper_tex = cache.get_or_load("ui_textReaper", "ui/ui_textReaper.jaz").texture
-        button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=button_sm, button_md=button_md)
+        self._button_textures = load_classic_ui_assets(self.state, cache=cache).button_textures
 
     def close(self) -> None:
         self._ground = None

--- a/src/crimson/screens/quest_views/quests_menu.py
+++ b/src/crimson/screens/quest_views/quests_menu.py
@@ -14,7 +14,7 @@ from ...game.types import GameState
 from ...game_modes import GameMode
 from ...ui.menu_panel import draw_classic_menu_panel
 from ...ui.perk_menu import UiButtonState, UiButtonTextureSet, button_draw, button_update, button_width
-from ..assets import MenuAssets, _ensure_texture_cache, load_menu_assets
+from ..assets import MenuAssets, _ensure_texture_cache, load_classic_ui_assets, load_menu_assets
 from ..menu import (
     MENU_PANEL_OFFSET_Y,
     MENU_PANEL_WIDTH,
@@ -112,6 +112,7 @@ class QuestsMenuView:
         # Sign and ground match the main menu/panels.
         self._assets = load_menu_assets(self.state)
         self._init_ground()
+        widgets = load_classic_ui_assets(self.state, cache=cache)
 
         self._text_quest = cache.get_or_load("ui_textQuest", "ui/ui_textQuest.jaz").texture
         self._stage_icons = {
@@ -121,11 +122,11 @@ class QuestsMenuView:
             4: cache.get_or_load("ui_num4", "ui/ui_num4.jaz").texture,
             5: cache.get_or_load("ui_num5", "ui/ui_num5.jaz").texture,
         }
-        self._check_on = cache.get_or_load("ui_checkOn", "ui/ui_checkOn.jaz").texture
-        self._check_off = cache.get_or_load("ui_checkOff", "ui/ui_checkOff.jaz").texture
-        self._button_sm = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz").texture
-        self._button_md = cache.get_or_load("ui_buttonMd", "ui/ui_button_128x32.jaz").texture
-        self._button_textures = UiButtonTextureSet(button_sm=self._button_sm, button_md=self._button_md)
+        self._check_on = widgets.check_on
+        self._check_off = widgets.check_off
+        self._button_sm = widgets.button_sm
+        self._button_md = widgets.button_md
+        self._button_textures = widgets.button_textures
 
         self._action = None
         self._dirty = False

--- a/src/crimson/screens/results/game_over.py
+++ b/src/crimson/screens/results/game_over.py
@@ -8,7 +8,13 @@ import msgspec
 
 from grim.assets import TextureLoader
 from grim.config import CrimsonConfig
-from grim.fonts.small import SmallFontData, draw_small_text, load_small_font, measure_small_text_width
+from grim.fonts.small import (
+    SmallFontData,
+    draw_small_text,
+    load_small_font,
+    measure_small_text_width,
+    unload_small_font,
+)
 from grim.geom import Rect, Vec2
 from grim.raylib_api import rl
 
@@ -194,7 +200,7 @@ class GameOverUi(msgspec.Struct):
         if self.assets is not None:
             self.assets = None
         if self.font is not None:
-            rl.unload_texture(self.font.texture)
+            unload_small_font(self.font)
             self.font = None
 
     def consume_enter(self) -> bool:

--- a/src/crimson/screens/results/quest_results.py
+++ b/src/crimson/screens/results/quest_results.py
@@ -8,7 +8,13 @@ import msgspec
 
 from grim.assets import TextureLoader
 from grim.config import CrimsonConfig
-from grim.fonts.small import SmallFontData, draw_small_text, load_small_font, measure_small_text_width
+from grim.fonts.small import (
+    SmallFontData,
+    draw_small_text,
+    load_small_font,
+    measure_small_text_width,
+    unload_small_font,
+)
 from grim.geom import Rect, Vec2
 from grim.raylib_api import rl
 
@@ -243,7 +249,7 @@ class QuestResultsUi(msgspec.Struct):
         if self.assets is not None:
             self.assets = None
         if self.font is not None:
-            rl.unload_texture(self.font.texture)
+            unload_small_font(self.font)
             self.font = None
 
     def _begin_close_transition(self, action: str) -> None:

--- a/src/crimson/ui/demo_trial_overlay.py
+++ b/src/crimson/ui/demo_trial_overlay.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from grim.assets import PaqTextureCache
-from grim.fonts.small import SmallFontData, draw_small_text, load_small_font
+from grim.fonts.small import SmallFontData, draw_small_text, load_small_font, unload_small_font
 from grim.geom import Vec2
 from grim.math import clamp
 from grim.raylib_api import rl
@@ -40,7 +40,7 @@ class DemoTrialOverlayUi:
 
     def close(self) -> None:
         if self._font is not None:
-            rl.unload_texture(self._font.texture)
+            unload_small_font(self._font)
             self._font = None
         self._assets = None
         self._cl_logo = None

--- a/src/grim/assets.py
+++ b/src/grim/assets.py
@@ -50,6 +50,9 @@ class TextureLoader(msgspec.Struct):
 
     @classmethod
     def from_assets_root(cls, assets_root: Path) -> TextureLoader:
+        shared = preloaded_paq_resources(assets_root)
+        if shared is not None:
+            return cls(assets_root=assets_root, cache=shared.resource_paq.texture_cache)
         paq_path = find_paq_path(assets_root)
         if paq_path is not None:
             try:
@@ -135,6 +138,7 @@ class LogoAssets(msgspec.Struct):
 class PaqTextureCache(msgspec.Struct):
     entries: dict[str, bytes]
     textures: dict[str, TextureAsset]
+    paths: dict[str, TextureAsset] = msgspec.field(default_factory=dict)
 
     def get(self, name: str) -> TextureAsset | None:
         return self.textures.get(name)
@@ -146,12 +150,103 @@ class PaqTextureCache(msgspec.Struct):
     def get_or_load(self, name: str, rel_path: str) -> TextureAsset:
         if name in self.textures:
             return self.textures[name]
+        rel_path = rel_path.replace("\\", "/")
+        existing = self.paths.get(rel_path)
+        if existing is not None:
+            self.textures[name] = existing
+            return existing
         asset = _load_texture_asset_from_bytes(name, rel_path, self.entries.get(rel_path))
         self.textures[name] = asset
+        self.paths[rel_path] = asset
         return asset
 
     def loaded_count(self) -> int:
-        return sum(1 for asset in self.textures.values() if asset.texture is not None)
+        return sum(1 for asset in self.paths.values() if asset.texture is not None)
+
+    def unload_all(self) -> None:
+        seen: set[int] = set()
+        for asset in self.paths.values():
+            asset_id = id(asset)
+            if asset_id in seen:
+                continue
+            seen.add(asset_id)
+            asset.unload()
+        self.textures.clear()
+        self.paths.clear()
+
+
+class ResourcePaqStore(msgspec.Struct):
+    paq_path: Path
+    entries: dict[str, bytes]
+    texture_cache: PaqTextureCache
+
+
+class PreloadedPaqResources(msgspec.Struct):
+    assets_root: Path
+    resource_paq: ResourcePaqStore
+    logos: LogoAssets
+
+
+_PRELOADED_PAQ_RESOURCES: dict[Path, PreloadedPaqResources] = {}
+_PRELOADABLE_TEXTURE_SUFFIXES = frozenset({".jaz", ".tga", ".jpg", ".jpeg"})
+
+
+def _assets_root_key(assets_root: Path) -> Path:
+    return assets_root.resolve()
+
+
+def _is_preloadable_texture_entry(rel_path: str) -> bool:
+    suffix = Path(rel_path.replace("\\", "/")).suffix.lower()
+    return suffix in _PRELOADABLE_TEXTURE_SUFFIXES
+
+
+def preloaded_paq_resources(assets_root: Path) -> PreloadedPaqResources | None:
+    return _PRELOADED_PAQ_RESOURCES.get(_assets_root_key(assets_root))
+
+
+def preload_paq_resources(assets_root: Path, *, paq_path: Path | None = None) -> PreloadedPaqResources:
+    key = _assets_root_key(assets_root)
+    existing = _PRELOADED_PAQ_RESOURCES.get(key)
+    if existing is not None:
+        return existing
+
+    if paq_path is None:
+        resolved = find_paq_path(assets_root)
+        if resolved is None:
+            raise FileNotFoundError(f"Missing PAQ archive for assets root: {assets_root}")
+        paq_path = resolved
+
+    entries = load_paq_entries_from_path(paq_path)
+    cache = PaqTextureCache(entries=entries, textures={})
+    for rel_path in sorted(entries):
+        if not _is_preloadable_texture_entry(rel_path):
+            continue
+        cache.get_or_load(rel_path, rel_path)
+
+    resources = PreloadedPaqResources(
+        assets_root=assets_root,
+        resource_paq=ResourcePaqStore(
+            paq_path=Path(paq_path),
+            entries=entries,
+            texture_cache=cache,
+        ),
+        logos=LogoAssets(
+            backplasma=cache.get_or_load("backplasma", "load/backplasma.jaz"),
+            mockup=cache.get_or_load("mockup", "load/mockup.jaz"),
+            logo_esrb=cache.get_or_load("logo_esrb", "load/esrb_mature.jaz"),
+            loading=cache.get_or_load("loading", "load/loading.jaz"),
+            cl_logo=cache.get_or_load("cl_logo", "load/logo_crimsonland.tga"),
+        ),
+    )
+    _PRELOADED_PAQ_RESOURCES[key] = resources
+    return resources
+
+
+def unload_preloaded_paq_resources(assets_root: Path) -> None:
+    resources = _PRELOADED_PAQ_RESOURCES.pop(_assets_root_key(assets_root), None)
+    if resources is None:
+        return
+    resources.resource_paq.texture_cache.unload_all()
 
 
 def load_paq_entries_from_path(paq_path: Path) -> dict[str, bytes]:

--- a/src/grim/audio.py
+++ b/src/grim/audio.py
@@ -54,6 +54,7 @@ def init_audio_state(config: CrimsonConfig, assets_dir: Path, console: ConsoleSt
         sfx=sfx.init_sfx_state(ready=True, enabled=sfx_enabled, volume=sfx_volume),
     )
     sfx.load_sfx_index(state.sfx, assets_dir, console)
+    sfx.preload_sfx_samples(state.sfx, console)
     music.load_music_tracks(state.music, assets_dir, console)
     return state
 

--- a/src/grim/console.py
+++ b/src/grim/console.py
@@ -11,12 +11,14 @@ from grim.fonts.grim_mono import (
     GrimMonoFont,
     draw_grim_mono_text,
     load_grim_mono_font,
+    unload_grim_mono_font,
 )
 from grim.fonts.small import (
     SmallFontData,
     draw_small_text,
     load_small_font,
     measure_small_text_width,
+    unload_small_font,
 )
 from grim.geom import Vec2
 from grim.math import clamp
@@ -373,10 +375,10 @@ class ConsoleState(msgspec.Struct):
 
     def close(self) -> None:
         if self._mono_font is not None:
-            rl.unload_texture(self._mono_font.texture)
+            unload_grim_mono_font(self._mono_font)
             self._mono_font = None
         if self._small_font is not None:
-            rl.unload_texture(self._small_font.texture)
+            unload_small_font(self._small_font)
             self._small_font = None
 
     def _tokenize_line(self, line: str) -> list[str]:

--- a/src/grim/fonts/grim_mono.py
+++ b/src/grim/fonts/grim_mono.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import msgspec
 from construct import ConstructError
 
-from grim.assets import PaqTextureCache, find_paq_path, load_paq_entries_from_path
+from grim.assets import PaqTextureCache, find_paq_path, load_paq_entries_from_path, preloaded_paq_resources
 from grim.geom import Vec2
 from grim.raylib_api import rl
 
@@ -17,13 +17,78 @@ GRIM_MONO_TEXTURE_FILTER = rl.TextureFilter.TEXTURE_FILTER_BILINEAR
 
 class GrimMonoFont(msgspec.Struct, frozen=True):
     texture: rl.Texture
+    shared: bool = False
     grid: int = 16
     cell_width: float = 16.0
     cell_height: float = 16.0
     advance: float = GRIM_MONO_ADVANCE
 
 
+_SHARED_GRIM_MONO_FONTS: dict[Path, GrimMonoFont] = {}
+
+
+def _assets_root_key(assets_root: Path) -> Path:
+    return assets_root.resolve()
+
+
+def _load_grim_mono_from_shared_paq(assets_root: Path) -> GrimMonoFont | None:
+    shared = preloaded_paq_resources(assets_root)
+    if shared is None:
+        return None
+    texture_asset = shared.resource_paq.texture_cache.get_or_load(
+        "default_font_courier",
+        "load/default_font_courier.tga",
+    )
+    texture = texture_asset.texture
+    if texture is None:
+        raise FileNotFoundError("Missing grim mono font atlas in resource PAQ: load/default_font_courier.tga")
+    rl.set_texture_filter(texture, GRIM_MONO_TEXTURE_FILTER)
+    grid = 16
+    cell_width = texture.width / grid
+    cell_height = texture.height / grid
+    return GrimMonoFont(
+        texture=texture,
+        shared=True,
+        grid=grid,
+        cell_width=cell_width,
+        cell_height=cell_height,
+        advance=GRIM_MONO_ADVANCE,
+    )
+
+
+def preload_grim_mono_font(assets_root: Path) -> GrimMonoFont:
+    key = _assets_root_key(assets_root)
+    existing = _SHARED_GRIM_MONO_FONTS.get(key)
+    if existing is not None:
+        return existing
+    font = _load_grim_mono_from_shared_paq(assets_root)
+    if font is None:
+        raise FileNotFoundError(f"Shared grim mono font requires preloaded PAQ resources: {assets_root}")
+    _SHARED_GRIM_MONO_FONTS[key] = font
+    return font
+
+
+def clear_preloaded_grim_mono_font(assets_root: Path) -> None:
+    _SHARED_GRIM_MONO_FONTS.pop(_assets_root_key(assets_root), None)
+
+
+def unload_grim_mono_font(font: GrimMonoFont | None) -> None:
+    if font is None or bool(getattr(font, "shared", False)):
+        return
+    texture = getattr(font, "texture", None)
+    if texture is None:
+        return
+    rl.unload_texture(texture)
+
+
 def load_grim_mono_font(assets_root: Path) -> GrimMonoFont:
+    shared = _SHARED_GRIM_MONO_FONTS.get(_assets_root_key(assets_root))
+    if shared is not None:
+        return shared
+    preloaded = _load_grim_mono_from_shared_paq(assets_root)
+    if preloaded is not None:
+        _SHARED_GRIM_MONO_FONTS[_assets_root_key(assets_root)] = preloaded
+        return preloaded
     # Prefer crimson.paq (runtime source-of-truth), but fall back to extracted
     # assets when present for development convenience.
     paq_path = find_paq_path(assets_root)
@@ -58,6 +123,7 @@ def load_grim_mono_font(assets_root: Path) -> GrimMonoFont:
     cell_height = texture.height / grid
     return GrimMonoFont(
         texture=texture,
+        shared=False,
         grid=grid,
         cell_width=cell_width,
         cell_height=cell_height,

--- a/src/grim/fonts/small.py
+++ b/src/grim/fonts/small.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import msgspec
 
-from grim.assets import PaqTextureCache, find_paq_path, load_paq_entries_from_path
+from grim.assets import PaqTextureCache, find_paq_path, load_paq_entries_from_path, preloaded_paq_resources
 from grim.geom import Vec2
 from grim.raylib_api import rl
 
@@ -12,6 +12,7 @@ from grim.raylib_api import rl
 class SmallFontData(msgspec.Struct, frozen=True):
     widths: list[int]
     texture: rl.Texture
+    shared: bool = False
     cell_size: int = 16
     grid: int = 16
 
@@ -19,9 +20,61 @@ class SmallFontData(msgspec.Struct, frozen=True):
 SMALL_FONT_UV_BIAS_PX = 0.5
 SMALL_FONT_FILTER = rl.TextureFilter.TEXTURE_FILTER_POINT
 SMALL_FONT_RENDER_SCALE = 1.0
+_SHARED_SMALL_FONTS: dict[Path, SmallFontData] = {}
+
+
+def _assets_root_key(assets_root: Path) -> Path:
+    return assets_root.resolve()
+
+
+def _load_small_font_from_shared_paq(assets_root: Path) -> SmallFontData | None:
+    shared = preloaded_paq_resources(assets_root)
+    if shared is None:
+        return None
+    widths_data = shared.resource_paq.entries.get("load/smallFnt.dat")
+    if widths_data is None:
+        raise FileNotFoundError("Missing small font widths in resource PAQ: load/smallFnt.dat")
+    texture_asset = shared.resource_paq.texture_cache.get_or_load("smallWhite", "load/smallWhite.tga")
+    texture = texture_asset.texture
+    if texture is None:
+        raise FileNotFoundError("Missing small font atlas in resource PAQ: load/smallWhite.tga")
+    rl.set_texture_filter(texture, SMALL_FONT_FILTER)
+    return SmallFontData(widths=list(widths_data), texture=texture, shared=True)
+
+
+def preload_small_font(assets_root: Path) -> SmallFontData:
+    key = _assets_root_key(assets_root)
+    existing = _SHARED_SMALL_FONTS.get(key)
+    if existing is not None:
+        return existing
+    font = _load_small_font_from_shared_paq(assets_root)
+    if font is None:
+        raise FileNotFoundError(f"Shared small font requires preloaded PAQ resources: {assets_root}")
+    _SHARED_SMALL_FONTS[key] = font
+    return font
+
+
+def clear_preloaded_small_font(assets_root: Path) -> None:
+    _SHARED_SMALL_FONTS.pop(_assets_root_key(assets_root), None)
+
+
+def unload_small_font(font: SmallFontData | None) -> None:
+    if font is None or bool(getattr(font, "shared", False)):
+        return
+    texture = getattr(font, "texture", None)
+    if texture is None:
+        return
+    rl.unload_texture(texture)
 
 
 def load_small_font(assets_root: Path) -> SmallFontData:
+    shared = _SHARED_SMALL_FONTS.get(_assets_root_key(assets_root))
+    if shared is not None:
+        return shared
+    preloaded = _load_small_font_from_shared_paq(assets_root)
+    if preloaded is not None:
+        _SHARED_SMALL_FONTS[_assets_root_key(assets_root)] = preloaded
+        return preloaded
     # Prefer crimson.paq (runtime source-of-truth), but fall back to extracted
     # assets when present for development convenience.
     paq_path = find_paq_path(assets_root)
@@ -34,7 +87,7 @@ def load_small_font(assets_root: Path) -> SmallFontData:
                 texture_asset = cache.get_or_load("smallWhite", "load/smallWhite.tga")
                 if texture_asset.texture is not None:
                     rl.set_texture_filter(texture_asset.texture, SMALL_FONT_FILTER)
-                    return SmallFontData(widths=list(widths_data), texture=texture_asset.texture)
+                    return SmallFontData(widths=list(widths_data), texture=texture_asset.texture, shared=False)
         except (FileNotFoundError, OSError, ValueError):
             # Fall back to extracted assets when PAQ decode/load fails.
             paq_path = None
@@ -47,7 +100,7 @@ def load_small_font(assets_root: Path) -> SmallFontData:
     widths = list(widths_path.read_bytes())
     texture = rl.load_texture(str(atlas_png if atlas_png.is_file() else atlas_tga))
     rl.set_texture_filter(texture, SMALL_FONT_FILTER)
-    return SmallFontData(widths=widths, texture=texture)
+    return SmallFontData(widths=widths, texture=texture, shared=False)
 
 
 def draw_small_text(font: SmallFontData, text: str, pos: Vec2, scale: float, color: rl.Color) -> None:

--- a/src/grim/sfx.py
+++ b/src/grim/sfx.py
@@ -208,6 +208,35 @@ def load_sfx_index(state: SfxState, assets_dir: Path, console: ConsoleState) -> 
     console.log.flush()
 
 
+def _iter_preload_keys(state: SfxState) -> Iterable[str]:
+    seen: set[str] = set()
+    for group in (sfx_map.SFX_LOAD_ORDER, sfx_map.SFX_UNREFERENCED):
+        for key, _entry_name in group:
+            if key not in state.key_to_entry or key in seen:
+                continue
+            seen.add(key)
+            yield key
+    for key in sorted(state.key_to_entry):
+        if key in seen:
+            continue
+        seen.add(key)
+        yield key
+
+
+def preload_sfx_samples(state: SfxState, console: ConsoleState | None = None) -> None:
+    if not state.ready or not state.enabled:
+        return
+    loaded = 0
+    total = 0
+    for key in _iter_preload_keys(state):
+        total += 1
+        if _load_sample(state, key) is not None:
+            loaded += 1
+    if console is not None:
+        console.log.log(f"audio: sfx samples loaded {loaded}/{total}")
+        console.log.flush()
+
+
 def _normalize_sfx_key(state: SfxState, key: str) -> str | None:
     key = key.strip().lstrip("_")
     if not key:

--- a/tests/grim/test_assets.py
+++ b/tests/grim/test_assets.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import grim.assets as assets_module
+from grim.assets import (
+    LogoAssets,
+    PaqTextureCache,
+    PreloadedPaqResources,
+    ResourcePaqStore,
+    TextureAsset,
+    TextureLoader,
+)
+from grim.raylib_api import rl
+
+
+def test_paq_texture_cache_reuses_loaded_asset_for_same_rel_path(mocker) -> None:
+    cache = PaqTextureCache(entries={"ui/ui_button_64x32.jaz": b"button"}, textures={})
+    shared_texture = cast("rl.Texture", object())
+    load_texture = mocker.patch.object(
+        assets_module,
+        "_load_texture_asset_from_bytes",
+        return_value=TextureAsset(
+            name="ui_buttonSm",
+            rel_path="ui/ui_button_64x32.jaz",
+            texture=shared_texture,
+        ),
+    )
+
+    by_name = cache.get_or_load("ui_buttonSm", "ui/ui_button_64x32.jaz")
+    by_path = cache.get_or_load("ui/ui_button_64x32.jaz", "ui/ui_button_64x32.jaz")
+
+    assert by_name is by_path
+    assert cache.loaded_count() == 1
+    load_texture.assert_called_once_with("ui_buttonSm", "ui/ui_button_64x32.jaz", b"button")
+
+
+def test_texture_loader_from_assets_root_reuses_preloaded_cache(mocker, tmp_path: Path) -> None:
+    shared_cache = PaqTextureCache(entries={}, textures={})
+    shared = PreloadedPaqResources(
+        assets_root=tmp_path,
+        resource_paq=ResourcePaqStore(
+            paq_path=tmp_path / "crimson.paq",
+            entries={},
+            texture_cache=shared_cache,
+        ),
+        logos=LogoAssets(
+            backplasma=TextureAsset("backplasma", "load/backplasma.jaz", None),
+            mockup=TextureAsset("mockup", "load/mockup.jaz", None),
+            logo_esrb=TextureAsset("logo_esrb", "load/esrb_mature.jaz", None),
+            loading=TextureAsset("loading", "load/loading.jaz", None),
+            cl_logo=TextureAsset("cl_logo", "load/logo_crimsonland.tga", None),
+        ),
+    )
+    mocker.patch.object(assets_module, "preloaded_paq_resources", return_value=shared)
+
+    loader = TextureLoader.from_assets_root(tmp_path)
+
+    assert loader.assets_root == tmp_path
+    assert loader.cache is shared_cache

--- a/tests/grim/test_audio_init.py
+++ b/tests/grim/test_audio_init.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import grim.audio as grim_audio
+
+
+def test_init_audio_state_preloads_sfx_before_music(mocker, make_game_state) -> None:
+    game_state = make_game_state()
+    mocker.patch.object(grim_audio.rl, "is_audio_device_ready", return_value=True)
+    load_sfx_index = mocker.patch.object(grim_audio.sfx, "load_sfx_index")
+    preload_sfx_samples = mocker.patch.object(grim_audio.sfx, "preload_sfx_samples")
+    load_music_tracks = mocker.patch.object(grim_audio.music, "load_music_tracks")
+    call_order = mocker.Mock()
+    call_order.attach_mock(load_sfx_index, "load_sfx_index")
+    call_order.attach_mock(preload_sfx_samples, "preload_sfx_samples")
+    call_order.attach_mock(load_music_tracks, "load_music_tracks")
+
+    state = grim_audio.init_audio_state(game_state.config, game_state.assets_dir, game_state.console)
+
+    assert state.ready is True
+    assert call_order.mock_calls == [
+        mocker.call.load_sfx_index(state.sfx, game_state.assets_dir, game_state.console),
+        mocker.call.preload_sfx_samples(state.sfx, game_state.console),
+        mocker.call.load_music_tracks(state.music, game_state.assets_dir, game_state.console),
+    ]

--- a/tests/grim/test_sfx_preload.py
+++ b/tests/grim/test_sfx_preload.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import grim.sfx as grim_sfx
+
+
+def test_preload_sfx_samples_uses_native_order_before_extras(mocker) -> None:
+    state = grim_sfx.init_sfx_state(ready=True, enabled=True, volume=1.0)
+    native_a = grim_sfx.sfx_map.SFX_LOAD_ORDER[0][0]
+    native_b = grim_sfx.sfx_map.SFX_LOAD_ORDER[1][0]
+    unused = grim_sfx.sfx_map.SFX_UNREFERENCED[0][0]
+    state.key_to_entry = {
+        "sfx_custom": "custom.ogg",
+        unused: "unused.ogg",
+        native_b: "native-b.ogg",
+        native_a: "native-a.ogg",
+    }
+    load_sample = mocker.patch.object(grim_sfx, "_load_sample", side_effect=lambda _state, _key: object())
+
+    grim_sfx.preload_sfx_samples(state)
+
+    assert [call.args[1] for call in load_sample.call_args_list] == [
+        native_a,
+        native_b,
+        unused,
+        "sfx_custom",
+    ]

--- a/tests/grim/test_shared_fonts.py
+++ b/tests/grim/test_shared_fonts.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import grim.fonts.grim_mono as grim_mono_module
+import grim.fonts.small as small_module
+from grim.assets import LogoAssets, PaqTextureCache, PreloadedPaqResources, ResourcePaqStore, TextureAsset
+from grim.raylib_api import rl
+
+
+def _empty_logos() -> LogoAssets:
+    return LogoAssets(
+        backplasma=TextureAsset("backplasma", "load/backplasma.jaz", None),
+        mockup=TextureAsset("mockup", "load/mockup.jaz", None),
+        logo_esrb=TextureAsset("logo_esrb", "load/esrb_mature.jaz", None),
+        loading=TextureAsset("loading", "load/loading.jaz", None),
+        cl_logo=TextureAsset("cl_logo", "load/logo_crimsonland.tga", None),
+    )
+
+
+def test_small_font_uses_shared_preload_and_skips_unload(mocker, tmp_path: Path) -> None:
+    texture = cast("rl.Texture", object())
+    cache = PaqTextureCache(
+        entries={"load/smallFnt.dat": bytes(range(16)), "load/smallWhite.tga": b"atlas"},
+        textures={"smallWhite": TextureAsset("smallWhite", "load/smallWhite.tga", texture)},
+    )
+    shared = PreloadedPaqResources(
+        assets_root=tmp_path,
+        resource_paq=ResourcePaqStore(
+            paq_path=tmp_path / "crimson.paq",
+            entries=cache.entries,
+            texture_cache=cache,
+        ),
+        logos=_empty_logos(),
+    )
+    mocker.patch.object(small_module, "preloaded_paq_resources", return_value=shared)
+    mocker.patch.object(small_module.rl, "set_texture_filter")
+    unload_texture = mocker.patch.object(small_module.rl, "unload_texture")
+
+    small_module.clear_preloaded_small_font(tmp_path)
+    font = small_module.preload_small_font(tmp_path)
+    small_module.unload_small_font(font)
+    small_module.clear_preloaded_small_font(tmp_path)
+
+    assert font.shared is True
+    assert font.texture is texture
+    unload_texture.assert_not_called()
+
+
+def test_grim_mono_font_uses_shared_preload_and_skips_unload(mocker, tmp_path: Path) -> None:
+    texture = cast("rl.Texture", SimpleNamespace(width=256.0, height=256.0))
+    cache = PaqTextureCache(
+        entries={"load/default_font_courier.tga": b"atlas"},
+        textures={
+            "default_font_courier": TextureAsset(
+                "default_font_courier",
+                "load/default_font_courier.tga",
+                texture,
+            ),
+        },
+    )
+    shared = PreloadedPaqResources(
+        assets_root=tmp_path,
+        resource_paq=ResourcePaqStore(
+            paq_path=tmp_path / "crimson.paq",
+            entries=cache.entries,
+            texture_cache=cache,
+        ),
+        logos=_empty_logos(),
+    )
+    mocker.patch.object(grim_mono_module, "preloaded_paq_resources", return_value=shared)
+    mocker.patch.object(grim_mono_module.rl, "set_texture_filter")
+    unload_texture = mocker.patch.object(grim_mono_module.rl, "unload_texture")
+
+    grim_mono_module.clear_preloaded_grim_mono_font(tmp_path)
+    font = grim_mono_module.preload_grim_mono_font(tmp_path)
+    grim_mono_module.unload_grim_mono_font(font)
+    grim_mono_module.clear_preloaded_grim_mono_font(tmp_path)
+
+    assert font.shared is True
+    assert font.texture is texture
+    unload_texture.assert_not_called()

--- a/tests/screens/test_boot_preload.py
+++ b/tests/screens/test_boot_preload.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import cast
+
+import crimson.screens.boot as boot_module
+from crimson.screens.boot import BootView
+from grim.assets import LogoAssets, PaqTextureCache, PreloadedPaqResources, ResourcePaqStore, TextureAsset
+from grim.raylib_api import rl
+
+
+def test_boot_open_adopts_preloaded_resource_cache(make_game_state, mocker) -> None:
+    state = make_game_state()
+    view = BootView(state)
+    texture = cast("rl.Texture", object())
+    shared_cache = PaqTextureCache(
+        entries={},
+        textures={
+            "backplasma": TextureAsset("backplasma", "load/backplasma.jaz", texture),
+            "mockup": TextureAsset("mockup", "load/mockup.jaz", texture),
+            "logo_esrb": TextureAsset("logo_esrb", "load/esrb_mature.jaz", texture),
+            "loading": TextureAsset("loading", "load/loading.jaz", texture),
+            "cl_logo": TextureAsset("cl_logo", "load/logo_crimsonland.tga", texture),
+        },
+    )
+    logos = LogoAssets(
+        backplasma=shared_cache.textures["backplasma"],
+        mockup=shared_cache.textures["mockup"],
+        logo_esrb=shared_cache.textures["logo_esrb"],
+        loading=shared_cache.textures["loading"],
+        cl_logo=shared_cache.textures["cl_logo"],
+    )
+    resources = PreloadedPaqResources(
+        assets_root=state.assets_dir,
+        logos=logos,
+        resource_paq=ResourcePaqStore(
+            paq_path=state.resource_paq,
+            entries={},
+            texture_cache=shared_cache,
+        ),
+    )
+    preload = mocker.patch.object(boot_module, "preload_paq_resources", return_value=resources)
+    init_audio = mocker.patch.object(boot_module, "init_audio_state", return_value=object())
+    exec_line = mocker.patch.object(type(state.console), "exec_line")
+
+    view.open()
+
+    preload.assert_called_once_with(state.assets_dir, paq_path=state.resource_paq)
+    init_audio.assert_called_once_with(state.config, state.assets_dir, state.console)
+    exec_line.assert_called_once_with("exec music/game_tunes.txt")
+    assert state.logos is logos
+    assert state.texture_cache is shared_cache

--- a/tests/screens/test_boot_preload.py
+++ b/tests/screens/test_boot_preload.py
@@ -39,12 +39,16 @@ def test_boot_open_adopts_preloaded_resource_cache(make_game_state, mocker) -> N
         ),
     )
     preload = mocker.patch.object(boot_module, "preload_paq_resources", return_value=resources)
+    preload_small = mocker.patch.object(boot_module, "preload_small_font")
+    preload_grim_mono = mocker.patch.object(boot_module, "preload_grim_mono_font")
     init_audio = mocker.patch.object(boot_module, "init_audio_state", return_value=object())
     exec_line = mocker.patch.object(type(state.console), "exec_line")
 
     view.open()
 
     preload.assert_called_once_with(state.assets_dir, paq_path=state.resource_paq)
+    preload_small.assert_called_once_with(state.assets_dir)
+    preload_grim_mono.assert_called_once_with(state.assets_dir)
     init_audio.assert_called_once_with(state.config, state.assets_dir, state.console)
     exec_line.assert_called_once_with("exec music/game_tunes.txt")
     assert state.logos is logos

--- a/tests/screens/test_screen_assets.py
+++ b/tests/screens/test_screen_assets.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import cast
+
+from crimson.screens.assets import load_classic_ui_assets
+from grim.assets import PaqTextureCache, TextureAsset
+from grim.raylib_api import rl
+
+
+def test_load_classic_ui_assets_reuses_cached_widget_textures(make_game_state) -> None:
+    state = make_game_state()
+    textures = {
+        "ui_buttonSm": TextureAsset("ui_buttonSm", "ui/ui_button_64x32.jaz", cast("rl.Texture", object())),
+        "ui_buttonMd": TextureAsset("ui_buttonMd", "ui/ui_button_128x32.jaz", cast("rl.Texture", object())),
+        "ui_checkOn": TextureAsset("ui_checkOn", "ui/ui_checkOn.jaz", cast("rl.Texture", object())),
+        "ui_checkOff": TextureAsset("ui_checkOff", "ui/ui_checkOff.jaz", cast("rl.Texture", object())),
+        "ui_rectOn": TextureAsset("ui_rectOn", "ui/ui_rectOn.jaz", cast("rl.Texture", object())),
+        "ui_rectOff": TextureAsset("ui_rectOff", "ui/ui_rectOff.jaz", cast("rl.Texture", object())),
+        "ui_dropOn": TextureAsset("ui_dropOn", "ui/ui_dropDownOn.jaz", cast("rl.Texture", object())),
+        "ui_dropOff": TextureAsset("ui_dropOff", "ui/ui_dropDownOff.jaz", cast("rl.Texture", object())),
+        "ui_arrow": TextureAsset("ui_arrow", "ui/ui_arrow.jaz", cast("rl.Texture", object())),
+    }
+    state.texture_cache = PaqTextureCache(entries={}, textures=textures)
+
+    assets = load_classic_ui_assets(state)
+
+    assert assets.button_sm is textures["ui_buttonSm"].texture
+    assert assets.button_md is textures["ui_buttonMd"].texture
+    assert assets.check_on is textures["ui_checkOn"].texture
+    assert assets.check_off is textures["ui_checkOff"].texture
+    assert assets.rect_on is textures["ui_rectOn"].texture
+    assert assets.rect_off is textures["ui_rectOff"].texture
+    assert assets.drop_on is textures["ui_dropOn"].texture
+    assert assets.drop_off is textures["ui_dropOff"].texture
+    assert assets.arrow is textures["ui_arrow"].texture
+    assert assets.button_textures.button_sm is assets.button_sm
+    assert assets.button_textures.button_md is assets.button_md


### PR DESCRIPTION
## Summary

- preload `crimson.paq` textures once at boot and share the cache for the full app lifetime
- preload shared small/grim-mono UI fonts from the startup-owned resource Paq cache
- preload all SFX samples during audio init in native load order while keeping play-time RNG behavior unchanged
- add and update `asset_loading_memo.md` with before/after architecture diagrams and parity notes

## Parity notes

- boot visuals are unchanged; the staged boot sequence now walks a warm cache
- no gameplay RNG calls were moved into startup loading
- SFX startup decode preserves native `SFX_LOAD_ORDER` before extra entries

## Validation

- `just check`
