### PR TITLE
refactor: inline single-use screen layout constants

### DIFF
--- a/src/crimson/screens/menu.py
+++ b/src/crimson/screens/menu.py
@@ -33,7 +33,6 @@ MENU_LABEL_ROW_MODS = 4
 MENU_LABEL_ROW_OTHER_GAMES = 5
 MENU_LABEL_ROW_QUIT = 6
 MENU_LABEL_ROW_BACK = 7
-MENU_LABEL_BASE_X = -60.0
 MENU_LABEL_BASE_Y = 210.0
 MENU_LABEL_OFFSET_X = 271.0
 MENU_LABEL_OFFSET_Y = -37.0
@@ -49,10 +48,6 @@ MENU_PANEL_OFFSET_Y = -81.0
 MENU_PANEL_BASE_X = -45.0
 MENU_PANEL_BASE_Y = 210.0
 MENU_SCALE_SMALL_THRESHOLD = 640
-MENU_SCALE_LARGE_MIN = 801
-MENU_SCALE_LARGE_MAX = 1024
-MENU_SCALE_SMALL = 0.8
-MENU_SCALE_LARGE = 1.2
 MENU_SCALE_SHIFT = 10.0
 
 MENU_SIGN_WIDTH = 571.44
@@ -580,7 +575,7 @@ class MenuView:
     @staticmethod
     def _menu_slot_pos_x(slot: int) -> float:
         # ui_menu_layout_init: subtract 20, 40, ... from later menu items
-        return MENU_LABEL_BASE_X - float(slot * 20)
+        return -60.0 - float(slot * 20)
 
     @staticmethod
     def _menu_slot_start_ms(slot: int) -> int:
@@ -704,7 +699,7 @@ class MenuView:
     @staticmethod
     def _sign_layout_scale(width: int) -> tuple[float, float]:
         if width <= MENU_SCALE_SMALL_THRESHOLD:
-            return MENU_SCALE_SMALL, MENU_SCALE_SHIFT
-        if MENU_SCALE_LARGE_MIN <= width <= MENU_SCALE_LARGE_MAX:
-            return MENU_SCALE_LARGE, MENU_SCALE_SHIFT
+            return 0.8, MENU_SCALE_SHIFT
+        if 801 <= width <= 1024:
+            return 1.2, MENU_SCALE_SHIFT
         return 1.0, 0.0

--- a/src/crimson/screens/panels/base.py
+++ b/src/crimson/screens/panels/base.py
@@ -38,10 +38,6 @@ from ..menu import (
 )
 from ..transitions import _draw_screen_fade
 
-PANEL_POS_X = -45.0
-PANEL_POS_Y = 210.0
-PANEL_BACK_POS_X = -55.0
-PANEL_BACK_POS_Y = 430.0
 PANEL_TIMELINE_START_MS = 300
 PANEL_TIMELINE_END_MS = 0
 
@@ -63,10 +59,10 @@ class PanelMenuView:
         *,
         title: str,
         body: str | None = None,
-        panel_pos: Vec2 = Vec2(PANEL_POS_X, PANEL_POS_Y),
+        panel_pos: Vec2 = Vec2(-45.0, 210.0),
         panel_offset: Vec2 = Vec2(MENU_PANEL_OFFSET_X, MENU_PANEL_OFFSET_Y),
         panel_height: float = MENU_PANEL_HEIGHT,
-        back_pos: Vec2 = Vec2(PANEL_BACK_POS_X, PANEL_BACK_POS_Y),
+        back_pos: Vec2 = Vec2(-55.0, 430.0),
         back_action: str = "back_to_menu",
     ) -> None:
         self.state = state

--- a/src/crimson/screens/panels/controls.py
+++ b/src/crimson/screens/panels/controls.py
@@ -37,12 +37,9 @@ from .hit_test import mouse_inside_rect_with_padding
 
 # Measured from ui_render_trace_oracle_1024x768.json (state_3:Configure for:, timeline=300).
 CONTROLS_LEFT_PANEL_POS_X = -165.0
-CONTROLS_LEFT_PANEL_POS_Y = 200.0
 CONTROLS_RIGHT_PANEL_POS_X = 590.0
 CONTROLS_RIGHT_PANEL_POS_Y = 110.0
 CONTROLS_RIGHT_PANEL_HEIGHT = 378.0
-CONTROLS_BACK_POS_X = -155.0
-CONTROLS_BACK_POS_Y = 420.0
 
 # `ui_menu_item_update`: idle rebind value tint (rgb 70,180,240 @ alpha 0.6).
 CONTROLS_REBIND_VALUE_COLOR = rl.Color(70, 180, 240, 153)
@@ -118,8 +115,8 @@ class ControlsMenuView(PanelMenuView):
             state,
             title="Controls",
             back_action="open_options",
-            panel_pos=Vec2(CONTROLS_LEFT_PANEL_POS_X, CONTROLS_LEFT_PANEL_POS_Y),
-            back_pos=Vec2(CONTROLS_BACK_POS_X, CONTROLS_BACK_POS_Y),
+            panel_pos=Vec2(CONTROLS_LEFT_PANEL_POS_X, 200.0),
+            back_pos=Vec2(-155.0, 420.0),
         )
         self._small_font: SmallFontData | None = None
         self._text_controls: rl.Texture | None = None

--- a/src/crimson/screens/panels/credits.py
+++ b/src/crimson/screens/panels/credits.py
@@ -40,11 +40,6 @@ from ..menu import (
 from ..transitions import _draw_screen_fade
 from .base import PANEL_TIMELINE_END_MS, PANEL_TIMELINE_START_MS
 
-# Measured from ui_render_trace_oracle_1024x768.json (state_17:credits, timeline=300).
-CREDITS_PANEL_POS_X = -119.0
-CREDITS_PANEL_POS_Y = 185.0
-CREDITS_PANEL_HEIGHT = 378.0
-
 # Child layout inside the panel (relative to panel top-left).
 _TITLE_X = 202.0
 _TITLE_Y = 46.0
@@ -53,8 +48,6 @@ _TEXT_ANCHOR_X = 198.0
 _TEXT_CENTER_OFFSET_X = 140.0
 _TEXT_BASE_Y = 60.0
 _TEXT_LINE_HEIGHT = 16.0
-_TEXT_FADE_PX = 24.0
-_TEXT_RECT_H = 16.0
 
 _BACK_BUTTON_X = 298.0
 _BACK_BUTTON_Y = 310.0
@@ -326,9 +319,10 @@ class CreditsView:
         return self._small_font
 
     def _panel_top_left(self, *, scale: float) -> Vec2:
+        # Measured from ui_render_trace_oracle_1024x768.json (state_17:credits, timeline=300).
         return Vec2(
-            CREDITS_PANEL_POS_X + MENU_PANEL_OFFSET_X * scale,
-            CREDITS_PANEL_POS_Y + self._widescreen_y_shift + MENU_PANEL_OFFSET_Y * scale,
+            -119.0 + MENU_PANEL_OFFSET_X * scale,
+            185.0 + self._widescreen_y_shift + MENU_PANEL_OFFSET_Y * scale,
         )
 
     @staticmethod
@@ -393,7 +387,7 @@ class CreditsView:
         visible_count: int,
         scale: float,
     ) -> float:
-        fade_px = _TEXT_FADE_PX * scale
+        fade_px = 24.0 * scale
         top = base_y + (8.0 * scale)
         alpha = 1.0
         if y < top:
@@ -438,7 +432,7 @@ class CreditsView:
                 x=x,
                 y=y,
                 w=text_w,
-                h=_TEXT_RECT_H * scale,
+                h=16.0 * scale,
             ):
                 continue
 
@@ -572,7 +566,7 @@ class CreditsView:
             panel_top_left.x,
             panel_top_left.y,
             MENU_PANEL_WIDTH * scale,
-            CREDITS_PANEL_HEIGHT * scale,
+            378.0 * scale,
         )
         fx_detail = self.state.config.fx_detail(level=0, default=False)
         draw_classic_menu_panel(assets.panel, dst=dst, tint=rl.WHITE, shadow=fx_detail)

--- a/src/crimson/screens/panels/databases_base.py
+++ b/src/crimson/screens/panels/databases_base.py
@@ -35,9 +35,6 @@ from .base import PANEL_TIMELINE_END_MS, PANEL_TIMELINE_START_MS
 
 # Shared panel layout (state_14/15/16 in the oracle): tall left panel + short right panel.
 LEFT_PANEL_POS_Y = 185.0
-LEFT_PANEL_HEIGHT = 378.0
-RIGHT_PANEL_POS_Y = 200.0
-RIGHT_PANEL_HEIGHT = 254.0
 
 
 class _DatabaseBaseView:
@@ -259,19 +256,19 @@ class _DatabaseBaseView:
         left_panel_pos_x = hs_left_panel_pos_x(screen_width)
         left_top_left = self._panel_top_left(pos=Vec2(left_panel_pos_x, LEFT_PANEL_POS_Y), scale=scale)
         right_panel_pos_x = hs_right_panel_pos_x(screen_width)
-        right_top_left = self._panel_top_left(pos=Vec2(right_panel_pos_x, RIGHT_PANEL_POS_Y), scale=scale)
+        right_top_left = self._panel_top_left(pos=Vec2(right_panel_pos_x, 200.0), scale=scale)
         left_panel_top_left = left_top_left.offset(dx=float(left_slide_x))
         right_panel_top_left = right_top_left.offset(dx=float(right_slide_x))
 
         draw_classic_menu_panel(
             assets.panel,
-            dst=rl.Rectangle(left_panel_top_left.x, left_panel_top_left.y, panel_w, LEFT_PANEL_HEIGHT * scale),
+            dst=rl.Rectangle(left_panel_top_left.x, left_panel_top_left.y, panel_w, 378.0 * scale),
             tint=rl.WHITE,
             shadow=fx_detail,
         )
         draw_classic_menu_panel(
             assets.panel,
-            dst=rl.Rectangle(right_panel_top_left.x, right_panel_top_left.y, panel_w, RIGHT_PANEL_HEIGHT * scale),
+            dst=rl.Rectangle(right_panel_top_left.x, right_panel_top_left.y, panel_w, 254.0 * scale),
             tint=rl.WHITE,
             shadow=fx_detail,
             flip_x=True,

--- a/src/crimson/screens/panels/stats.py
+++ b/src/crimson/screens/panels/stats.py
@@ -37,16 +37,9 @@ from ..menu import (
 from ..transitions import _draw_screen_fade
 from .base import PANEL_TIMELINE_END_MS, PANEL_TIMELINE_START_MS
 
-# Measured from ui_render_trace_oracle_1024x768.json (state_4:played for # hours # minutes, timeline=300).
-STATISTICS_PANEL_POS_X = -89.0
-STATISTICS_PANEL_POS_Y = 185.0
-STATISTICS_PANEL_HEIGHT = 378.0
-
 # Child layout inside the panel (relative to panel top-left).
 _TITLE_X = 290.0
 _TITLE_Y = 52.0
-_TITLE_W = 128.0
-_TITLE_H = 32.0
 
 _BUTTON_X = 270.0
 _BUTTON_Y0 = 104.0
@@ -55,13 +48,9 @@ _BUTTON_STEP_Y = 34.0
 _BACK_BUTTON_X = 394.0
 _BACK_BUTTON_Y = 290.0
 
-_PLAYTIME_X = 204.0
-_PLAYTIME_Y = 334.0
-
 _STATS_EASTER_ROLL_UNSET = -1
 _STATS_EASTER_TRIGGER_ROLL = 3
 _STATS_EASTER_TEXT = "Orbes Volantes Exstare"
-_STATS_EASTER_TEXT_Y = 5.0
 
 
 def _stats_menu_easter_roll(current_roll: int, *, rng: Crand) -> int:
@@ -201,9 +190,10 @@ class StatisticsMenuView:
         return self._small_font
 
     def _panel_top_left(self, *, scale: float) -> Vec2:
+        # Measured from ui_render_trace_oracle_1024x768.json (state_4:played for # hours # minutes, timeline=300).
         return Vec2(
-            STATISTICS_PANEL_POS_X + MENU_PANEL_OFFSET_X * scale,
-            STATISTICS_PANEL_POS_Y + self._widescreen_y_shift + MENU_PANEL_OFFSET_Y * scale,
+            -89.0 + MENU_PANEL_OFFSET_X * scale,
+            185.0 + self._widescreen_y_shift + MENU_PANEL_OFFSET_Y * scale,
         )
 
     def _begin_close_transition(self, action: str) -> None:
@@ -325,7 +315,7 @@ class StatisticsMenuView:
         )
         panel_top_left = self._panel_top_left(scale=scale).offset(dx=float(slide_x))
         dst = rl.Rectangle(
-            panel_top_left.x, panel_top_left.y, panel_w, STATISTICS_PANEL_HEIGHT * scale,
+            panel_top_left.x, panel_top_left.y, panel_w, 378.0 * scale,
         )
         fx_detail = self.state.config.fx_detail(level=0, default=False)
         draw_classic_menu_panel(assets.panel, dst=dst, tint=rl.WHITE, shadow=fx_detail)
@@ -340,8 +330,8 @@ class StatisticsMenuView:
             dst=rl.Rectangle(
                 panel_top_left.x + _TITLE_X * scale,
                 panel_top_left.y + _TITLE_Y * scale,
-                _TITLE_W * scale,
-                _TITLE_H * scale,
+                128.0 * scale,
+                32.0 * scale,
             ),
             origin=rl.Vector2(0.0, 0.0),
             rotation_deg=0.0,
@@ -353,12 +343,12 @@ class StatisticsMenuView:
         draw_small_text(font, _format_playtime_text(
             int(self.state.status.game_sequence_id),
             preserve_bugs=bool(self.state.preserve_bugs),
-        ), panel_top_left + Vec2(_PLAYTIME_X * scale, _PLAYTIME_Y * scale), rl.Color(255, 255, 255, int(255 * 0.8)))
+        ), panel_top_left + Vec2(204.0 * scale, 334.0 * scale), rl.Color(255, 255, 255, int(255 * 0.8)))
 
         if _is_orbes_volantes_day(dt.date.today()) and int(self.state.stats_menu_easter_egg_roll) == _STATS_EASTER_TRIGGER_ROLL:
             self.state.stats_menu_easter_egg_roll = _STATS_EASTER_ROLL_UNSET
             x = float(self.state.rng.rand() % 64 + 16)
-            draw_small_text(font, _STATS_EASTER_TEXT, Vec2(x, _STATS_EASTER_TEXT_Y), rl.Color(51, 255, 153, 128))
+            draw_small_text(font, _STATS_EASTER_TEXT, Vec2(x, 5.0), rl.Color(51, 255, 153, 128))
 
         # Buttons.
         textures = self._button_textures

--- a/src/crimson/screens/results/game_over.py
+++ b/src/crimson/screens/results/game_over.py
@@ -39,23 +39,15 @@ from ...ui.perk_menu import (
 from ...ui.text_input import flush_text_input_events, gameplay_controls_held, poll_text_input
 from ...weapons import WEAPON_BY_ID, WeaponId, weapon_display_name
 
-GAME_OVER_PANEL_X = -45.0
 # `ui_menu_layout_init` sets game-over panel pos to (-45, 110):
 #   _DAT_0048cc60 = 0xc2340000 (-45.0)
 #   _DAT_0048cc64 = 0x42dc0000 (110.0)
-GAME_OVER_PANEL_Y = 110.0
 # `DAT_0048cc48` is cloned from the 3-slice menu panel layout (`ui_menu_item_element._pad4+0xac`)
 # in `ui_menu_layout_init`; trace confirms a 510x378 bbox for both phase 0 and phase 1.
 GAME_OVER_PANEL_W = 510.0
-GAME_OVER_PANEL_H = 378.0
 
 # Measured from ui_render_trace at 1024x768 (stable timeline):
 # panel top-left is (pos_x + 21, pos_y - 81) and size is 510x254, plus a shadow pass at +7,+7.
-GAME_OVER_PANEL_OFFSET_X = 21.0
-GAME_OVER_PANEL_OFFSET_Y = -81.0
-
-TEXTURE_TOP_BANNER_W = 256.0
-TEXTURE_TOP_BANNER_H = 64.0
 
 # `game_over_screen_update` (0x0040ffc0) computes banner/content X from:
 #   local_10 = quad0_x0 + pos_x + 180.0
@@ -227,13 +219,13 @@ class GameOverUi(msgspec.Struct):
         eased = _ease_out_cubic(t)
         panel_slide_x = -GAME_OVER_PANEL_W * (1.0 - eased)
 
-        panel_pos = Vec2((GAME_OVER_PANEL_X + panel_slide_x) * scale, 0.0)
+        panel_pos = Vec2((-45.0 + panel_slide_x) * scale, 0.0)
         layout_w = screen_w / scale if scale else screen_w
         widescreen_shift_y = menu_widescreen_y_shift(layout_w)
-        panel_pos = Vec2(panel_pos.x, (GAME_OVER_PANEL_Y + widescreen_shift_y) * scale)
-        panel_origin = Vec2(-(GAME_OVER_PANEL_OFFSET_X * scale), -(GAME_OVER_PANEL_OFFSET_Y * scale))
+        panel_pos = Vec2(panel_pos.x, (110.0 + widescreen_shift_y) * scale)
+        panel_origin = Vec2(-21.0 * scale, 81.0 * scale)
         top_left = panel_pos - panel_origin
-        panel = Rect.from_top_left(top_left, GAME_OVER_PANEL_W * scale, GAME_OVER_PANEL_H * scale)
+        panel = Rect.from_top_left(top_left, GAME_OVER_PANEL_W * scale, 378.0 * scale)
         return _GameOverPanelLayout(panel=panel, top_left=top_left)
 
     def _begin_close_transition(self, action: str) -> None:
@@ -673,8 +665,8 @@ class GameOverUi(msgspec.Struct):
             _draw_texture_centered(
                 banner,
                 banner_pos,
-                TEXTURE_TOP_BANNER_W * scale,
-                TEXTURE_TOP_BANNER_H * scale,
+                256.0 * scale,
+                64.0 * scale,
                 1.0,
             )
 

--- a/src/crimson/screens/results/quest_results.py
+++ b/src/crimson/screens/results/quest_results.py
@@ -49,23 +49,13 @@ from ...weapons import WEAPON_BY_ID, WeaponId, weapon_display_name
 # - pos_x/pos_y are `ui_element_t` position fields set to (-45, 110)
 # - geom_x0/geom_y0 are the first vertex coordinates of the `ui_menuPanel` geo,
 #   after `ui_menu_assets_init` transforms it into an 8-vertex 3-slice panel.
-QUEST_RESULTS_PANEL_POS_X = -45.0
-QUEST_RESULTS_PANEL_POS_Y = 110.0
-QUEST_RESULTS_PANEL_GEOM_X0 = -63.0
-QUEST_RESULTS_PANEL_GEOM_Y0 = -81.0
-
 QUEST_RESULTS_PANEL_W = 510.0
-QUEST_RESULTS_PANEL_H = 378.0
-
-TEXTURE_TOP_BANNER_W = 256.0
-TEXTURE_TOP_BANNER_H = 64.0
 
 # `quest_results_screen_update` uses the classic UI element sums for positioning:
 #   content_x = (pos_x + offset_x + slide_x) + 180.0 + 40.0
 #   banner_x  = content_x - 18.0
 #   score_x   = content_x + 30.0
 QUEST_RESULTS_CONTENT_X = 220.0
-QUEST_RESULTS_BANNER_X_FROM_CONTENT = -18.0
 QUEST_RESULTS_SCORE_CARD_X_FROM_CONTENT = 30.0
 
 INPUT_BOX_W = 166.0
@@ -386,13 +376,13 @@ class QuestResultsUi(msgspec.Struct):
         else:
             panel_slide_x = 0.0
 
-        panel_pos = Vec2((QUEST_RESULTS_PANEL_GEOM_X0 + QUEST_RESULTS_PANEL_POS_X + panel_slide_x) * scale, 0.0)
+        panel_pos = Vec2((-63.0 - 45.0 + panel_slide_x) * scale, 0.0)
         layout_w = screen_w / scale if scale else screen_w
         widescreen_shift_y = menu_widescreen_y_shift(layout_w)
         panel_pos = Vec2(
-            panel_pos.x, (QUEST_RESULTS_PANEL_GEOM_Y0 + QUEST_RESULTS_PANEL_POS_Y + widescreen_shift_y) * scale,
+            panel_pos.x, (-81.0 + 110.0 + widescreen_shift_y) * scale,
         )
-        panel = Rect.from_top_left(panel_pos, QUEST_RESULTS_PANEL_W * scale, QUEST_RESULTS_PANEL_H * scale)
+        panel = Rect.from_top_left(panel_pos, QUEST_RESULTS_PANEL_W * scale, 378.0 * scale)
         return _QuestResultsPanelLayout(panel=panel, top_left=panel_pos)
 
     def update(
@@ -665,12 +655,12 @@ class QuestResultsUi(msgspec.Struct):
             )
 
         content_pos = panel_layout.top_left.offset(dx=QUEST_RESULTS_CONTENT_X * scale)
-        banner_pos = content_pos + Vec2(QUEST_RESULTS_BANNER_X_FROM_CONTENT * scale, 36.0 * scale)
+        banner_pos = content_pos + Vec2(-18.0 * scale, 36.0 * scale)
         if self.assets.text_well_done is not None:
             src = rl.Rectangle(
                 0.0, 0.0, float(self.assets.text_well_done.width), float(self.assets.text_well_done.height),
             )
-            dst = rl.Rectangle(banner_pos.x, banner_pos.y, TEXTURE_TOP_BANNER_W * scale, TEXTURE_TOP_BANNER_H * scale)
+            dst = rl.Rectangle(banner_pos.x, banner_pos.y, 256.0 * scale, 64.0 * scale)
             rl.draw_texture_pro(self.assets.text_well_done, src, dst, rl.Vector2(0.0, 0.0), 0.0, rl.WHITE)
 
         qualifies = int(self.rank) < TABLE_MAX


### PR DESCRIPTION
## Summary
- inline module-local, single-use screen layout constants in menu, panel, and results views
- keep shared layout tables and non-layout constants untouched

## Testing
- `uv run pytest tests/screens`
- `uv run ruff check src/crimson/screens/menu.py src/crimson/screens/panels/base.py src/crimson/screens/panels/controls.py src/crimson/screens/panels/credits.py src/crimson/screens/panels/databases_base.py src/crimson/screens/panels/stats.py src/crimson/screens/results/game_over.py src/crimson/screens/results/quest_results.py`
