### PR TITLE
feat(zig): render live world with runtime assets

### DIFF
--- a/crimson-zig/README.md
+++ b/crimson-zig/README.md
@@ -67,6 +67,7 @@ zig build
 zig build run -- replay verify survival_20260224_041009_score76661.crd --format json
 zig build run-window
 zig build web-window
+zig build asset-smoke
 zig build test
 zig build wasm
 ```
@@ -75,6 +76,8 @@ zig build wasm
 
 - `zig build run-window` opens the current desktop playable slice using `raylib-zig`.
 - `zig build window` compiles that target without running it.
+- `zig build asset-smoke` runs a local decode smoke pass over `crimson.paq` and
+  runtime-mapped texture entries, printing exact failing asset paths.
 - `zig build web-window` builds an HTML+WASM placeholder window for browser use.
 - `zig build run-web-window` serves the web build through `emrun` (`--no_browser`).
 - The desktop target is currently a menu-to-gameplay Survival slice with a

--- a/crimson-zig/README.md
+++ b/crimson-zig/README.md
@@ -48,10 +48,12 @@ This wave is intentionally codec-only:
 - Native CLI still hard-fails for unsupported or unported native paths instead of falling back.
 - `zig build run-window` now boots a real desktop Survival slice:
   boot screen -> main menu -> live 1-player Survival run -> results.
-- `zig build run-window` now also opportunistically loads runtime assets from
-  `CRIMSON_ASSETS_DIR`, `./artifacts/assets`, or the current directory when
-  `crimson.paq` is present, including `.jaz`, `.tga`, `.jpg/.jpeg`, and
-  `load/smallFnt.dat`.
+- `zig build run-window` now looks for runtime assets using the same default
+  runtime-dir policy as Python first:
+  `CRIMSON_ASSETS_DIR`, then `CRIMSON_RUNTIME_DIR` / `CRIMSON_BASE_DIR`, then
+  the per-user platform data dir (`platformdirs`-compatible layout), with
+  `./artifacts/assets` and the current directory left as checkout-local
+  fallback. It loads `.jaz`, `.tga`, `.jpg/.jpeg`, and `load/smallFnt.dat`.
 - The freestanding WASM ABI now runs the same replay verification core for
   byte-input payloads, with JSON output and JSON error reporting via
   `crimson_last_error_json`.
@@ -75,9 +77,10 @@ zig build wasm
 - `zig build window` compiles that target without running it.
 - `zig build web-window` builds an HTML+WASM placeholder window for browser use.
 - `zig build run-web-window` serves the web build through `emrun` (`--no_browser`).
-- The desktop target is currently a menu-to-gameplay Survival slice with primitive
-  gameplay rendering and HUD, but it now loads archive-backed textures for
-  boot/menu surfaces when `crimson.paq` is available.
+- The desktop target is currently a menu-to-gameplay Survival slice with a
+  mixed renderer: gameplay world surfaces now use archive-backed textures when
+  `crimson.paq` is available, with primitive fallback where exact sprite atlas
+  mapping is still incomplete.
 - `zig build wasm` remains the freestanding ABI module (`wasm32-freestanding`) and
   is intentionally separate from the raylib web target (`wasm32-emscripten`).
 

--- a/crimson-zig/build.zig
+++ b/crimson-zig/build.zig
@@ -77,6 +77,25 @@ pub fn build(b: *std.Build) void {
     const run_window_cmd = b.addRunArtifact(window_exe);
     run_window_step.dependOn(&run_window_cmd.step);
 
+    const asset_smoke_exe = b.addExecutable(.{
+        .name = "crimson-zig-asset-smoke",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/asset_smoke_main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "raylib", .module = raylib_module },
+                .{ .name = "crimson_zig", .module = mod },
+            },
+        }),
+    });
+    const asset_smoke_step = b.step("asset-smoke", "Run local runtime asset decode smoke");
+    const asset_smoke_cmd = b.addRunArtifact(asset_smoke_exe);
+    asset_smoke_step.dependOn(&asset_smoke_cmd.step);
+    if (b.args) |args| {
+        asset_smoke_cmd.addArgs(args);
+    }
+
     const web_target = b.resolveTargetQuery(.{
         .cpu_arch = .wasm32,
         .os_tag = .emscripten,

--- a/crimson-zig/src/asset_smoke_main.zig
+++ b/crimson-zig/src/asset_smoke_main.zig
@@ -1,0 +1,189 @@
+const std = @import("std");
+const rl = @import("raylib");
+
+const window_assets = @import("window_assets.zig");
+
+const SmokeStats = struct {
+    archive_entries: usize = 0,
+    jaz_entries: usize = 0,
+    tga_entries: usize = 0,
+    jpg_entries: usize = 0,
+    jpeg_entries: usize = 0,
+    dat_entries: usize = 0,
+    skipped_entries: usize = 0,
+    decoded_entries: usize = 0,
+    runtime_texture_specs: usize = 0,
+    failures: usize = 0,
+};
+
+pub fn main() !void {
+    rl.setTraceLogLevel(.err);
+
+    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    if (args.len >= 2 and (std.mem.eql(u8, args[1], "--help") or std.mem.eql(u8, args[1], "-h"))) {
+        try printUsage();
+        return;
+    }
+    if (args.len > 2) {
+        try printUsage();
+        std.process.exit(2);
+    }
+
+    const assets_dir = if (args.len == 2)
+        try allocator.dupe(u8, args[1])
+    else
+        (try window_assets.resolveRuntimeAssetsDir(allocator)) orelse {
+            try writeStderr("asset-smoke: no runtime assets dir resolved\n");
+            try writeStderr("set CRIMSON_ASSETS_DIR or place crimson.paq under the runtime dir\n");
+            std.process.exit(1);
+        };
+    defer allocator.free(assets_dir);
+
+    const stats = try runSmoke(allocator, assets_dir);
+
+    var out_buf: [4096]u8 = undefined;
+    var out_writer = std.fs.File.stdout().writer(&out_buf);
+    const out = &out_writer.interface;
+    try out.print(
+        "asset-smoke: {s}\narchive_entries={d} decoded={d} jaz={d} tga={d} jpg={d} jpeg={d} dat={d} skipped={d} runtime_specs={d} failures={d}\n",
+        .{
+            assets_dir,
+            stats.archive_entries,
+            stats.decoded_entries,
+            stats.jaz_entries,
+            stats.tga_entries,
+            stats.jpg_entries,
+            stats.jpeg_entries,
+            stats.dat_entries,
+            stats.skipped_entries,
+            stats.runtime_texture_specs,
+            stats.failures,
+        },
+    );
+    try out.flush();
+
+    if (stats.failures != 0) {
+        std.process.exit(1);
+    }
+}
+
+fn runSmoke(allocator: std.mem.Allocator, assets_dir: []const u8) !SmokeStats {
+    const paq_path = try std.fs.path.join(allocator, &.{ assets_dir, window_assets.paq_name });
+    defer allocator.free(paq_path);
+
+    var archive = try window_assets.AssetArchive.fromPath(allocator, paq_path);
+    defer archive.deinit();
+
+    var stats: SmokeStats = .{
+        .archive_entries = archive.entryCount(),
+    };
+
+    for (archive.normalized_names, 0..) |rel_path, idx| {
+        const payload = archive.archive.entries[idx].payload;
+        const decoded = try decodeArchiveEntry(allocator, rel_path, payload, &stats);
+        if (decoded) {
+            stats.decoded_entries += 1;
+        }
+    }
+
+    inline for (std.meta.fields(window_assets.TextureId)) |field| {
+        const texture_id: window_assets.TextureId = @enumFromInt(field.value);
+        const spec = window_assets.runtimeTextureSpec(texture_id);
+        stats.runtime_texture_specs += 1;
+
+        if (archive.get(spec.rel_path)) |payload| {
+            if (!try decodeImage(allocator, spec.rel_path, payload)) {
+                stats.failures += 1;
+            }
+        } else {
+            try printFailure(spec.rel_path, error.MissingTextureAsset);
+            stats.failures += 1;
+        }
+    }
+
+    if (archive.get(window_assets.small_font_widths_path) == null) {
+        try printFailure(window_assets.small_font_widths_path, error.MissingFontWidths);
+        stats.failures += 1;
+    }
+
+    return stats;
+}
+
+fn decodeArchiveEntry(allocator: std.mem.Allocator, rel_path: []const u8, payload: []const u8, stats: *SmokeStats) !bool {
+    return switch (window_assets.detectAssetFormat(rel_path)) {
+        .jaz => blk: {
+            stats.jaz_entries += 1;
+            break :blk try decodeImage(allocator, rel_path, payload);
+        },
+        .tga => blk: {
+            stats.tga_entries += 1;
+            break :blk try decodeImage(allocator, rel_path, payload);
+        },
+        .jpg => blk: {
+            stats.jpg_entries += 1;
+            break :blk try decodeImage(allocator, rel_path, payload);
+        },
+        .jpeg => blk: {
+            stats.jpeg_entries += 1;
+            break :blk try decodeImage(allocator, rel_path, payload);
+        },
+        .dat => blk: {
+            stats.dat_entries += 1;
+            break :blk false;
+        },
+        .unsupported => blk: {
+            stats.skipped_entries += 1;
+            break :blk false;
+        },
+    };
+}
+
+fn decodeImage(allocator: std.mem.Allocator, rel_path: []const u8, payload: []const u8) !bool {
+    var image = window_assets.decodeImageFromBytes(allocator, rel_path, payload) catch |err| {
+        try printFailure(rel_path, err);
+        return false;
+    };
+    defer image.unload();
+    return true;
+}
+
+fn printFailure(rel_path: []const u8, err: anyerror) !void {
+    var err_buf: [1024]u8 = undefined;
+    var err_writer = std.fs.File.stderr().writer(&err_buf);
+    const stderr = &err_writer.interface;
+    try stderr.print("asset-smoke failure: {s}: {s}\n", .{ rel_path, @errorName(err) });
+    try stderr.flush();
+}
+
+fn printUsage() !void {
+    try writeStdout(
+        \\Usage:
+        \\  zig build asset-smoke
+        \\  zig build asset-smoke -- /path/to/assets
+        \\
+        \\Runs a local decode smoke pass over crimson.paq and runtime-mapped assets.
+        \\
+    );
+}
+
+fn writeStdout(bytes: []const u8) !void {
+    var buffer: [1024]u8 = undefined;
+    var writer = std.fs.File.stdout().writer(&buffer);
+    const out = &writer.interface;
+    try out.writeAll(bytes);
+    try out.flush();
+}
+
+fn writeStderr(bytes: []const u8) !void {
+    var buffer: [1024]u8 = undefined;
+    var writer = std.fs.File.stderr().writer(&buffer);
+    const err = &writer.interface;
+    try err.writeAll(bytes);
+    try err.flush();
+}

--- a/crimson-zig/src/formats/mod.zig
+++ b/crimson-zig/src/formats/mod.zig
@@ -3,6 +3,7 @@ pub const crimson_cfg = @import("crimson_cfg.zig");
 pub const game_cfg = @import("game_cfg.zig");
 pub const jaz = @import("jaz.zig");
 pub const paq = @import("paq.zig");
+pub const tga = @import("tga.zig");
 
 test {
     _ = binary;
@@ -10,4 +11,5 @@ test {
     _ = game_cfg;
     _ = jaz;
     _ = paq;
+    _ = tga;
 }

--- a/crimson-zig/src/formats/tga.zig
+++ b/crimson-zig/src/formats/tga.zig
@@ -1,0 +1,184 @@
+const std = @import("std");
+const binary = @import("binary.zig");
+
+pub const TgaError = binary.BinaryError || std.mem.Allocator.Error || error{
+    UnsupportedColorMap,
+    UnsupportedImageType,
+    UnsupportedPixelDepth,
+    InvalidDimensions,
+    InvalidImageData,
+};
+
+pub const Header = struct {
+    id_length: u8,
+    color_map_type: u8,
+    image_type: u8,
+    color_map_origin: u16,
+    color_map_length: u16,
+    color_map_depth: u8,
+    x_origin: u16,
+    y_origin: u16,
+    width: u16,
+    height: u16,
+    pixel_depth: u8,
+    image_descriptor: u8,
+};
+
+pub const Image = struct {
+    width: u16,
+    height: u16,
+    pixels_rgba: []u8,
+
+    pub fn deinit(self: Image, allocator: std.mem.Allocator) void {
+        allocator.free(self.pixels_rgba);
+    }
+};
+
+const image_type_truecolor_rle: u8 = 10;
+const descriptor_origin_right: u8 = 0x10;
+const descriptor_origin_top: u8 = 0x20;
+
+pub fn decode(allocator: std.mem.Allocator, bytes: []const u8) TgaError!Image {
+    if (bytes.len < 18) return error.UnexpectedEof;
+
+    var reader = binary.Reader.init(bytes);
+    const header: Header = .{
+        .id_length = try reader.readU8(),
+        .color_map_type = try reader.readU8(),
+        .image_type = try reader.readU8(),
+        .color_map_origin = try reader.readU16Le(),
+        .color_map_length = try reader.readU16Le(),
+        .color_map_depth = try reader.readU8(),
+        .x_origin = try reader.readU16Le(),
+        .y_origin = try reader.readU16Le(),
+        .width = try reader.readU16Le(),
+        .height = try reader.readU16Le(),
+        .pixel_depth = try reader.readU8(),
+        .image_descriptor = try reader.readU8(),
+    };
+
+    _ = header.color_map_origin;
+    _ = header.color_map_length;
+    _ = header.color_map_depth;
+    _ = header.x_origin;
+    _ = header.y_origin;
+
+    if (header.color_map_type != 0) return error.UnsupportedColorMap;
+    if (header.image_type != image_type_truecolor_rle) return error.UnsupportedImageType;
+    if (header.pixel_depth != 32) return error.UnsupportedPixelDepth;
+    if (header.width == 0 or header.height == 0) return error.InvalidDimensions;
+
+    _ = try reader.readBytes(header.id_length);
+
+    const pixel_count = @as(usize, header.width) * @as(usize, header.height);
+    const pixels_rgba = try allocator.alloc(u8, pixel_count * 4);
+    errdefer allocator.free(pixels_rgba);
+
+    var emitted_pixels: usize = 0;
+    var encoded_y: usize = 0;
+    var encoded_x: usize = 0;
+    while (emitted_pixels < pixel_count) {
+        const packet_header = try reader.readU8();
+        const packet_count = @as(usize, (packet_header & 0x7f) + 1);
+        if (packet_count > pixel_count - emitted_pixels) return error.InvalidImageData;
+
+        if ((packet_header & 0x80) != 0) {
+            const pixel = try readPixel(reader.readBytes(4) catch return error.UnexpectedEof);
+            for (0..packet_count) |_| {
+                writePixel(
+                    pixels_rgba,
+                    header,
+                    encoded_x,
+                    encoded_y,
+                    pixel,
+                );
+                advanceCursor(header, &encoded_x, &encoded_y);
+                emitted_pixels += 1;
+            }
+        } else {
+            for (0..packet_count) |_| {
+                const pixel = try readPixel(reader.readBytes(4) catch return error.UnexpectedEof);
+                writePixel(
+                    pixels_rgba,
+                    header,
+                    encoded_x,
+                    encoded_y,
+                    pixel,
+                );
+                advanceCursor(header, &encoded_x, &encoded_y);
+                emitted_pixels += 1;
+            }
+        }
+    }
+
+    return .{
+        .width = header.width,
+        .height = header.height,
+        .pixels_rgba = pixels_rgba,
+    };
+}
+
+fn readPixel(raw: []const u8) TgaError![4]u8 {
+    if (raw.len != 4) return error.InvalidImageData;
+    return .{ raw[2], raw[1], raw[0], raw[3] };
+}
+
+fn advanceCursor(header: Header, encoded_x: *usize, encoded_y: *usize) void {
+    encoded_x.* += 1;
+    if (encoded_x.* >= header.width) {
+        encoded_x.* = 0;
+        encoded_y.* += 1;
+    }
+}
+
+fn writePixel(
+    pixels_rgba: []u8,
+    header: Header,
+    encoded_x: usize,
+    encoded_y: usize,
+    pixel: [4]u8,
+) void {
+    const width_usize: usize = header.width;
+    const height_usize: usize = header.height;
+    const out_x = if ((header.image_descriptor & descriptor_origin_right) != 0)
+        width_usize - 1 - encoded_x
+    else
+        encoded_x;
+    const out_y = if ((header.image_descriptor & descriptor_origin_top) != 0)
+        encoded_y
+    else
+        height_usize - 1 - encoded_y;
+
+    const offset = (out_y * width_usize + out_x) * 4;
+    pixels_rgba[offset..][0..4].* = pixel;
+}
+
+test "decode RLE 32-bit TGA with bottom-left origin" {
+    const allocator = std.testing.allocator;
+    const bytes = [_]u8{
+        0,    0,    10,   0,    0,    0,    0,    0,    0,    0,    0,    0,
+        2,    0,    2,    0,    32,   8,    0x81, 0x01, 0x02, 0x03, 0x04, 0x01,
+        0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+    };
+
+    const image = try decode(allocator, &bytes);
+    defer image.deinit(allocator);
+
+    try std.testing.expectEqual(@as(u16, 2), image.width);
+    try std.testing.expectEqual(@as(u16, 2), image.height);
+    try std.testing.expectEqualSlices(u8, &[_]u8{
+        0x07, 0x06, 0x05, 0x08,
+        0x0b, 0x0a, 0x09, 0x0c,
+        0x03, 0x02, 0x01, 0x04,
+        0x03, 0x02, 0x01, 0x04,
+    }, image.pixels_rgba);
+}
+
+test "decode rejects unsupported pixel depth" {
+    const allocator = std.testing.allocator;
+    const bytes = [_]u8{
+        0, 0, 10, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+        1, 0, 1,  0, 24, 0,
+    };
+    try std.testing.expectError(error.UnsupportedPixelDepth, decode(allocator, &bytes));
+}

--- a/crimson-zig/src/window_assets.zig
+++ b/crimson-zig/src/window_assets.zig
@@ -100,7 +100,7 @@ pub const AssetArchiveError = formats.paq.PaqError || std.mem.Allocator.Error ||
     InvalidAssetPath,
 };
 
-pub const DecodeImageError = formats.jaz.JazError || std.mem.Allocator.Error || rl.RaylibError || error{
+pub const DecodeImageError = formats.jaz.JazError || formats.tga.TgaError || std.mem.Allocator.Error || rl.RaylibError || error{
     InvalidImageDimensions,
     UnsupportedTextureFormat,
 };
@@ -224,7 +224,7 @@ pub fn detectAssetFormat(rel_path: []const u8) AssetFormat {
 pub fn decodeImageFromBytes(allocator: std.mem.Allocator, rel_path: []const u8, bytes: []const u8) DecodeImageError!rl.Image {
     return switch (detectAssetFormat(rel_path)) {
         .jaz => decodeJazImage(allocator, bytes),
-        .tga => rl.loadImageFromMemory(".tga", bytes),
+        .tga => decodeTgaImage(bytes),
         .jpg => rl.loadImageFromMemory(".jpg", bytes),
         .jpeg => rl.loadImageFromMemory(".jpeg", bytes),
         else => error.UnsupportedTextureFormat,
@@ -412,6 +412,17 @@ fn decodeJazImage(allocator: std.mem.Allocator, bytes: []const u8) DecodeImageEr
     }
 
     return image;
+}
+
+fn decodeTgaImage(bytes: []const u8) DecodeImageError!rl.Image {
+    const decoded = try formats.tga.decode(std.heap.c_allocator, bytes);
+    return .{
+        .data = @ptrCast(decoded.pixels_rgba.ptr),
+        .width = decoded.width,
+        .height = decoded.height,
+        .mipmaps = 1,
+        .format = .uncompressed_r8g8b8a8,
+    };
 }
 
 fn textureSpec(texture_id: TextureId) TextureSpec {

--- a/crimson-zig/src/window_assets.zig
+++ b/crimson-zig/src/window_assets.zig
@@ -277,7 +277,8 @@ pub fn loadRuntimeAssetsFromDefaultSearch(allocator: std.mem.Allocator) LoadRunt
 
     if (env_assets_dir) |dir| {
         if (try archiveExistsAtDir(allocator, dir)) {
-            return loadRuntimeAssets(allocator, dir);
+            const assets = try loadRuntimeAssets(allocator, dir);
+            return assets;
         }
     }
 
@@ -287,7 +288,8 @@ pub fn loadRuntimeAssetsFromDefaultSearch(allocator: std.mem.Allocator) LoadRunt
     };
     for (default_candidates) |candidate| {
         if (try archiveExistsAtDir(allocator, candidate)) {
-            return loadRuntimeAssets(allocator, candidate);
+            const assets = try loadRuntimeAssets(allocator, candidate);
+            return assets;
         }
     }
 

--- a/crimson-zig/src/window_assets.zig
+++ b/crimson-zig/src/window_assets.zig
@@ -282,6 +282,16 @@ pub fn loadRuntimeAssetsFromDefaultSearch(allocator: std.mem.Allocator) LoadRunt
         }
     }
 
+    const runtime_dir = try defaultRuntimeDir(allocator);
+    defer if (runtime_dir) |dir| allocator.free(dir);
+
+    if (runtime_dir) |dir| {
+        if (try archiveExistsAtDir(allocator, dir)) {
+            const assets = try loadRuntimeAssets(allocator, dir);
+            return assets;
+        }
+    }
+
     const default_candidates = [_][]const u8{
         "artifacts/assets",
         ".",
@@ -294,6 +304,61 @@ pub fn loadRuntimeAssetsFromDefaultSearch(allocator: std.mem.Allocator) LoadRunt
     }
 
     return null;
+}
+
+fn defaultRuntimeDir(allocator: std.mem.Allocator) (std.process.GetEnvVarOwnedError || std.mem.Allocator.Error)!?[]u8 {
+    if (builtin.target.os.tag == .emscripten or builtin.target.os.tag == .freestanding) {
+        return null;
+    }
+
+    if (std.process.getEnvVarOwned(allocator, "CRIMSON_RUNTIME_DIR")) |path| {
+        return path;
+    } else |err| switch (err) {
+        error.EnvironmentVariableNotFound => {},
+        else => return err,
+    }
+
+    if (std.process.getEnvVarOwned(allocator, "CRIMSON_BASE_DIR")) |path| {
+        return path;
+    } else |err| switch (err) {
+        error.EnvironmentVariableNotFound => {},
+        else => return err,
+    }
+
+    return switch (builtin.target.os.tag) {
+        .macos => blk: {
+            const home = std.process.getEnvVarOwned(allocator, "HOME") catch |err| switch (err) {
+                error.EnvironmentVariableNotFound => return null,
+                else => return err,
+            };
+            defer allocator.free(home);
+            break :blk try std.fs.path.join(allocator, &.{ home, "Library", "Application Support", "banteg", "crimsonland" });
+        },
+        .windows => blk: {
+            const appdata = std.process.getEnvVarOwned(allocator, "APPDATA") catch |err| switch (err) {
+                error.EnvironmentVariableNotFound => return null,
+                else => return err,
+            };
+            defer allocator.free(appdata);
+            break :blk try std.fs.path.join(allocator, &.{ appdata, "banteg", "crimsonland" });
+        },
+        else => blk: {
+            if (std.process.getEnvVarOwned(allocator, "XDG_DATA_HOME")) |xdg_data_home| {
+                defer allocator.free(xdg_data_home);
+                break :blk try std.fs.path.join(allocator, &.{ xdg_data_home, "banteg", "crimsonland" });
+            } else |err| switch (err) {
+                error.EnvironmentVariableNotFound => {},
+                else => return err,
+            }
+
+            const home = std.process.getEnvVarOwned(allocator, "HOME") catch |err| switch (err) {
+                error.EnvironmentVariableNotFound => return null,
+                else => return err,
+            };
+            defer allocator.free(home);
+            break :blk try std.fs.path.join(allocator, &.{ home, ".local", "share", "banteg", "crimsonland" });
+        },
+    };
 }
 
 fn archiveExistsAtDir(allocator: std.mem.Allocator, dir_path: []const u8) (std.mem.Allocator.Error || std.fs.Dir.AccessError)!bool {
@@ -481,4 +546,16 @@ test "decode image rejects unsupported extensions" {
         error.UnsupportedTextureFormat,
         decodeImageFromBytes(std.testing.allocator, "test.dat", "abc"),
     );
+}
+
+test "default runtime dir matches python platformdirs layout on supported targets" {
+    const allocator = std.testing.allocator;
+    const runtime_dir = (try defaultRuntimeDir(allocator)) orelse return;
+    defer allocator.free(runtime_dir);
+
+    switch (builtin.target.os.tag) {
+        .macos => try std.testing.expect(std.mem.endsWith(u8, runtime_dir, "/Library/Application Support/banteg/crimsonland")),
+        .windows => try std.testing.expect(std.mem.endsWith(u8, runtime_dir, "\\banteg\\crimsonland") or std.mem.endsWith(u8, runtime_dir, "/banteg/crimsonland")),
+        else => try std.testing.expect(std.mem.endsWith(u8, runtime_dir, "/banteg/crimsonland")),
+    }
 }

--- a/crimson-zig/src/window_assets.zig
+++ b/crimson-zig/src/window_assets.zig
@@ -208,6 +208,10 @@ pub const RuntimeAssets = struct {
 
 pub const texture_count = std.meta.fields(TextureId).len;
 
+pub fn runtimeTextureSpec(texture_id: TextureId) TextureSpec {
+    return textureSpec(texture_id);
+}
+
 pub fn detectAssetFormat(rel_path: []const u8) AssetFormat {
     if (std.ascii.endsWithIgnoreCase(rel_path, ".jaz")) return .jaz;
     if (std.ascii.endsWithIgnoreCase(rel_path, ".tga")) return .tga;
@@ -266,30 +270,28 @@ pub fn loadRuntimeAssets(allocator: std.mem.Allocator, assets_dir: []const u8) L
     };
 }
 
-pub fn loadRuntimeAssetsFromDefaultSearch(allocator: std.mem.Allocator) LoadRuntimeAssetsError!?RuntimeAssets {
+pub fn resolveRuntimeAssetsDir(allocator: std.mem.Allocator) LoadRuntimeAssetsError!?[]u8 {
     if (builtin.target.os.tag == .emscripten) return null;
 
     const env_assets_dir = std.process.getEnvVarOwned(allocator, "CRIMSON_ASSETS_DIR") catch |err| switch (err) {
         error.EnvironmentVariableNotFound => null,
         else => return err,
     };
-    defer if (env_assets_dir) |dir| allocator.free(dir);
 
     if (env_assets_dir) |dir| {
         if (try archiveExistsAtDir(allocator, dir)) {
-            const assets = try loadRuntimeAssets(allocator, dir);
-            return assets;
+            return dir;
         }
+        allocator.free(dir);
     }
 
     const runtime_dir = try defaultRuntimeDir(allocator);
-    defer if (runtime_dir) |dir| allocator.free(dir);
 
     if (runtime_dir) |dir| {
         if (try archiveExistsAtDir(allocator, dir)) {
-            const assets = try loadRuntimeAssets(allocator, dir);
-            return assets;
+            return dir;
         }
+        allocator.free(dir);
     }
 
     const default_candidates = [_][]const u8{
@@ -298,12 +300,19 @@ pub fn loadRuntimeAssetsFromDefaultSearch(allocator: std.mem.Allocator) LoadRunt
     };
     for (default_candidates) |candidate| {
         if (try archiveExistsAtDir(allocator, candidate)) {
-            const assets = try loadRuntimeAssets(allocator, candidate);
-            return assets;
+            const owned_candidate = try allocator.dupe(u8, candidate);
+            return owned_candidate;
         }
     }
 
     return null;
+}
+
+pub fn loadRuntimeAssetsFromDefaultSearch(allocator: std.mem.Allocator) LoadRuntimeAssetsError!?RuntimeAssets {
+    const assets_dir = (try resolveRuntimeAssetsDir(allocator)) orelse return null;
+    defer allocator.free(assets_dir);
+    const assets = try loadRuntimeAssets(allocator, assets_dir);
+    return assets;
 }
 
 fn defaultRuntimeDir(allocator: std.mem.Allocator) (std.process.GetEnvVarOwnedError || std.mem.Allocator.Error)!?[]u8 {

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -4,9 +4,12 @@ const rl = @import("raylib");
 const cz = @import("crimson_zig");
 const window_assets = @import("window_assets.zig");
 
+const bonuses_runtime = cz.bonuses;
 const game_ids = cz.game_ids;
 const live_runner = cz.live_runner;
+const secondary_projectiles_runtime = cz.secondary_projectiles;
 const runtime_session = cz.session;
+const spawn_runtime = cz.spawn;
 const state_mod = cz.state;
 
 const window_width = 1280;
@@ -282,19 +285,19 @@ const App = struct {
 
         if (self.gameplay) |*gameplay| {
             const runner = &gameplay.runner;
+            const runtime_assets: ?*const window_assets.RuntimeAssets = if (self.runtime_assets) |*loaded_assets| loaded_assets else null;
             const camera = buildWorldCamera(
                 runner.session.world_size,
                 runner.session.state.camera_shake_offset,
             );
 
             camera.begin();
-            defer camera.end();
-
-            drawWorld(runner);
-            drawPlayers(runner);
-            drawCreatures(runner);
-            drawProjectiles(runner);
-            drawBonuses(runner);
+            drawWorld(runner, runtime_assets);
+            drawPlayers(runner, runtime_assets);
+            drawCreatures(runner, runtime_assets);
+            drawProjectiles(runner, runtime_assets);
+            drawBonuses(runner, runtime_assets);
+            camera.end();
 
             drawGameplayHud(runner, gameplay.last_update);
             if (gameplay.last_update.paused_for_perk_pick) {
@@ -441,6 +444,32 @@ fn drawTextureCentered(texture: rl.Texture2D, center: rl.Vector2, width: f32, he
     );
 }
 
+fn drawTextureCenteredRotated(texture: rl.Texture2D, center: rl.Vector2, width: f32, height: f32, rotation_deg: f32, tint: rl.Color) void {
+    const src = rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height));
+    const dest = rl.Rectangle.init(center.x, center.y, width, height);
+    rl.drawTexturePro(texture, src, dest, rl.Vector2.init(width * 0.5, height * 0.5), rotation_deg, tint);
+}
+
+fn drawTextureTiled(texture: rl.Texture2D, area: rl.Rectangle, tint: rl.Color) void {
+    const tile_width = @as(f32, @floatFromInt(texture.width));
+    const tile_height = @as(f32, @floatFromInt(texture.height));
+    if (!(tile_width > 0.0 and tile_height > 0.0 and area.width > 0.0 and area.height > 0.0)) return;
+
+    const max_x = area.x + area.width;
+    const max_y = area.y + area.height;
+    var y = area.y;
+    while (y < max_y - 0.001) : (y += tile_height) {
+        const draw_height = @min(tile_height, max_y - y);
+        var x = area.x;
+        while (x < max_x - 0.001) : (x += tile_width) {
+            const draw_width = @min(tile_width, max_x - x);
+            const src = rl.Rectangle.init(0.0, 0.0, draw_width, draw_height);
+            const dest = rl.Rectangle.init(x, y, draw_width, draw_height);
+            rl.drawTexturePro(texture, src, dest, rl.Vector2.zero(), 0.0, tint);
+        }
+    }
+}
+
 fn mainMenuButtons() [2]UiButton {
     const center_x: f32 = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
     return .{
@@ -559,68 +588,150 @@ fn axisFromKeys(negative: rl.KeyboardKey, positive: rl.KeyboardKey) f32 {
     return value;
 }
 
-fn drawWorld(runner: *const live_runner.LiveSurvivalRunner) void {
-    const terrain = runner.session.terrain_size;
+fn drawWorld(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     const world_size = runner.session.world_size;
-    rl.drawRectangleRec(.{
+    const world_rect = rl.Rectangle.init(0.0, 0.0, world_size, world_size);
+
+    if (runtime_assets) |assets| {
+        const terrain_set = terrainTextureSet(runner.session.quest_unlock_index);
+        drawTextureTiled(assets.texture(terrain_set.base), world_rect, rl.Color.white);
+        drawTextureTiled(assets.texture(terrain_set.overlay), world_rect, rl.Color.init(255, 255, 255, 124));
+        rl.drawRectangleRec(world_rect, rl.Color.init(16, 11, 9, 34));
+    } else {
+        rl.drawRectangleRec(world_rect, arena_color);
+
+        var coord: i32 = 0;
+        while (coord <= runner.session.terrain_size) : (coord += 128) {
+            const line_pos: f32 = @floatFromInt(coord);
+            rl.drawLineV(rl.Vector2.init(line_pos, 0.0), rl.Vector2.init(line_pos, world_size), arena_grid);
+            rl.drawLineV(rl.Vector2.init(0.0, line_pos), rl.Vector2.init(world_size, line_pos), arena_grid);
+        }
+    }
+
+    rl.drawRectangleLinesEx(.{
         .x = 0.0,
         .y = 0.0,
         .width = world_size,
         .height = world_size,
-    }, arena_color);
-
-    var coord: i32 = 0;
-    while (coord <= terrain) : (coord += 128) {
-        const line_pos: f32 = @floatFromInt(coord);
-        rl.drawLineV(rl.Vector2.init(line_pos, 0.0), rl.Vector2.init(line_pos, world_size), arena_grid);
-        rl.drawLineV(rl.Vector2.init(0.0, line_pos), rl.Vector2.init(world_size, line_pos), arena_grid);
-    }
-    rl.drawRectangleLinesEx(
-        .{
-            .x = 0.0,
-            .y = 0.0,
-            .width = world_size,
-            .height = world_size,
-        },
-        4.0,
-        border_color,
-    );
+    }, 4.0, border_color);
 }
 
-fn drawPlayers(runner: *const live_runner.LiveSurvivalRunner) void {
+fn drawPlayers(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     for (runner.session.playersConst()) |player| {
         const center = toRlVec(player.pos);
         const radius = @max(10.0, player.size * 0.28);
         const color = if (player.health > 0.0) player_color else dead_player_color;
-        rl.drawCircleV(center, radius, color);
-        rl.drawCircleLinesV(center, radius + 2.0, rl.Color.black);
+
+        if (runtime_assets) |assets| {
+            const base_tint = if (player.health > 0.0) rl.Color.white else dead_player_color;
+            drawTextureCenteredRotated(
+                assets.texture(.trooper),
+                center,
+                player.size * 1.2,
+                player.size * 1.2,
+                headingToDegrees(player.aim_heading),
+                base_tint,
+            );
+
+            if (player.health > 0.0 and player.muzzle_flash_alpha > 0.02) {
+                drawTextureCenteredRotated(
+                    assets.texture(.muzzle_flash),
+                    toRlVec(player.aim),
+                    player.size * 0.72,
+                    player.size * 0.72,
+                    headingToDegrees(player.aim_heading),
+                    colorWithAlpha(rl.Color.white, std.math.clamp(player.muzzle_flash_alpha, @as(f32, 0.0), @as(f32, 1.0))),
+                );
+            }
+        } else {
+            rl.drawCircleV(center, radius, color);
+            rl.drawCircleLinesV(center, radius + 2.0, rl.Color.black);
+        }
+
         rl.drawLineEx(center, toRlVec(player.aim), 2.0, rl.Color.gold);
     }
 }
 
-fn drawCreatures(runner: *const live_runner.LiveSurvivalRunner) void {
+fn drawCreatures(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     for (runner.session.creatures.entries) |creature| {
         if (!creature.active) continue;
         const color = if (creature.hp > 0.0) creature_color else corpse_color;
         const radius = @max(6.0, creature.size * 0.24);
+        if (runtime_assets) |assets| {
+            if (creatureTextureId(creature)) |texture_id| {
+                drawTextureCenteredRotated(
+                    assets.texture(texture_id),
+                    toRlVec(creature.pos),
+                    creature.size * 1.14,
+                    creature.size * 1.14,
+                    headingToDegrees(creature.heading),
+                    if (creature.hp > 0.0) rl.Color.white else corpse_color,
+                );
+                continue;
+            }
+        }
         rl.drawCircleV(toRlVec(creature.pos), radius, color);
     }
 }
 
-fn drawProjectiles(runner: *const live_runner.LiveSurvivalRunner) void {
+fn drawProjectiles(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     for (runner.session.projectiles.entries) |projectile| {
         if (!projectile.active) continue;
+        if (runtime_assets) |assets| {
+            const projectile_texture = projectileTextureId(projectile.type_id) orelse {
+                rl.drawCircleV(toRlVec(projectile.pos), 3.0, projectile_color);
+                continue;
+            };
+            const sprite_size = projectileSpriteSize(projectile.type_id);
+            drawTextureCenteredRotated(
+                assets.texture(projectile_texture),
+                toRlVec(projectile.pos),
+                sprite_size,
+                sprite_size,
+                headingToDegrees(projectile.angle),
+                rl.Color.white,
+            );
+            continue;
+        }
         rl.drawCircleV(toRlVec(projectile.pos), 3.0, projectile_color);
     }
     for (runner.session.secondary_projectiles.entries) |projectile| {
         if (!projectile.active) continue;
+        if (runtime_assets) |assets| {
+            if (secondaryProjectileTextureId(projectile.type_id)) |texture_id| {
+                const sprite_size = secondaryProjectileSpriteSize(projectile);
+                drawTextureCenteredRotated(
+                    assets.texture(texture_id),
+                    toRlVec(projectile.pos),
+                    sprite_size,
+                    sprite_size,
+                    headingToDegrees(projectile.angle),
+                    colorWithAlpha(rl.Color.white, secondaryProjectileAlpha(projectile)),
+                );
+                continue;
+            }
+        }
         rl.drawCircleV(toRlVec(projectile.pos), 6.0, secondary_projectile_color);
     }
 }
 
-fn drawBonuses(runner: *const live_runner.LiveSurvivalRunner) void {
+fn drawBonuses(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     for (runner.session.bonuses.entries) |entry| {
         if (entry.bonus_id == .unused) continue;
+        if (runtime_assets) |assets| {
+            if (bonusTextureId(entry)) |texture_id| {
+                const alpha = bonusAlpha(entry);
+                drawTextureCenteredRotated(
+                    assets.texture(texture_id),
+                    toRlVec(entry.pos),
+                    26.0,
+                    26.0,
+                    0.0,
+                    colorWithAlpha(rl.Color.white, alpha),
+                );
+                continue;
+            }
+        }
         rl.drawRectangleRec(
             .{
                 .x = entry.pos.x - 8.0,
@@ -631,6 +742,139 @@ fn drawBonuses(runner: *const live_runner.LiveSurvivalRunner) void {
             bonus_color,
         );
     }
+}
+
+const TerrainTextureSet = struct {
+    base: window_assets.TextureId,
+    overlay: window_assets.TextureId,
+};
+
+fn terrainTextureSet(quest_unlock_index: i32) TerrainTextureSet {
+    return if (quest_unlock_index >= 40)
+        .{ .base = .ter_q4_base, .overlay = .ter_q4_overlay }
+    else if (quest_unlock_index >= 30)
+        .{ .base = .ter_q3_base, .overlay = .ter_q3_overlay }
+    else if (quest_unlock_index >= 20)
+        .{ .base = .ter_q2_base, .overlay = .ter_q2_overlay }
+    else
+        .{ .base = .ter_q1_base, .overlay = .ter_q1_overlay };
+}
+
+fn creatureTextureId(creature: cz.creatures.CreatureState) ?window_assets.TextureId {
+    const creature_type = std.meta.intToEnum(spawn_runtime.CreatureTypeId, creature.type_id) catch return null;
+    return switch (creature_type) {
+        .alien => .alien,
+        .lizard => .lizard,
+        .spider_sp1 => .spider_sp1,
+        .spider_sp2 => .spider_sp2,
+        .trooper => .trooper,
+        .zombie => .zombie,
+    };
+}
+
+fn projectileTextureId(projectile_type_raw: i32) ?window_assets.TextureId {
+    const projectile_type = std.meta.intToEnum(game_ids.ProjectileTypeId, projectile_type_raw) catch return null;
+    return switch (projectile_type) {
+        .pistol,
+        .assault_rifle,
+        .shotgun,
+        .submachine_gun,
+        => .bullet_i,
+        .gauss_gun,
+        .plasma_rifle,
+        .plasma_minigun,
+        .pulse_gun,
+        .ion_rifle,
+        .ion_minigun,
+        .ion_cannon,
+        .shrinkifier,
+        .blade_gun,
+        .spider_plasma,
+        .plasma_cannon,
+        .splitter_gun,
+        .plague_spreader,
+        .rainbow_gun,
+        .fire_bullets,
+        => .bullet_trail,
+    };
+}
+
+fn projectileSpriteSize(projectile_type_raw: i32) f32 {
+    const projectile_type = std.meta.intToEnum(game_ids.ProjectileTypeId, projectile_type_raw) catch return 10.0;
+    return switch (projectile_type) {
+        .ion_cannon,
+        .plasma_cannon,
+        => 26.0,
+        .ion_rifle,
+        .ion_minigun,
+        .plasma_rifle,
+        .plasma_minigun,
+        .pulse_gun,
+        => 18.0,
+        .gauss_gun,
+        .blade_gun,
+        => 16.0,
+        else => 12.0,
+    };
+}
+
+fn secondaryProjectileTextureId(projectile_type: secondary_projectiles_runtime.SecondaryProjectileTypeId) ?window_assets.TextureId {
+    return switch (projectile_type) {
+        .rocket, .homing_rocket, .rocket_minigun => .arrow,
+        .detonation => .muzzle_flash,
+        .none => null,
+    };
+}
+
+fn secondaryProjectileSpriteSize(projectile: secondary_projectiles_runtime.SecondaryProjectile) f32 {
+    return switch (projectile.type_id) {
+        .rocket => 26.0,
+        .homing_rocket => 30.0,
+        .rocket_minigun => 22.0,
+        .detonation => 96.0 * projectile.detonation_scale * @max(0.35, projectile.detonation_t),
+        .none => 18.0,
+    };
+}
+
+fn secondaryProjectileAlpha(projectile: secondary_projectiles_runtime.SecondaryProjectile) f32 {
+    return switch (projectile.type_id) {
+        .detonation => std.math.clamp(1.0 - projectile.detonation_t * 0.5, @as(f32, 0.15), @as(f32, 1.0)),
+        else => 1.0,
+    };
+}
+
+fn bonusTextureId(entry: bonuses_runtime.BonusEntry) ?window_assets.TextureId {
+    return switch (entry.bonus_id) {
+        .unused => null,
+        .points, .energizer, .double_experience => .ui_arrow,
+        .weapon, .weapon_power_up => .ui_ind_bullet,
+        .nuke => .ui_ind_rocket,
+        .shock_chain => .ui_ind_electric,
+        .fireblast, .fire_bullets => .ui_ind_fire,
+        .reflex_boost => .ui_icon_aim,
+        .shield, .medikit => .ui_ind_life,
+        .freeze => .ui_ind_panel,
+        .speed => .arrow,
+    };
+}
+
+fn bonusAlpha(entry: bonuses_runtime.BonusEntry) f32 {
+    if (entry.picked) return 0.42;
+    if (!(entry.time_max > 0.0)) return 1.0;
+    return std.math.clamp(entry.time_left / entry.time_max, @as(f32, 0.28), @as(f32, 1.0));
+}
+
+fn colorWithAlpha(color: rl.Color, alpha: f32) rl.Color {
+    return rl.Color.init(
+        color.r,
+        color.g,
+        color.b,
+        @intFromFloat(std.math.clamp(alpha, @as(f32, 0.0), @as(f32, 1.0)) * 255.0),
+    );
+}
+
+fn headingToDegrees(heading: f32) f32 {
+    return heading * (180.0 / std.math.pi);
 }
 
 fn drawGameplayHud(runner: *live_runner.LiveSurvivalRunner, update: live_runner.FrameUpdate) void {


### PR DESCRIPTION
## Summary
- switch the desktop playable slice from primitive-only world rendering to asset-backed terrain and sprite draws
- render players, creatures, projectiles, and bonuses through runtime asset mappings with primitive fallback when a clean mapping is still missing
- align desktop runtime asset discovery with Python by checking `CRIMSON_ASSETS_DIR`, then `CRIMSON_RUNTIME_DIR` / `CRIMSON_BASE_DIR`, then the same per-user platform data dir layout before local checkout fallbacks

## Testing
- zig build test
- zig build window
- zig build wasm
- just docs-check
- push hooks: zig-test, zig-release, zig-wasm
