### PR TITLE
feat(zig): port deterministic ground rendering

### DIFF
--- a/crimson-zig/src/root.zig
+++ b/crimson-zig/src/root.zig
@@ -13,6 +13,7 @@ pub const state = @import("runtime/state.zig");
 pub const weapons = @import("runtime/weapons.zig");
 pub const projectiles = @import("runtime/projectiles.zig");
 pub const bonuses = @import("runtime/bonuses.zig");
+pub const bootstrap = @import("runtime/bootstrap.zig");
 pub const session = @import("runtime/session.zig");
 pub const session_builders = @import("runtime/session_builders.zig");
 pub const live_runner = @import("runtime/live_runner.zig");

--- a/crimson-zig/src/runtime/bootstrap.zig
+++ b/crimson-zig/src/runtime/bootstrap.zig
@@ -14,6 +14,24 @@ const terrain_density_shift: u6 = 19;
 const terrain_rand_draws_per_stamp: u64 = 3;
 const rush_forced_ammo: f32 = 30.0;
 
+pub const TerrainSlotTriplet = [3]u8;
+
+pub const TerrainSetup = struct {
+    terrain_slots: TerrainSlotTriplet,
+    terrain_seed: u32,
+};
+
+const default_terrain_slots: TerrainSlotTriplet = .{ 0, 1, 0 };
+
+const unlock_terrain_slots = [_]struct {
+    threshold: i32,
+    slots: TerrainSlotTriplet,
+}{
+    .{ .threshold = 40, .slots = .{ 6, 7, 6 } },
+    .{ .threshold = 30, .slots = .{ 4, 5, 4 } },
+    .{ .threshold = 20, .slots = .{ 2, 3, 2 } },
+};
+
 pub const ParsedQuestLevel = struct {
     major: i32,
     minor: i32,
@@ -85,6 +103,21 @@ pub fn advanceReplayBootstrapRng(
     }
 }
 
+pub fn previewUnlockTerrain(
+    seed: u32,
+    unlock_index: i32,
+    terrain_width: i32,
+    terrain_height: i32,
+) TerrainSetup {
+    var rng = spawn_mod.Crand.init(seed);
+    return advanceUnlockTerrain(
+        &rng,
+        unlock_index,
+        terrain_width,
+        terrain_height,
+    );
+}
+
 fn terrainStampingDraws(width: i32, height: i32) usize {
     const clamped_width: u64 = @intCast(@max(width, 0));
     const clamped_height: u64 = @intCast(@max(height, 0));
@@ -105,18 +138,50 @@ fn advanceUnlockTerrainRng(
     width: i32,
     height: i32,
 ) void {
+    _ = advanceUnlockTerrain(rng, unlock_index, width, height);
+}
+
+fn advanceUnlockTerrain(
+    rng: *spawn_mod.Crand,
+    unlock_index: i32,
+    width: i32,
+    height: i32,
+) TerrainSetup {
     advanceRng(rng, terrain_random_prelude_draws);
-    if (unlock_index >= 40 and (rng.rand() & 7) == 3) {
-        advanceRng(rng, terrainStampingDraws(width, height));
-        return;
-    }
-    if (unlock_index >= 30 and (rng.rand() & 7) == 3) {
-        advanceRng(rng, terrainStampingDraws(width, height));
-        return;
-    }
-    if (unlock_index >= 20 and (rng.rand() & 7) == 3) {
-        advanceRng(rng, terrainStampingDraws(width, height));
-        return;
-    }
+    const terrain_slots = chooseUnlockTerrainSlots(rng, unlock_index);
+    const terrain_seed = rng.state;
     advanceRng(rng, terrainStampingDraws(width, height));
+    return .{
+        .terrain_slots = terrain_slots,
+        .terrain_seed = terrain_seed,
+    };
+}
+
+fn chooseUnlockTerrainSlots(
+    rng: *spawn_mod.Crand,
+    unlock_index: i32,
+) TerrainSlotTriplet {
+    for (unlock_terrain_slots) |entry| {
+        if (unlock_index >= entry.threshold and (rng.rand() & 7) == 3) {
+            return entry.slots;
+        }
+    }
+    return default_terrain_slots;
+}
+
+test "preview unlock terrain matches replay bootstrap rng advance for survival" {
+    const terrain = previewUnlockTerrain(0xBEEF, 30, 1024, 1024);
+
+    var expected_rng = spawn_mod.Crand.init(0xBEEF);
+    advanceRng(&expected_rng, terrain_random_prelude_draws);
+    const expected_slots = chooseUnlockTerrainSlots(&expected_rng, 30);
+    const expected_seed = expected_rng.state;
+    advanceRng(&expected_rng, terrainStampingDraws(1024, 1024));
+
+    var rng = spawn_mod.Crand.init(0xBEEF);
+    advanceReplayBootstrapRng(&rng, .survival, 30, 1024, 1024);
+
+    try std.testing.expectEqualDeep(expected_slots, terrain.terrain_slots);
+    try std.testing.expectEqual(expected_seed, terrain.terrain_seed);
+    try std.testing.expectEqual(expected_rng.state, rng.state);
 }

--- a/crimson-zig/src/runtime/live_runner.zig
+++ b/crimson-zig/src/runtime/live_runner.zig
@@ -63,6 +63,7 @@ pub fn defaultGameInput() player_runtime.GameInput {
 }
 
 pub const LiveSurvivalRunner = struct {
+    seed: u32,
     session: runtime_session.DeterministicSession,
     accumulator: f32 = 0.0,
     max_substeps_per_frame: usize = 8,
@@ -86,6 +87,7 @@ pub const LiveSurvivalRunner = struct {
         );
 
         return .{
+            .seed = config.seed,
             .session = session,
         };
     }

--- a/crimson-zig/src/window_ground.zig
+++ b/crimson-zig/src/window_ground.zig
@@ -1,0 +1,259 @@
+const std = @import("std");
+const rl = @import("raylib");
+
+const cz = @import("crimson_zig");
+const window_assets = @import("window_assets.zig");
+
+const runtime_bootstrap = cz.bootstrap;
+const spawn_runtime = cz.spawn;
+
+const terrain_texture_size: i32 = 1024;
+const terrain_patch_size: f32 = 128.0;
+const terrain_patch_overscan: i32 = 64;
+const terrain_density_base: i64 = 800;
+const terrain_density_overlay: i64 = 0x23;
+const terrain_density_detail: i64 = 0x0F;
+const terrain_density_shift: u6 = 19;
+const terrain_rotation_max: u32 = 0x13A;
+
+const terrain_clear_color = rl.Color.init(63, 56, 25, 255);
+const terrain_base_tint = rl.Color.init(178, 178, 178, 230);
+const terrain_overlay_tint = rl.Color.init(178, 178, 178, 230);
+const terrain_detail_tint = rl.Color.init(178, 178, 178, 153);
+
+const alpha_test_vs: [:0]const u8 =
+    \\#version 330
+    \\
+    \\in vec3 vertexPosition;
+    \\in vec2 vertexTexCoord;
+    \\in vec4 vertexColor;
+    \\
+    \\out vec2 fragTexCoord;
+    \\out vec4 fragColor;
+    \\
+    \\uniform mat4 mvp;
+    \\
+    \\void main() {
+    \\    fragTexCoord = vertexTexCoord;
+    \\    fragColor = vertexColor;
+    \\    gl_Position = mvp * vec4(vertexPosition, 1.0);
+    \\}
+;
+
+const alpha_test_fs: [:0]const u8 =
+    \\#version 330
+    \\
+    \\in vec2 fragTexCoord;
+    \\in vec4 fragColor;
+    \\
+    \\uniform sampler2D texture0;
+    \\uniform vec4 colDiffuse;
+    \\
+    \\out vec4 finalColor;
+    \\
+    \\void main() {
+    \\    vec4 texel = texture(texture0, fragTexCoord) * fragColor * colDiffuse;
+    \\    if (texel.a <= 0.0156862745) discard;
+    \\    finalColor = texel;
+    \\}
+;
+
+pub const GroundRenderError = rl.RaylibError;
+
+pub const TerrainTextureSet = struct {
+    base: window_assets.TextureId,
+    overlay: window_assets.TextureId,
+    detail: window_assets.TextureId,
+};
+
+pub const GroundRenderer = struct {
+    base: rl.Texture2D,
+    overlay: rl.Texture2D,
+    detail: rl.Texture2D,
+    width: i32 = terrain_texture_size,
+    height: i32 = terrain_texture_size,
+    render_target: ?rl.RenderTexture2D = null,
+    alpha_test_shader: ?rl.Shader = null,
+    ready: bool = false,
+
+    pub fn initForUnlockTerrain(
+        runtime_assets: *const window_assets.RuntimeAssets,
+        seed: u32,
+        unlock_index: i32,
+        width: i32,
+        height: i32,
+    ) GroundRenderError!GroundRenderer {
+        const terrain = runtime_bootstrap.previewUnlockTerrain(seed, unlock_index, width, height);
+        const texture_ids = terrainTextureSet(terrain.terrain_slots);
+
+        var renderer: GroundRenderer = .{
+            .base = runtime_assets.texture(texture_ids.base),
+            .overlay = runtime_assets.texture(texture_ids.overlay),
+            .detail = runtime_assets.texture(texture_ids.detail),
+            .width = width,
+            .height = height,
+        };
+        errdefer renderer.deinit();
+
+        try renderer.ensureResources();
+        try renderer.generate(terrain.terrain_seed);
+        return renderer;
+    }
+
+    pub fn deinit(self: *GroundRenderer) void {
+        if (self.alpha_test_shader) |shader| {
+            shader.unload();
+            self.alpha_test_shader = null;
+        }
+        if (self.render_target) |target| {
+            rl.unloadRenderTexture(target);
+            self.render_target = null;
+        }
+        self.ready = false;
+        self.* = undefined;
+    }
+
+    pub fn draw(self: *const GroundRenderer) void {
+        if (!self.ready) {
+            rl.drawRectangle(
+                0,
+                0,
+                self.width,
+                self.height,
+                terrain_clear_color,
+            );
+            return;
+        }
+
+        const target = self.render_target orelse return;
+        const src = rl.Rectangle.init(
+            0.0,
+            0.0,
+            @floatFromInt(target.texture.width),
+            -@as(f32, @floatFromInt(target.texture.height)),
+        );
+        const dst = rl.Rectangle.init(
+            0.0,
+            0.0,
+            @floatFromInt(self.width),
+            @floatFromInt(self.height),
+        );
+        rl.drawTexturePro(target.texture, src, dst, rl.Vector2.zero(), 0.0, rl.Color.white);
+    }
+
+    fn generate(self: *GroundRenderer, terrain_seed: u32) GroundRenderError!void {
+        try self.ensureResources();
+        const target = self.render_target orelse return;
+
+        var rng = spawn_runtime.Crand.init(terrain_seed);
+        rl.beginTextureMode(target);
+        defer rl.endTextureMode();
+
+        rl.clearBackground(terrain_clear_color);
+        if (self.alpha_test_shader) |shader| {
+            shader.activate();
+            defer shader.deactivate();
+        }
+
+        self.scatterTexture(self.base, terrain_base_tint, &rng, terrain_density_base);
+        self.scatterTexture(self.overlay, terrain_overlay_tint, &rng, terrain_density_overlay);
+        self.scatterTexture(self.detail, terrain_detail_tint, &rng, terrain_density_detail);
+        self.ready = true;
+    }
+
+    fn ensureResources(self: *GroundRenderer) GroundRenderError!void {
+        if (self.alpha_test_shader == null) {
+            self.alpha_test_shader = try rl.loadShaderFromMemory(alpha_test_vs, alpha_test_fs);
+        }
+
+        if (self.render_target) |target| {
+            if (target.texture.width == self.width and target.texture.height == self.height) {
+                return;
+            }
+            rl.unloadRenderTexture(target);
+            self.render_target = null;
+        }
+
+        const render_target = try rl.loadRenderTexture(self.width, self.height);
+        rl.setTextureFilter(render_target.texture, .bilinear);
+        rl.setTextureWrap(render_target.texture, .clamp);
+        self.render_target = render_target;
+        self.ready = false;
+    }
+
+    fn scatterTexture(
+        self: *GroundRenderer,
+        texture: rl.Texture2D,
+        tint: rl.Color,
+        rng: *spawn_runtime.Crand,
+        density: i64,
+    ) void {
+        const area = @as(i64, self.width) * @as(i64, self.height);
+        const count = (area * density) >> terrain_density_shift;
+        if (count <= 0) return;
+
+        const src = rl.Rectangle.init(
+            0.0,
+            0.0,
+            @floatFromInt(texture.width),
+            @floatFromInt(texture.height),
+        );
+        const origin = rl.Vector2.init(terrain_patch_size * 0.5, terrain_patch_size * 0.5);
+        const span_w = self.width + terrain_patch_overscan * 2;
+        const span_h = span_w;
+
+        var idx: i64 = 0;
+        while (idx < count) : (idx += 1) {
+            const angle = @as(f32, @floatFromInt(rng.rand() % terrain_rotation_max)) * 0.01;
+            const y = @as(f32, @floatFromInt(@as(i32, @intCast(rng.rand() % @as(u32, @intCast(span_h)))) - terrain_patch_overscan));
+            const x = @as(f32, @floatFromInt(@as(i32, @intCast(rng.rand() % @as(u32, @intCast(span_w)))) - terrain_patch_overscan));
+            const dst = rl.Rectangle.init(
+                x + terrain_patch_size * 0.5,
+                y + terrain_patch_size * 0.5,
+                terrain_patch_size,
+                terrain_patch_size,
+            );
+            rl.drawTexturePro(
+                texture,
+                src,
+                dst,
+                origin,
+                radiansToDegrees(angle),
+                tint,
+            );
+        }
+    }
+};
+
+pub fn terrainTextureSet(slots: runtime_bootstrap.TerrainSlotTriplet) TerrainTextureSet {
+    return .{
+        .base = terrainSlotTextureId(slots[0]),
+        .overlay = terrainSlotTextureId(slots[1]),
+        .detail = terrainSlotTextureId(slots[2]),
+    };
+}
+
+fn terrainSlotTextureId(slot: u8) window_assets.TextureId {
+    return switch (slot) {
+        0 => .ter_q1_base,
+        1 => .ter_q1_overlay,
+        2 => .ter_q2_base,
+        3 => .ter_q2_overlay,
+        4 => .ter_q3_base,
+        5 => .ter_q3_overlay,
+        6 => .ter_q4_base,
+        7 => .ter_q4_overlay,
+        else => .ter_q1_base,
+    };
+}
+
+fn radiansToDegrees(radians: f32) f32 {
+    return radians * (180.0 / std.math.pi);
+}
+
+test "terrain slot mapping follows python ids" {
+    const set = terrainTextureSet(.{ 4, 5, 4 });
+    try std.testing.expectEqual(window_assets.TextureId.ter_q3_base, set.base);
+    try std.testing.expectEqual(window_assets.TextureId.ter_q3_overlay, set.overlay);
+    try std.testing.expectEqual(window_assets.TextureId.ter_q3_base, set.detail);
+}

--- a/crimson-zig/src/window_ground.zig
+++ b/crimson-zig/src/window_ground.zig
@@ -138,6 +138,8 @@ pub const GroundRenderer = struct {
             @floatFromInt(self.width),
             @floatFromInt(self.height),
         );
+        beginCustomBlend(rl.gl.rl_one, rl.gl.rl_zero, rl.gl.rl_func_add);
+        defer endCustomBlend();
         rl.drawTexturePro(target.texture, src, dst, rl.Vector2.zero(), 0.0, rl.Color.white);
     }
 
@@ -155,6 +157,8 @@ pub const GroundRenderer = struct {
             defer shader.deactivate();
         }
 
+        beginTerrainRenderTargetBlend();
+        defer endTerrainRenderTargetBlend();
         self.scatterTexture(self.base, terrain_base_tint, &rng, terrain_density_base);
         self.scatterTexture(self.overlay, terrain_overlay_tint, &rng, terrain_density_overlay);
         self.scatterTexture(self.detail, terrain_detail_tint, &rng, terrain_density_detail);
@@ -249,6 +253,26 @@ fn terrainSlotTextureId(slot: u8) window_assets.TextureId {
 
 fn radiansToDegrees(radians: f32) f32 {
     return radians * (180.0 / std.math.pi);
+}
+
+fn beginCustomBlend(src_factor: i32, dst_factor: i32, blend_equation: i32) void {
+    rl.gl.rlSetBlendFactors(src_factor, dst_factor, blend_equation);
+    rl.beginBlendMode(.custom);
+    rl.gl.rlSetBlendFactors(src_factor, dst_factor, blend_equation);
+}
+
+fn endCustomBlend() void {
+    rl.endBlendMode();
+}
+
+fn beginTerrainRenderTargetBlend() void {
+    rl.gl.rlColorMask(true, true, true, false);
+    beginCustomBlend(rl.gl.rl_src_alpha, rl.gl.rl_one_minus_src_alpha, rl.gl.rl_func_add);
+}
+
+fn endTerrainRenderTargetBlend() void {
+    endCustomBlend();
+    rl.gl.rlColorMask(true, true, true, true);
 }
 
 test "terrain slot mapping follows python ids" {

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -3,6 +3,7 @@ const rl = @import("raylib");
 
 const cz = @import("crimson_zig");
 const window_assets = @import("window_assets.zig");
+const window_ground = @import("window_ground.zig");
 
 const bonuses_runtime = cz.bonuses;
 const game_ids = cz.game_ids;
@@ -65,6 +66,15 @@ const UiButton = struct {
 const GameplayScreen = struct {
     runner: live_runner.LiveSurvivalRunner,
     last_update: live_runner.FrameUpdate,
+    ground: ?window_ground.GroundRenderer = null,
+
+    fn deinit(self: *GameplayScreen) void {
+        if (self.ground) |*ground| {
+            ground.deinit();
+            self.ground = null;
+        }
+        self.* = undefined;
+    }
 };
 
 const ResultsScreen = struct {
@@ -97,6 +107,10 @@ const App = struct {
     }
 
     fn deinit(self: *App) void {
+        if (self.gameplay) |*gameplay| {
+            gameplay.deinit();
+            self.gameplay = null;
+        }
         if (self.runtime_assets) |*runtime_assets| {
             runtime_assets.deinit();
             self.runtime_assets = null;
@@ -165,7 +179,7 @@ const App = struct {
     fn updateGameplay(self: *App, frame_dt: f32) void {
         if (self.gameplay) |*gameplay| {
             if (rl.isKeyPressed(.escape)) {
-                self.finishRun(&gameplay.runner, .abandoned, null);
+                self.finishRun(gameplay, .abandoned, null);
                 return;
             }
 
@@ -175,12 +189,12 @@ const App = struct {
             );
             const input = collectGameplayInput(&gameplay.runner, camera);
             gameplay.last_update = gameplay.runner.stepFrame(frame_dt, input) catch |err| {
-                self.finishRun(&gameplay.runner, .runtime_error, @errorName(err));
+                self.finishRun(gameplay, .runtime_error, @errorName(err));
                 return;
             };
 
             if (gameplay.last_update.all_players_dead) {
-                self.finishRun(&gameplay.runner, .dead, null);
+                self.finishRun(gameplay, .dead, null);
             }
         }
     }
@@ -201,7 +215,10 @@ const App = struct {
         switch (self.results_selection) {
             0 => self.startNewRun(),
             1 => {
-                self.gameplay = null;
+                if (self.gameplay) |*gameplay| {
+                    gameplay.deinit();
+                    self.gameplay = null;
+                }
                 self.results = null;
                 self.menu_selection = 0;
                 self.screen = .main_menu;
@@ -225,15 +242,31 @@ const App = struct {
             return;
         };
         const last_update = runner.stepFrame(0.0, .{}) catch unreachable;
-        self.gameplay = .{
+        if (self.gameplay) |*gameplay| {
+            gameplay.deinit();
+            self.gameplay = null;
+        }
+
+        var gameplay: GameplayScreen = .{
             .runner = runner,
             .last_update = last_update,
         };
+        if (self.runtime_assets) |*runtime_assets| {
+            gameplay.ground = window_ground.GroundRenderer.initForUnlockTerrain(
+                runtime_assets,
+                gameplay.runner.seed,
+                gameplay.runner.session.quest_unlock_index,
+                gameplay.runner.session.terrain_size,
+                gameplay.runner.session.terrain_size,
+            ) catch null;
+        }
+        self.gameplay = gameplay;
         self.results = null;
         self.screen = .gameplay;
     }
 
-    fn finishRun(self: *App, runner: *const live_runner.LiveSurvivalRunner, reason: ResultsReason, runtime_error: ?[]const u8) void {
+    fn finishRun(self: *App, gameplay: *GameplayScreen, reason: ResultsReason, runtime_error: ?[]const u8) void {
+        const runner = &gameplay.runner;
         const player_health = if (runner.player0Const()) |player| player.health else 0.0;
         self.results = .{
             .reason = reason,
@@ -241,6 +274,7 @@ const App = struct {
             .player_health = player_health,
             .runtime_error = runtime_error,
         };
+        gameplay.deinit();
         self.gameplay = null;
         self.results_selection = 0;
         self.screen = .results;
@@ -292,7 +326,7 @@ const App = struct {
             );
 
             camera.begin();
-            drawWorld(runner, runtime_assets);
+            drawWorld(runner, runtime_assets, if (gameplay.ground) |*ground| ground else null);
             drawPlayers(runner, runtime_assets);
             drawCreatures(runner, runtime_assets);
             drawProjectiles(runner, runtime_assets);
@@ -588,11 +622,17 @@ fn axisFromKeys(negative: rl.KeyboardKey, positive: rl.KeyboardKey) f32 {
     return value;
 }
 
-fn drawWorld(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+fn drawWorld(
+    runner: *const live_runner.LiveSurvivalRunner,
+    runtime_assets: ?*const window_assets.RuntimeAssets,
+    ground: ?*const window_ground.GroundRenderer,
+) void {
     const world_size = runner.session.world_size;
     const world_rect = rl.Rectangle.init(0.0, 0.0, world_size, world_size);
 
-    if (runtime_assets) |assets| {
+    if (ground) |rendered_ground| {
+        rendered_ground.draw();
+    } else if (runtime_assets) |assets| {
         const terrain_set = terrainTextureSet(runner.session.quest_unlock_index);
         drawTextureTiled(assets.texture(terrain_set.base), world_rect, rl.Color.white);
         drawTextureTiled(assets.texture(terrain_set.overlay), world_rect, rl.Color.init(255, 255, 255, 124));


### PR DESCRIPTION
## Summary
- replace the tiled terrain approximation with a generated ground render target in Zig
- port the deterministic terrain bootstrap flow so unlock rolls and terrain seed match the Python/runtime path
- emulate the DX8 XRGB terrain render-target behavior to avoid the blobby alpha accumulation bug

## Testing
- zig build test
- zig build window
- zig build asset-smoke
- zig build wasm
- just docs-check
