### PR TITLE
feat(zig): port atlas sprite rendering

### DIFF
--- a/crimson-zig/src/root.zig
+++ b/crimson-zig/src/root.zig
@@ -5,8 +5,10 @@ pub const quest_spawn_logic_full = @import("quest_spawn/logic_full.zig");
 pub const replay_codec = @import("replay_codec.zig");
 pub const replay_runner = @import("runtime/replay_runner.zig");
 pub const spawn = @import("runtime/spawn.zig");
+pub const anim = @import("runtime/anim.zig");
 pub const creatures = @import("runtime/creatures.zig");
 pub const perks = @import("runtime/perks.zig");
+pub const weapon_data = @import("runtime/weapon_data.zig");
 pub const particles = @import("runtime/particles.zig");
 pub const secondary_projectiles = @import("runtime/secondary_projectiles.zig");
 pub const state = @import("runtime/state.zig");
@@ -19,5 +21,6 @@ pub const session_builders = @import("runtime/session_builders.zig");
 pub const live_runner = @import("runtime/live_runner.zig");
 
 pub const formats = @import("formats/mod.zig");
+pub const window_atlas = @import("window_atlas.zig");
 
 pub const version = "0.1.0-dev";

--- a/crimson-zig/src/runtime/anim.zig
+++ b/crimson-zig/src/runtime/anim.zig
@@ -1,0 +1,190 @@
+const std = @import("std");
+const native_math = @import("native_math.zig");
+const spawn_mod = @import("spawn.zig");
+
+const narrowF32 = native_math.roundF32;
+
+pub const CreatureAnimInfo = struct {
+    base: i32,
+    anim_rate: f32,
+    mirror: bool,
+};
+
+pub const PhaseAdvance = struct {
+    phase: f32,
+    step: f32,
+};
+
+pub const FrameMode = enum {
+    long,
+    ping_pong,
+};
+
+pub const FrameSelection = struct {
+    frame: i32,
+    mirrored: bool,
+    mode: FrameMode,
+};
+
+const creature_corpse_frames = std.EnumArray(spawn_mod.CreatureTypeId, i32).init(.{
+    .zombie = 0,
+    .lizard = 3,
+    .alien = 4,
+    .spider_sp1 = 1,
+    .spider_sp2 = 2,
+    .trooper = 7,
+});
+
+pub const creature_anim_info = std.EnumArray(spawn_mod.CreatureTypeId, CreatureAnimInfo).init(.{
+    .zombie = .{ .base = 0x20, .anim_rate = 1.2, .mirror = false },
+    .lizard = .{ .base = 0x10, .anim_rate = 1.6, .mirror = true },
+    .alien = .{ .base = 0x20, .anim_rate = 1.35, .mirror = false },
+    .spider_sp1 = .{ .base = 0x10, .anim_rate = 1.5, .mirror = true },
+    .spider_sp2 = .{ .base = 0x10, .anim_rate = 1.5, .mirror = true },
+    .trooper = .{ .base = 0x00, .anim_rate = 1.0, .mirror = false },
+});
+
+pub fn creatureAnimInfoForRawTypeId(type_id_raw: i32) ?CreatureAnimInfo {
+    const type_id = std.meta.intToEnum(spawn_mod.CreatureTypeId, type_id_raw) catch return null;
+    return creature_anim_info.get(type_id);
+}
+
+pub fn creatureCorpseFrameForType(type_id_raw: i32) i32 {
+    if (type_id_raw == 7) return 6;
+    const type_id = std.meta.intToEnum(spawn_mod.CreatureTypeId, type_id_raw) catch return type_id_raw & 0xF;
+    return creature_corpse_frames.get(type_id);
+}
+
+pub fn creatureAnimIsLongStrip(flags: u32) bool {
+    return (flags & spawn_mod.CreatureFlags.anim_ping_pong) == 0 or
+        (flags & spawn_mod.CreatureFlags.anim_long_strip) != 0;
+}
+
+pub fn creatureAnimPhaseStep(
+    anim_rate: f32,
+    move_speed: f32,
+    dt: f32,
+    size: f32,
+    local_scale: f32,
+    flags: u32,
+    ai_mode: spawn_mod.CreatureAiMode,
+) f32 {
+    if (size == 0.0) return 0.0;
+
+    const anim_rate_f32 = narrowF32(anim_rate);
+    const move_speed_f32 = narrowF32(move_speed);
+    const dt_f32 = narrowF32(dt);
+    const size_f32 = narrowF32(size);
+    const local_scale_f32 = narrowF32(local_scale);
+    const speed_scale = narrowF32(30.0) / size_f32;
+    const is_long_strip = creatureAnimIsLongStrip(flags);
+    if (is_long_strip and ai_mode == .hold_timer) return 0.0;
+
+    const strip_mul: f32 = if (is_long_strip) narrowF32(25.0) else narrowF32(22.0);
+    return narrowF32(anim_rate_f32 * move_speed_f32 * dt_f32 * speed_scale * strip_mul * local_scale_f32);
+}
+
+pub fn creatureAnimAdvancePhase(
+    phase: f32,
+    anim_rate: f32,
+    move_speed: f32,
+    dt: f32,
+    size: f32,
+    local_scale: f32,
+    flags: u32,
+    ai_mode: spawn_mod.CreatureAiMode,
+) PhaseAdvance {
+    var next_phase = narrowF32(phase);
+    const step = creatureAnimPhaseStep(anim_rate, move_speed, dt, size, local_scale, flags, ai_mode);
+    if (step == 0.0) {
+        return .{ .phase = next_phase, .step = 0.0 };
+    }
+
+    next_phase = narrowF32(next_phase + step);
+    if (creatureAnimIsLongStrip(flags)) {
+        while (next_phase > 31.0) {
+            next_phase = narrowF32(next_phase - 31.0);
+        }
+    } else {
+        while (next_phase > 15.0) {
+            next_phase = narrowF32(next_phase - 15.0);
+        }
+    }
+
+    return .{ .phase = next_phase, .step = step };
+}
+
+pub fn creatureAnimSelectFrame(
+    phase: f32,
+    base_frame: i32,
+    mirror_long: bool,
+    flags: u32,
+) FrameSelection {
+    if (creatureAnimIsLongStrip(flags)) {
+        if (phase < 0.0) {
+            return .{ .frame = base_frame + 0x0F, .mirrored = false, .mode = .long };
+        }
+
+        var frame: i32 = @intFromFloat(phase + 0.5);
+        var mirrored = false;
+        if (mirror_long and frame > 0x0F) {
+            frame = 0x1F - frame;
+            mirrored = true;
+        }
+        if ((flags & spawn_mod.CreatureFlags.ranged_attack_shock) != 0) {
+            frame += 0x20;
+        }
+        return .{ .frame = frame, .mirrored = mirrored, .mode = .long };
+    }
+
+    const raw: i32 = @intFromFloat(phase + 0.5);
+    var idx: i32 = @bitCast(@as(u32, @bitCast(raw)) & 0x8000000F);
+    if (idx < 0) {
+        idx = @bitCast((@as(u32, @bitCast(idx - 1)) | 0xFFFFFFF0) + 1);
+    }
+    if (idx > 7) idx = 0x0F - idx;
+    return .{ .frame = base_frame + 0x10 + idx, .mirrored = false, .mode = .ping_pong };
+}
+
+test "creature anim select mirrors long strips and shock frames" {
+    const base = creature_anim_info.get(.lizard).base;
+    const mirrored = creatureAnimSelectFrame(17.2, base, true, 0);
+    try std.testing.expectEqual(@as(i32, 14), mirrored.frame);
+    try std.testing.expect(mirrored.mirrored);
+    try std.testing.expectEqual(FrameMode.long, mirrored.mode);
+
+    const shocked = creatureAnimSelectFrame(2.0, base, false, spawn_mod.CreatureFlags.ranged_attack_shock);
+    try std.testing.expectEqual(@as(i32, 0x22), shocked.frame);
+}
+
+test "creature anim select handles ping pong strips" {
+    const selection = creatureAnimSelectFrame(
+        9.0,
+        creature_anim_info.get(.alien).base,
+        false,
+        spawn_mod.CreatureFlags.anim_ping_pong,
+    );
+    try std.testing.expectEqual(@as(i32, 0x36), selection.frame);
+    try std.testing.expectEqual(FrameMode.ping_pong, selection.mode);
+}
+
+test "creature anim advance wraps long strips" {
+    const advanced = creatureAnimAdvancePhase(
+        30.0,
+        1.0,
+        1.0,
+        0.1,
+        30.0,
+        1.0,
+        0,
+        .orbit_player,
+    );
+    try std.testing.expectApproxEqAbs(@as(f32, 1.5), advanced.phase, 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 2.5), advanced.step, 1e-6);
+}
+
+test "creature corpse frame table matches bodyset mapping" {
+    try std.testing.expectEqual(@as(i32, 0), creatureCorpseFrameForType(@intFromEnum(spawn_mod.CreatureTypeId.zombie)));
+    try std.testing.expectEqual(@as(i32, 6), creatureCorpseFrameForType(7));
+    try std.testing.expectEqual(@as(i32, 9), creatureCorpseFrameForType(9));
+}

--- a/crimson-zig/src/runtime/creatures.zig
+++ b/crimson-zig/src/runtime/creatures.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const game_ids = @import("../game_ids.zig");
 const native_math = @import("native_math.zig");
 
+const runtime_anim = @import("anim.zig");
 const bonus_runtime = @import("bonuses.zig");
 const creature_lifecycle = @import("lifecycle.zig").CreatureLifecycle;
 const owner_ref = @import("owner_ref.zig");
@@ -40,6 +41,7 @@ pub const CreatureState = struct {
     heading: f32 = 0.0,
     target_heading: f32 = 0.0,
     phase_seed: f32 = 0.0,
+    anim_phase: f32 = 0.0,
     vel: state_mod.Vec2 = .{},
     move_scale: f32 = 1.0,
     force_target: i32 = 0,
@@ -140,6 +142,7 @@ pub const CreaturePool = struct {
             .heading = if (init.set_heading) narrowF32(init.heading) else stale_heading,
             .target_heading = stale_target_heading,
             .phase_seed = narrowF32(init.phase_seed),
+            .anim_phase = 0.0,
             .vel = .{},
             .move_scale = 1.0,
             .force_target = 0,
@@ -2001,6 +2004,19 @@ pub const CreaturePool = struct {
                         .y = moved_y,
                     };
                 }
+            }
+            if (runtime_anim.creatureAnimInfoForRawTypeId(creature.type_id)) |anim_info| {
+                const advanced = runtime_anim.creatureAnimAdvancePhase(
+                    creature.anim_phase,
+                    anim_info.anim_rate,
+                    creature.move_speed,
+                    dt_f32,
+                    creature.size,
+                    creature.move_scale,
+                    creature.flags,
+                    creature.ai_mode,
+                );
+                creature.anim_phase = advanced.phase;
             }
             if (perkActive(player, PerkId.plaguebearer) and state.plaguebearer_infection_count < 0x3c) {
                 spreadPlagueInfection(self.entries[0..], creature);

--- a/crimson-zig/src/runtime/weapon_data.zig
+++ b/crimson-zig/src/runtime/weapon_data.zig
@@ -74,6 +74,55 @@ pub const weapon_stats = std.EnumArray(WeaponId, WeaponStats).init(.{
     .nuke_launcher = .{ .clip_size = 1, .reload_time = 8.0, .shot_cooldown = 4.0, .pellet_count = 1, .travel_budget = 45.0, .damage_scale = 1.0, .flags = 8, .spread_heat_inc = 1.0 },
 });
 
+pub const weapon_icon_index = std.EnumArray(WeaponId, i32).initDefault(-1, .{
+    .pistol = 0,
+    .assault_rifle = 1,
+    .shotgun = 2,
+    .sawed_off_shotgun = 3,
+    .submachine_gun = 4,
+    .gauss_gun = 5,
+    .mean_minigun = 6,
+    .flamethrower = 7,
+    .plasma_rifle = 8,
+    .multi_plasma = 9,
+    .plasma_minigun = 10,
+    .rocket_launcher = 11,
+    .seeker_rockets = 12,
+    .plasma_shotgun = 13,
+    .blow_torch = 14,
+    .hr_flamer = 15,
+    .mini_rocket_swarmers = 16,
+    .rocket_minigun = 17,
+    .pulse_gun = 18,
+    .jackhammer = 19,
+    .ion_rifle = 20,
+    .ion_minigun = 21,
+    .ion_cannon = 22,
+    .shrinkifier_5k = 23,
+    .blade_gun = 24,
+    .spider_plasma = 25,
+    .evil_scythe = 25,
+    .plasma_cannon = 25,
+    .splitter_gun = 28,
+    .gauss_shotgun = 30,
+    .ion_shotgun = 31,
+    .flameburst = 29,
+    .raygun = 30,
+    .plague_spreader_gun = 40,
+    .bubblegun = 41,
+    .rainbow_gun = 42,
+    .grim_weapon = 43,
+    .fire_bullets = 44,
+    .transmutator = 49,
+    .blaster_r_300 = 50,
+    .lightning_rifle = 51,
+    .nuke_launcher = 52,
+});
+
+pub inline fn weaponIconIndex(weapon_id: WeaponId) i32 {
+    return weapon_icon_index.get(weapon_id);
+}
+
 pub inline fn weaponIdToInt(weapon_id: WeaponId) i32 {
     return @intFromEnum(weapon_id);
 }
@@ -201,4 +250,12 @@ test "non projectile weapons map to empty projectile type ids" {
         try std.testing.expectEqual(@as(?ProjectileTypeId, null), projectileTypeIdFromWeaponId(id));
         try std.testing.expectEqual(@as(usize, 0), projectileTypeIdsFromWeaponId(id).slice().len);
     }
+}
+
+test "weapon icon indices mirror runtime ui wicon metadata" {
+    try std.testing.expectEqual(@as(i32, 0), weaponIconIndex(.pistol));
+    try std.testing.expectEqual(@as(i32, 25), weaponIconIndex(.evil_scythe));
+    try std.testing.expectEqual(@as(i32, 30), weaponIconIndex(.raygun));
+    try std.testing.expectEqual(@as(i32, 52), weaponIconIndex(.nuke_launcher));
+    try std.testing.expectEqual(@as(i32, -1), weaponIconIndex(.unknown_34));
 }

--- a/crimson-zig/src/test_root.zig
+++ b/crimson-zig/src/test_root.zig
@@ -1,4 +1,5 @@
 test {
+    _ = @import("runtime/anim.zig");
     _ = @import("hash.zig");
     _ = @import("quest_spawn/logic_full.zig");
     _ = @import("replay_codec.zig");
@@ -15,5 +16,6 @@ test {
     _ = @import("runtime/weapons.zig");
     _ = @import("verify_native.zig");
     _ = @import("wasm_exports.zig");
+    _ = @import("window_atlas.zig");
     _ = @import("formats/mod.zig");
 }

--- a/crimson-zig/src/window_atlas.zig
+++ b/crimson-zig/src/window_atlas.zig
@@ -1,0 +1,327 @@
+const std = @import("std");
+
+const bonuses_runtime = @import("runtime/bonuses.zig");
+const creature_lifecycle = @import("runtime/lifecycle.zig").CreatureLifecycle;
+const creatures_runtime = @import("runtime/creatures.zig");
+const game_ids = @import("game_ids.zig");
+const runtime_anim = @import("runtime/anim.zig");
+const spawn_runtime = @import("runtime/spawn.zig");
+
+pub const AtlasRect = struct {
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+};
+
+pub const EffectId = enum(i32) {
+    shield_ring = 0x02,
+    glow = 0x0D,
+    aura = 0x10,
+};
+
+pub const ColorRgb = struct {
+    r: u8,
+    g: u8,
+    b: u8,
+};
+
+pub const ColorRgbf = struct {
+    r: f32,
+    g: f32,
+    b: f32,
+};
+
+pub const KnownProjectileFrame = struct {
+    grid: i32,
+    frame: i32,
+};
+
+pub const PlasmaRenderConfig = struct {
+    rgb: ColorRgbf,
+    spacing: f32,
+    seg_limit: i32,
+    tail_size: f32,
+    head_size: f32,
+    head_alpha_mul: f32,
+    aura_rgb: ColorRgbf,
+    aura_size: f32,
+    aura_alpha_mul: f32,
+};
+
+pub const CreatureTextureKind = enum {
+    alien,
+    lizard,
+    spider_sp1,
+    spider_sp2,
+    trooper,
+    zombie,
+};
+
+pub const CreatureRenderFrame = struct {
+    texture_kind: CreatureTextureKind,
+    frame: i32,
+    lifecycle: creature_lifecycle.Phase,
+};
+
+const default_plasma_render_config: PlasmaRenderConfig = .{
+    .rgb = .{ .r = 1.0, .g = 1.0, .b = 1.0 },
+    .spacing = 2.1,
+    .seg_limit = 3,
+    .tail_size = 12.0,
+    .head_size = 16.0,
+    .head_alpha_mul = 0.45,
+    .aura_rgb = .{ .r = 1.0, .g = 1.0, .b = 1.0 },
+    .aura_size = 120.0,
+    .aura_alpha_mul = 0.15,
+};
+
+pub fn atlasRect(texture_width: i32, texture_height: i32, grid: i32, frame: i32) AtlasRect {
+    const safe_grid = @max(grid, 1);
+    const cell_w = @as(f32, @floatFromInt(texture_width)) / @as(f32, @floatFromInt(safe_grid));
+    const cell_h = @as(f32, @floatFromInt(texture_height)) / @as(f32, @floatFromInt(safe_grid));
+    const safe_frame = @max(frame, 0);
+    const col = @mod(safe_frame, safe_grid);
+    const row = @divFloor(safe_frame, safe_grid);
+    return .{
+        .x = cell_w * @as(f32, @floatFromInt(col)),
+        .y = cell_h * @as(f32, @floatFromInt(row)),
+        .width = cell_w,
+        .height = cell_h,
+    };
+}
+
+pub fn atlasRectSpan(texture_width: i32, texture_height: i32, grid: i32, frame: i32, span_w: i32, span_h: i32) AtlasRect {
+    const base = atlasRect(texture_width, texture_height, grid, frame);
+    return .{
+        .x = base.x,
+        .y = base.y,
+        .width = base.width * @as(f32, @floatFromInt(@max(span_w, 1))),
+        .height = base.height * @as(f32, @floatFromInt(@max(span_h, 1))),
+    };
+}
+
+pub fn effectRect(texture_width: i32, texture_height: i32, effect_id: EffectId) ?AtlasRect {
+    const EffectEntry = struct {
+        size_code: i32,
+        frame: i32,
+    };
+    const entry = switch (effect_id) {
+        .shield_ring => EffectEntry{ .size_code = 0x20, .frame = 0x00 },
+        .glow => EffectEntry{ .size_code = 0x40, .frame = 0x03 },
+        .aura => EffectEntry{ .size_code = 0x40, .frame = 0x06 },
+    };
+    const grid: i32 = switch (entry.size_code) {
+        0x10 => 16,
+        0x20 => 8,
+        0x40 => 4,
+        0x80 => 2,
+        else => return null,
+    };
+    return atlasRect(texture_width, texture_height, grid, entry.frame);
+}
+
+pub fn bonusIconRect(texture_width: i32, texture_height: i32, icon_id: i32) AtlasRect {
+    return atlasRect(texture_width, texture_height, 4, icon_id);
+}
+
+pub fn weaponIconRect(texture_width: i32, texture_height: i32, icon_index: i32) AtlasRect {
+    return atlasRectSpan(texture_width, texture_height, 8, icon_index * 2, 2, 1);
+}
+
+pub fn bonusFade(time_left: f32, time_max: f32) f32 {
+    if (!(time_left > 0.0) or !(time_max > 0.0)) return 0.0;
+    if (time_left < 0.5) return std.math.clamp(time_left * 2.0, @as(f32, 0.0), @as(f32, 1.0));
+    const age = time_max - time_left;
+    if (age < 0.5) return std.math.clamp(age * 2.0, @as(f32, 0.0), @as(f32, 1.0));
+    return 1.0;
+}
+
+pub fn creatureSizeScale(size: f32) f32 {
+    return std.math.clamp(size / 64.0, @as(f32, 0.25), @as(f32, 2.0));
+}
+
+pub fn creatureRenderFrame(creature: creatures_runtime.CreatureState) ?CreatureRenderFrame {
+    const info = runtime_anim.creatureAnimInfoForRawTypeId(creature.type_id) orelse return null;
+    const creature_type = std.meta.intToEnum(spawn_runtime.CreatureTypeId, creature.type_id) catch return null;
+    var phase = creature.anim_phase;
+    if (runtime_anim.creatureAnimIsLongStrip(creature.flags)) {
+        if (creature.lifecycle_stage < 0.0) {
+            phase = -1.0;
+        } else if (creature.lifecycle_stage < creature_lifecycle.alive) {
+            phase = @as(f32, @floatFromInt(info.base + 0x0F)) - creature.lifecycle_stage - 0.5;
+        }
+    }
+
+    const selection = runtime_anim.creatureAnimSelectFrame(
+        phase,
+        info.base,
+        info.mirror and creature.lifecycle_stage >= creature_lifecycle.alive,
+        creature.flags,
+    );
+    return .{
+        .texture_kind = switch (creature_type) {
+            .alien => .alien,
+            .lizard => .lizard,
+            .spider_sp1 => .spider_sp1,
+            .spider_sp2 => .spider_sp2,
+            .trooper => .trooper,
+            .zombie => .zombie,
+        },
+        .frame = selection.frame,
+        .lifecycle = creature_lifecycle.classify(creature.lifecycle_stage),
+    };
+}
+
+pub fn bonusIconId(entry: bonuses_runtime.BonusEntry) ?i32 {
+    return switch (entry.bonus_id) {
+        .unused => null,
+        .points => if (entry.amount == 1000) 13 else 12,
+        .energizer => 10,
+        .weapon => null,
+        .weapon_power_up => 7,
+        .nuke => 1,
+        .double_experience => 4,
+        .shock_chain => 3,
+        .fireblast => 2,
+        .reflex_boost => 5,
+        .shield => 6,
+        .freeze => 8,
+        .medikit => 14,
+        .speed => 9,
+        .fire_bullets => 11,
+    };
+}
+
+pub fn projectileKnownFrame(type_id_raw: i32) ?KnownProjectileFrame {
+    const type_id = std.meta.intToEnum(game_ids.ProjectileTypeId, type_id_raw) catch return null;
+    return switch (type_id) {
+        .pulse_gun => .{ .grid = 2, .frame = 0 },
+        .splitter_gun => .{ .grid = 4, .frame = 3 },
+        .blade_gun => .{ .grid = 4, .frame = 6 },
+        .ion_minigun, .ion_cannon, .shrinkifier, .fire_bullets, .ion_rifle => .{ .grid = 4, .frame = 2 },
+        else => null,
+    };
+}
+
+pub fn knownProjectileRgb(type_id_raw: i32) ColorRgb {
+    const type_id = std.meta.intToEnum(game_ids.ProjectileTypeId, type_id_raw) catch return .{ .r = 240, .g = 220, .b = 160 };
+    return switch (type_id) {
+        .ion_rifle, .ion_minigun, .ion_cannon => .{ .r = 120, .g = 200, .b = 255 },
+        .fire_bullets => .{ .r = 255, .g = 170, .b = 90 },
+        .shrinkifier => .{ .r = 160, .g = 255, .b = 170 },
+        .blade_gun => .{ .r = 240, .g = 120, .b = 255 },
+        else => .{ .r = 240, .g = 220, .b = 160 },
+    };
+}
+
+pub fn isBulletTrailType(type_id_raw: i32) bool {
+    return (type_id_raw >= 0 and type_id_raw < 8) or
+        type_id_raw == @intFromEnum(game_ids.ProjectileTypeId.splitter_gun);
+}
+
+pub fn bulletSpriteSize(type_id_raw: i32) f32 {
+    const type_id = std.meta.intToEnum(game_ids.ProjectileTypeId, type_id_raw) catch return 4.0;
+    return switch (type_id) {
+        .assault_rifle => 6.0,
+        .submachine_gun => 8.0,
+        else => 4.0,
+    };
+}
+
+pub fn isBeamType(type_id_raw: i32) bool {
+    const type_id = std.meta.intToEnum(game_ids.ProjectileTypeId, type_id_raw) catch return false;
+    return switch (type_id) {
+        .ion_rifle, .ion_minigun, .ion_cannon, .fire_bullets => true,
+        else => false,
+    };
+}
+
+pub fn beamEffectScale(type_id_raw: i32) f32 {
+    const type_id = std.meta.intToEnum(game_ids.ProjectileTypeId, type_id_raw) catch return 0.8;
+    return switch (type_id) {
+        .ion_minigun => 1.05,
+        .ion_rifle => 2.2,
+        .ion_cannon => 3.5,
+        else => 0.8,
+    };
+}
+
+pub fn isPlasmaParticleType(type_id_raw: i32) bool {
+    const type_id = std.meta.intToEnum(game_ids.ProjectileTypeId, type_id_raw) catch return false;
+    return switch (type_id) {
+        .plasma_rifle, .plasma_minigun, .spider_plasma, .plasma_cannon, .shrinkifier => true,
+        else => false,
+    };
+}
+
+pub fn plasmaRenderConfig(type_id_raw: i32) PlasmaRenderConfig {
+    const type_id = std.meta.intToEnum(game_ids.ProjectileTypeId, type_id_raw) catch return default_plasma_render_config;
+    return switch (type_id) {
+        .plasma_rifle => .{
+            .rgb = .{ .r = 1.0, .g = 1.0, .b = 1.0 },
+            .spacing = 2.5,
+            .seg_limit = 8,
+            .tail_size = 22.0,
+            .head_size = 56.0,
+            .head_alpha_mul = 0.45,
+            .aura_rgb = .{ .r = 1.0, .g = 1.0, .b = 1.0 },
+            .aura_size = 256.0,
+            .aura_alpha_mul = 0.3,
+        },
+        .plasma_cannon => .{
+            .rgb = .{ .r = 1.0, .g = 1.0, .b = 1.0 },
+            .spacing = 2.6,
+            .seg_limit = 18,
+            .tail_size = 44.0,
+            .head_size = 84.0,
+            .head_alpha_mul = 0.45,
+            .aura_rgb = .{ .r = 1.0, .g = 1.0, .b = 1.0 },
+            .aura_size = 256.0,
+            .aura_alpha_mul = 0.4,
+        },
+        .spider_plasma => .{
+            .rgb = .{ .r = 0.3, .g = 1.0, .b = 0.3 },
+            .spacing = default_plasma_render_config.spacing,
+            .seg_limit = default_plasma_render_config.seg_limit,
+            .tail_size = default_plasma_render_config.tail_size,
+            .head_size = default_plasma_render_config.head_size,
+            .head_alpha_mul = default_plasma_render_config.head_alpha_mul,
+            .aura_rgb = .{ .r = 0.3, .g = 1.0, .b = 0.3 },
+            .aura_size = default_plasma_render_config.aura_size,
+            .aura_alpha_mul = default_plasma_render_config.aura_alpha_mul,
+        },
+        .shrinkifier => .{
+            .rgb = .{ .r = 0.3, .g = 0.3, .b = 1.0 },
+            .spacing = default_plasma_render_config.spacing,
+            .seg_limit = default_plasma_render_config.seg_limit,
+            .tail_size = default_plasma_render_config.tail_size,
+            .head_size = default_plasma_render_config.head_size,
+            .head_alpha_mul = default_plasma_render_config.head_alpha_mul,
+            .aura_rgb = .{ .r = 0.3, .g = 0.3, .b = 1.0 },
+            .aura_size = default_plasma_render_config.aura_size,
+            .aura_alpha_mul = default_plasma_render_config.aura_alpha_mul,
+        },
+        else => default_plasma_render_config,
+    };
+}
+
+test "weapon icon rect spans two ui wicon cells" {
+    const rect = weaponIconRect(256, 256, 3);
+    try std.testing.expectApproxEqAbs(@as(f32, 192.0), rect.x, 1e-6);
+    try std.testing.expectApproxEqAbs(@as(f32, 64.0), rect.width, 1e-6);
+}
+
+test "bonus icon mapping mirrors metadata" {
+    try std.testing.expectEqual(@as(?i32, 7), bonusIconId(.{ .bonus_id = .weapon_power_up }));
+    try std.testing.expectEqual(@as(?i32, 13), bonusIconId(.{ .bonus_id = .points, .amount = 1000 }));
+    try std.testing.expectEqual(@as(?i32, null), bonusIconId(.{ .bonus_id = .weapon }));
+}
+
+test "projectile lookup tables expose atlas fallback data" {
+    const known = projectileKnownFrame(@intFromEnum(game_ids.ProjectileTypeId.ion_rifle)).?;
+    try std.testing.expectEqual(@as(i32, 4), known.grid);
+    try std.testing.expectEqual(@as(i32, 2), known.frame);
+    try std.testing.expect(isBeamType(@intFromEnum(game_ids.ProjectileTypeId.fire_bullets)));
+    try std.testing.expect(isPlasmaParticleType(@intFromEnum(game_ids.ProjectileTypeId.plasma_cannon)));
+}

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -2,15 +2,18 @@ const std = @import("std");
 const rl = @import("raylib");
 
 const cz = @import("crimson_zig");
+const runtime_anim = cz.anim;
+const weapon_data = cz.weapon_data;
 const window_assets = @import("window_assets.zig");
+const window_atlas = cz.window_atlas;
 const window_ground = @import("window_ground.zig");
 
 const bonuses_runtime = cz.bonuses;
 const game_ids = cz.game_ids;
 const live_runner = cz.live_runner;
+const runtime_perks = cz.perks;
 const secondary_projectiles_runtime = cz.secondary_projectiles;
 const runtime_session = cz.session;
-const spawn_runtime = cz.spawn;
 const state_mod = cz.state;
 
 const window_width = 1280;
@@ -484,6 +487,86 @@ fn drawTextureCenteredRotated(texture: rl.Texture2D, center: rl.Vector2, width: 
     rl.drawTexturePro(texture, src, dest, rl.Vector2.init(width * 0.5, height * 0.5), rotation_deg, tint);
 }
 
+fn drawTextureRegionCenteredRotated(
+    texture: rl.Texture2D,
+    src_rect: window_atlas.AtlasRect,
+    center: rl.Vector2,
+    width: f32,
+    height: f32,
+    rotation_deg: f32,
+    tint: rl.Color,
+) void {
+    const src = rl.Rectangle.init(src_rect.x, src_rect.y, src_rect.width, src_rect.height);
+    const dest = rl.Rectangle.init(center.x, center.y, width, height);
+    rl.drawTexturePro(texture, src, dest, rl.Vector2.init(width * 0.5, height * 0.5), rotation_deg, tint);
+}
+
+fn drawAtlasFrameCenteredRotated(
+    texture: rl.Texture2D,
+    grid: i32,
+    frame: i32,
+    center: rl.Vector2,
+    scale: f32,
+    rotation_rad: f32,
+    tint: rl.Color,
+) void {
+    const src_rect = window_atlas.atlasRect(texture.width, texture.height, grid, frame);
+    drawTextureRegionCenteredRotated(
+        texture,
+        src_rect,
+        center,
+        src_rect.width * scale,
+        src_rect.height * scale,
+        radiansToDegrees(rotation_rad),
+        tint,
+    );
+}
+
+fn radiansToDegrees(radians: f32) f32 {
+    return radians * (180.0 / std.math.pi);
+}
+
+fn vecAdd(a: rl.Vector2, b: rl.Vector2) rl.Vector2 {
+    return .{ .x = a.x + b.x, .y = a.y + b.y };
+}
+
+fn vecSub(a: rl.Vector2, b: rl.Vector2) rl.Vector2 {
+    return .{ .x = a.x - b.x, .y = a.y - b.y };
+}
+
+fn vecScale(vec: rl.Vector2, scale: f32) rl.Vector2 {
+    return .{ .x = vec.x * scale, .y = vec.y * scale };
+}
+
+fn vecLength(vec: rl.Vector2) f32 {
+    return std.math.sqrt(vec.x * vec.x + vec.y * vec.y);
+}
+
+fn vecNormalizeOr(vec: rl.Vector2, fallback: rl.Vector2) rl.Vector2 {
+    const len = vecLength(vec);
+    if (!(len > 1e-6)) return fallback;
+    return .{ .x = vec.x / len, .y = vec.y / len };
+}
+
+fn colorLerp(a: rl.Color, b: rl.Color, t_raw: f32) rl.Color {
+    const t = std.math.clamp(t_raw, @as(f32, 0.0), @as(f32, 1.0));
+    return .{
+        .r = @intFromFloat(@as(f32, @floatFromInt(a.r)) + (@as(f32, @floatFromInt(b.r)) - @as(f32, @floatFromInt(a.r))) * t),
+        .g = @intFromFloat(@as(f32, @floatFromInt(a.g)) + (@as(f32, @floatFromInt(b.g)) - @as(f32, @floatFromInt(a.g))) * t),
+        .b = @intFromFloat(@as(f32, @floatFromInt(a.b)) + (@as(f32, @floatFromInt(b.b)) - @as(f32, @floatFromInt(a.b))) * t),
+        .a = @intFromFloat(@as(f32, @floatFromInt(a.a)) + (@as(f32, @floatFromInt(b.a)) - @as(f32, @floatFromInt(a.a))) * t),
+    };
+}
+
+fn rgbfColor(rgb: window_atlas.ColorRgbf, alpha: f32) rl.Color {
+    return .{
+        .r = @intFromFloat(std.math.clamp(rgb.r, @as(f32, 0.0), @as(f32, 1.0)) * 255.0),
+        .g = @intFromFloat(std.math.clamp(rgb.g, @as(f32, 0.0), @as(f32, 1.0)) * 255.0),
+        .b = @intFromFloat(std.math.clamp(rgb.b, @as(f32, 0.0), @as(f32, 1.0)) * 255.0),
+        .a = @intFromFloat(std.math.clamp(alpha, @as(f32, 0.0), @as(f32, 1.0)) * 255.0),
+    };
+}
+
 fn drawTextureTiled(texture: rl.Texture2D, area: rl.Rectangle, tint: rl.Color) void {
     const tile_width = @as(f32, @floatFromInt(texture.width));
     const tile_height = @as(f32, @floatFromInt(texture.height));
@@ -663,51 +746,221 @@ fn drawPlayers(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*
         const color = if (player.health > 0.0) player_color else dead_player_color;
 
         if (runtime_assets) |assets| {
-            const base_tint = if (player.health > 0.0) rl.Color.white else dead_player_color;
-            drawTextureCenteredRotated(
-                assets.texture(.trooper),
-                center,
-                player.size * 1.2,
-                player.size * 1.2,
-                headingToDegrees(player.aim_heading),
-                base_tint,
-            );
+            const trooper_texture = assets.texture(.trooper);
+            const cell = @as(f32, @floatFromInt(trooper_texture.width)) / 8.0;
+            if (cell > 0.0) {
+                const base_scale = player.size / cell;
+                const shadow_tint = colorWithAlpha(rl.Color.black, 90.0 / 255.0);
+                const elapsed_s = runner.session.elapsed_ms_sim * 0.001;
 
-            if (player.health > 0.0 and player.muzzle_flash_alpha > 0.02) {
-                drawTextureCenteredRotated(
-                    assets.texture(.muzzle_flash),
-                    toRlVec(player.aim),
-                    player.size * 0.72,
-                    player.size * 0.72,
-                    headingToDegrees(player.aim_heading),
-                    colorWithAlpha(rl.Color.white, std.math.clamp(player.muzzle_flash_alpha, @as(f32, 0.0), @as(f32, 1.0))),
+                if (player.health > 0.0) {
+                    if (runtime_perks.perkActive(&player, .radioactive)) {
+                        if (window_atlas.effectRect(assets.texture(.particles).width, assets.texture(.particles).height, .aura)) |src_rect| {
+                            const aura_alpha = ((std.math.sin(elapsed_s) + 1.0) * 0.1875 + 0.25);
+                            if (aura_alpha > 1e-3) {
+                                rl.beginBlendMode(.additive);
+                                drawTextureRegionCenteredRotated(
+                                    assets.texture(.particles),
+                                    src_rect,
+                                    center,
+                                    100.0,
+                                    100.0,
+                                    0.0,
+                                    colorWithAlpha(rl.Color.init(77, 153, 77, 255), aura_alpha),
+                                );
+                                rl.endBlendMode();
+                            }
+                        }
+                    }
+
+                    const leg_frame = std.math.clamp(@as(i32, @intFromFloat(player.move_phase + 0.5)), @as(i32, 0), @as(i32, 14));
+                    const torso_frame = leg_frame + 16;
+                    const recoil_dir = player.aim_heading + std.math.pi / 2.0;
+                    const recoil = player.muzzle_flash_alpha * 12.0;
+                    const recoil_offset = state_mod.Vec2.fromAngle(recoil_dir).mul(recoil);
+                    const torso_center = center;
+                    const torso_draw_center = rl.Vector2.init(torso_center.x + recoil_offset.x, torso_center.y + recoil_offset.y);
+
+                    drawAtlasFrameCenteredRotated(
+                        trooper_texture,
+                        8,
+                        leg_frame,
+                        .{ .x = center.x + 3.0 + player.size * 0.01, .y = center.y + 3.0 + player.size * 0.01 },
+                        base_scale * 1.02,
+                        player.heading,
+                        shadow_tint,
+                    );
+                    drawAtlasFrameCenteredRotated(
+                        trooper_texture,
+                        8,
+                        torso_frame,
+                        .{ .x = torso_draw_center.x + 1.0 + player.size * 0.015, .y = torso_draw_center.y + 1.0 + player.size * 0.015 },
+                        base_scale * 1.03,
+                        player.aim_heading,
+                        shadow_tint,
+                    );
+                    drawAtlasFrameCenteredRotated(trooper_texture, 8, leg_frame, center, base_scale, player.heading, rl.Color.white);
+                    drawAtlasFrameCenteredRotated(trooper_texture, 8, torso_frame, torso_draw_center, base_scale, player.aim_heading, rl.Color.white);
+
+                    if (player.shield_timer > 1e-3) {
+                        if (window_atlas.effectRect(assets.texture(.particles).width, assets.texture(.particles).height, .shield_ring)) |src_rect| {
+                            const timer = player.shield_timer;
+                            var strength = ((std.math.sin(elapsed_s) + 1.0) * 0.25 + timer);
+                            if (timer < 1.0) strength *= timer;
+                            strength = @min(1.0, strength);
+                            if (strength > 1e-3) {
+                                const offset_dir = player.aim_heading - std.math.pi / 2.0;
+                                const shield_center_off = state_mod.Vec2.fromAngle(offset_dir).mul(3.0);
+                                const shield_center = rl.Vector2.init(center.x + shield_center_off.x, center.y + shield_center_off.y);
+                                const half_1 = std.math.sin(elapsed_s * 3.0) + 17.5;
+                                const size_1 = half_1 * 2.0;
+                                const half_2 = std.math.sin(elapsed_s * 3.0) * 4.0 + 24.0;
+                                const size_2 = half_2 * 2.0;
+                                rl.beginBlendMode(.additive);
+                                drawTextureRegionCenteredRotated(
+                                    assets.texture(.particles),
+                                    src_rect,
+                                    shield_center,
+                                    size_1,
+                                    size_1,
+                                    radiansToDegrees(elapsed_s * 2.0),
+                                    colorWithAlpha(rl.Color.init(91, 180, 255, 255), strength * 0.4),
+                                );
+                                drawTextureRegionCenteredRotated(
+                                    assets.texture(.particles),
+                                    src_rect,
+                                    shield_center,
+                                    size_2,
+                                    size_2,
+                                    radiansToDegrees(elapsed_s * -2.0),
+                                    colorWithAlpha(rl.Color.init(91, 180, 255, 255), strength * 0.3),
+                                );
+                                rl.endBlendMode();
+                            }
+                        }
+                    }
+
+                    if (player.muzzle_flash_alpha > 0.02) {
+                        const flags = weapon_data.weapon_stats.get(player.weapon.weapon_id).flags;
+                        if ((flags & 0x8) == 0) {
+                            const flash_alpha = std.math.clamp(player.muzzle_flash_alpha * 0.8, @as(f32, 0.0), @as(f32, 1.0));
+                            if (flash_alpha > 1e-3) {
+                                const flash_size = player.size * (if ((flags & 0x4) != 0) @as(f32, 0.5) else @as(f32, 1.0));
+                                const flash_heading = player.aim_heading + std.math.pi / 2.0;
+                                const flash_offset = (player.muzzle_flash_alpha * 12.0) - 21.0;
+                                const flash_pos_off = state_mod.Vec2.fromAngle(flash_heading).mul(flash_offset);
+                                const flash_center = rl.Vector2.init(center.x + flash_pos_off.x, center.y + flash_pos_off.y);
+                                rl.beginBlendMode(.additive);
+                                drawTextureCenteredRotated(
+                                    assets.texture(.muzzle_flash),
+                                    flash_center,
+                                    flash_size,
+                                    flash_size,
+                                    radiansToDegrees(player.aim_heading),
+                                    colorWithAlpha(rl.Color.white, flash_alpha),
+                                );
+                                rl.endBlendMode();
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                var dead_frame: i32 = 52;
+                if (player.death_timer >= 0.0) {
+                    dead_frame = 32 + @as(i32, @intFromFloat((16.0 - player.death_timer) * 1.25));
+                    dead_frame = std.math.clamp(dead_frame, @as(i32, 32), @as(i32, 52));
+                }
+                drawAtlasFrameCenteredRotated(
+                    trooper_texture,
+                    8,
+                    dead_frame,
+                    .{ .x = center.x + 1.0 + player.size * 0.015, .y = center.y + 1.0 + player.size * 0.015 },
+                    base_scale * 1.03,
+                    player.aim_heading,
+                    shadow_tint,
                 );
+                drawAtlasFrameCenteredRotated(trooper_texture, 8, dead_frame, center, base_scale, player.aim_heading, dead_player_color);
+                continue;
             }
         } else {
             rl.drawCircleV(center, radius, color);
             rl.drawCircleLinesV(center, radius + 2.0, rl.Color.black);
+            rl.drawLineEx(center, toRlVec(player.aim), 2.0, rl.Color.gold);
         }
-
-        rl.drawLineEx(center, toRlVec(player.aim), 2.0, rl.Color.gold);
     }
 }
 
 fn drawCreatures(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+    const monster_vision_active = if (runner.player0Const()) |player|
+        runtime_perks.perkActive(player, .monster_vision)
+    else
+        false;
+
     for (runner.session.creatures.entries) |creature| {
         if (!creature.active) continue;
         const color = if (creature.hp > 0.0) creature_color else corpse_color;
         const radius = @max(6.0, creature.size * 0.24);
         if (runtime_assets) |assets| {
-            if (creatureTextureId(creature)) |texture_id| {
-                drawTextureCenteredRotated(
-                    assets.texture(texture_id),
-                    toRlVec(creature.pos),
-                    creature.size * 1.14,
-                    creature.size * 1.14,
-                    headingToDegrees(creature.heading),
-                    if (creature.hp > 0.0) rl.Color.white else corpse_color,
-                );
-                continue;
+            if (window_atlas.creatureRenderFrame(creature)) |render_frame| {
+                const texture = assets.texture(switch (render_frame.texture_kind) {
+                    .alien => .alien,
+                    .lizard => .lizard,
+                    .spider_sp1 => .spider_sp1,
+                    .spider_sp2 => .spider_sp2,
+                    .trooper => .trooper,
+                    .zombie => .zombie,
+                });
+                const cell = @as(f32, @floatFromInt(texture.width)) / 8.0;
+                if (cell > 0.0) {
+                    const base_scale = creature.size / cell;
+                    var tint = rl.Color.white;
+                    if (runner.session.state.bonuses.energizer > 0.0 and creature.max_hp < 500.0) {
+                        tint = colorLerp(
+                            rl.Color.white,
+                            rl.Color.init(128, 128, 255, 255),
+                            @min(runner.session.state.bonuses.energizer, 1.0),
+                        );
+                    }
+                    if (creature.lifecycle_stage < 0.0) {
+                        tint = colorWithAlpha(tint, @max(0.0, 1.0 + creature.lifecycle_stage * 0.1));
+                    }
+                    const shadow_enabled = !monster_vision_active;
+                    if (shadow_enabled) {
+                        const is_long = runtime_anim.creatureAnimIsLongStrip(creature.flags);
+                        var shadow_alpha: f32 = 0.4;
+                        if (creature.lifecycle_stage < 0.0) {
+                            shadow_alpha = @max(
+                                @as(f32, 0.0),
+                                shadow_alpha + creature.lifecycle_stage * (if (is_long) @as(f32, 0.5) else @as(f32, 0.1)),
+                            );
+                        }
+                        if (shadow_alpha > 1e-3) {
+                            drawAtlasFrameCenteredRotated(
+                                texture,
+                                8,
+                                render_frame.frame,
+                                .{
+                                    .x = creature.pos.x + creature.size * 0.035 - 0.7,
+                                    .y = creature.pos.y + creature.size * 0.035 - 0.7,
+                                },
+                                base_scale * 1.07,
+                                creature.heading - std.math.pi / 2.0,
+                                colorWithAlpha(rl.Color.black, shadow_alpha),
+                            );
+                        }
+                    }
+                    drawAtlasFrameCenteredRotated(
+                        texture,
+                        8,
+                        render_frame.frame,
+                        toRlVec(creature.pos),
+                        base_scale,
+                        creature.heading - std.math.pi / 2.0,
+                        tint,
+                    );
+                    continue;
+                }
             }
         }
         rl.drawCircleV(toRlVec(creature.pos), radius, color);
@@ -718,20 +971,7 @@ fn drawProjectiles(runner: *const live_runner.LiveSurvivalRunner, runtime_assets
     for (runner.session.projectiles.entries) |projectile| {
         if (!projectile.active) continue;
         if (runtime_assets) |assets| {
-            const projectile_texture = projectileTextureId(projectile.type_id) orelse {
-                rl.drawCircleV(toRlVec(projectile.pos), 3.0, projectile_color);
-                continue;
-            };
-            const sprite_size = projectileSpriteSize(projectile.type_id);
-            drawTextureCenteredRotated(
-                assets.texture(projectile_texture),
-                toRlVec(projectile.pos),
-                sprite_size,
-                sprite_size,
-                headingToDegrees(projectile.angle),
-                rl.Color.white,
-            );
-            continue;
+            if (drawProjectileWithAssets(projectile, assets)) continue;
         }
         rl.drawCircleV(toRlVec(projectile.pos), 3.0, projectile_color);
     }
@@ -745,7 +985,7 @@ fn drawProjectiles(runner: *const live_runner.LiveSurvivalRunner, runtime_assets
                     toRlVec(projectile.pos),
                     sprite_size,
                     sprite_size,
-                    headingToDegrees(projectile.angle),
+                    radiansToDegrees(projectile.angle),
                     colorWithAlpha(rl.Color.white, secondaryProjectileAlpha(projectile)),
                 );
                 continue;
@@ -756,19 +996,66 @@ fn drawProjectiles(runner: *const live_runner.LiveSurvivalRunner, runtime_assets
 }
 
 fn drawBonuses(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
-    for (runner.session.bonuses.entries) |entry| {
+    const bonus_phase = runner.session.elapsed_ms_sim * 0.001 * 1.3;
+    for (runner.session.bonuses.entries, 0..) |entry, idx| {
         if (entry.bonus_id == .unused) continue;
         if (runtime_assets) |assets| {
-            if (bonusTextureId(entry)) |texture_id| {
-                const alpha = bonusAlpha(entry);
-                drawTextureCenteredRotated(
-                    assets.texture(texture_id),
-                    toRlVec(entry.pos),
-                    26.0,
-                    26.0,
-                    0.0,
-                    colorWithAlpha(rl.Color.white, alpha),
-                );
+            const bonuses_texture = assets.texture(.bonuses);
+            const bubble_src = window_atlas.bonusIconRect(bonuses_texture.width, bonuses_texture.height, 0);
+            const fade = window_atlas.bonusFade(entry.time_left, entry.time_max);
+            const bubble_alpha = fade * 0.9;
+            const center = toRlVec(entry.pos);
+            drawTextureRegionCenteredRotated(
+                bonuses_texture,
+                bubble_src,
+                center,
+                32.0,
+                32.0,
+                0.0,
+                colorWithAlpha(rl.Color.white, bubble_alpha),
+            );
+
+            if (entry.bonus_id == .weapon) {
+                const weapon_id = std.meta.intToEnum(game_ids.WeaponId, entry.amount) catch {
+                    continue;
+                };
+                const icon_index = weapon_data.weaponIconIndex(weapon_id);
+                if (icon_index >= 0) {
+                    const pulse_sin = std.math.sin(bonus_phase);
+                    const pulse = pulse_sin * pulse_sin * pulse_sin * pulse_sin * 0.25 + 0.75;
+                    const icon_scale = fade * pulse;
+                    if (icon_scale > 1e-3) {
+                        const src_rect = window_atlas.weaponIconRect(assets.texture(.ui_wicons).width, assets.texture(.ui_wicons).height, icon_index);
+                        drawTextureRegionCenteredRotated(
+                            assets.texture(.ui_wicons),
+                            src_rect,
+                            center,
+                            60.0 * icon_scale,
+                            30.0 * icon_scale,
+                            0.0,
+                            colorWithAlpha(rl.Color.white, bubble_alpha),
+                        );
+                    }
+                }
+                continue;
+            }
+
+            if (window_atlas.bonusIconId(entry)) |icon_id| {
+                const idx_f: f32 = @floatFromInt(idx);
+                const pulse_sin = std.math.sin(idx_f + bonus_phase);
+                const pulse = pulse_sin * pulse_sin * pulse_sin * pulse_sin * 0.25 + 0.75;
+                const icon_scale = fade * pulse;
+                if (icon_scale > 1e-3) {
+                    drawTextureRegionCenteredRotated(
+                        bonuses_texture,
+                        window_atlas.bonusIconRect(bonuses_texture.width, bonuses_texture.height, icon_id),
+                        center,
+                        32.0 * icon_scale,
+                        32.0 * icon_scale,
+                        radiansToDegrees(std.math.sin(idx_f - runner.session.elapsed_ms_sim * 0.003) * 0.2),
+                        colorWithAlpha(rl.Color.white, bubble_alpha),
+                    );
+                }
                 continue;
             }
         }
@@ -782,6 +1069,178 @@ fn drawBonuses(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*
             bonus_color,
         );
     }
+}
+
+fn drawProjectileWithAssets(projectile: cz.projectiles.Projectile, assets: *const window_assets.RuntimeAssets) bool {
+    if (window_atlas.isBulletTrailType(projectile.type_id)) {
+        return drawBulletTrailProjectile(projectile, assets);
+    }
+    if (window_atlas.isBeamType(projectile.type_id)) {
+        return drawBeamProjectile(projectile, assets);
+    }
+    if (window_atlas.isPlasmaParticleType(projectile.type_id)) {
+        return drawPlasmaProjectile(projectile, assets);
+    }
+    if (window_atlas.projectileKnownFrame(projectile.type_id)) |known| {
+        const rgb = window_atlas.knownProjectileRgb(projectile.type_id);
+        drawAtlasFrameCenteredRotated(
+            assets.texture(.projs),
+            known.grid,
+            known.frame,
+            toRlVec(projectile.pos),
+            0.6,
+            projectile.angle,
+            colorWithAlpha(rl.Color.init(rgb.r, rgb.g, rgb.b, 255), std.math.clamp(projectile.life_timer / 0.4, @as(f32, 0.0), @as(f32, 1.0))),
+        );
+        return true;
+    }
+    return false;
+}
+
+fn drawBulletTrailProjectile(projectile: cz.projectiles.Projectile, assets: *const window_assets.RuntimeAssets) bool {
+    const start = toRlVec(projectile.origin);
+    const end = toRlVec(projectile.pos);
+    const segment = vecSub(end, start);
+    const distance = vecLength(segment);
+    const rotation = radiansToDegrees(std.math.atan2(segment.y, segment.x));
+    const alpha = std.math.clamp(projectile.life_timer, @as(f32, 0.0), @as(f32, 1.0));
+    if (distance > 1e-3) {
+        rl.beginBlendMode(.additive);
+        drawTextureCenteredRotated(
+            assets.texture(.bullet_trail),
+            .{ .x = (start.x + end.x) * 0.5, .y = (start.y + end.y) * 0.5 },
+            distance,
+            4.0,
+            rotation,
+            colorWithAlpha(rl.Color.init(180, 180, 180, 255), alpha),
+        );
+        rl.endBlendMode();
+    }
+    if (projectile.life_timer >= 0.39) {
+        const size = window_atlas.bulletSpriteSize(projectile.type_id);
+        drawTextureCenteredRotated(
+            assets.texture(.bullet_i),
+            end,
+            size,
+            size,
+            radiansToDegrees(projectile.angle),
+            colorWithAlpha(rl.Color.init(220, 220, 220, 255), alpha),
+        );
+    }
+    return true;
+}
+
+fn drawBeamProjectile(projectile: cz.projectiles.Projectile, assets: *const window_assets.RuntimeAssets) bool {
+    const origin = toRlVec(projectile.origin);
+    const head = toRlVec(projectile.pos);
+    const delta = vecSub(head, origin);
+    const dist = vecLength(delta);
+    if (!(dist > 1e-6)) return true;
+
+    const direction = vecNormalizeOr(delta, .{ .x = 1.0, .y = 0.0 });
+    const effect_scale = window_atlas.beamEffectScale(projectile.type_id);
+    const start = if (dist > 256.0) dist - 256.0 else 0.0;
+    const span = dist - start;
+    const step = @min(effect_scale * 3.1, 9.0);
+    const base_alpha = if (projectile.life_timer >= 0.4)
+        1.0
+    else
+        std.math.clamp(projectile.life_timer * 2.5, @as(f32, 0.0), @as(f32, 1.0));
+    const streak_rgb = if (projectile.type_id == @intFromEnum(game_ids.ProjectileTypeId.fire_bullets))
+        rl.Color.init(255, 153, 26, 255)
+    else
+        rl.Color.init(128, 153, 255, 255);
+
+    rl.beginBlendMode(.additive);
+    var s: f32 = start;
+    while (s < dist) : (s += step) {
+        const t = if (span > 1e-6) (s - start) / span else 1.0;
+        const seg_alpha = std.math.clamp(t * base_alpha, @as(f32, 0.0), @as(f32, 1.0));
+        if (seg_alpha <= 1e-3) continue;
+        const pos = vecAdd(origin, vecScale(direction, s));
+        drawAtlasFrameCenteredRotated(assets.texture(.projs), 4, 2, pos, effect_scale, 0.0, colorWithAlpha(streak_rgb, seg_alpha));
+    }
+    drawAtlasFrameCenteredRotated(assets.texture(.projs), 4, 2, head, effect_scale, projectile.angle, colorWithAlpha(rl.Color.init(255, 255, 179, 255), base_alpha));
+    if (projectile.type_id == @intFromEnum(game_ids.ProjectileTypeId.fire_bullets)) {
+        if (window_atlas.effectRect(assets.texture(.particles).width, assets.texture(.particles).height, .glow)) |src_rect| {
+            drawTextureRegionCenteredRotated(
+                assets.texture(.particles),
+                src_rect,
+                head,
+                64.0,
+                64.0,
+                radiansToDegrees(projectile.angle),
+                colorWithAlpha(rl.Color.white, base_alpha),
+            );
+        }
+    }
+    rl.endBlendMode();
+    return true;
+}
+
+fn drawPlasmaProjectile(projectile: cz.projectiles.Projectile, assets: *const window_assets.RuntimeAssets) bool {
+    const src_rect = window_atlas.effectRect(assets.texture(.particles).width, assets.texture(.particles).height, .glow) orelse return false;
+    const cfg = window_atlas.plasmaRenderConfig(projectile.type_id);
+    const alpha = if (projectile.life_timer >= 0.4)
+        1.0
+    else
+        std.math.clamp(projectile.life_timer * 2.5, @as(f32, 0.0), @as(f32, 1.0));
+    const origin = toRlVec(projectile.origin);
+    const head = toRlVec(projectile.pos);
+    const direction = vecNormalizeOr(vecSub(head, origin), .{ .x = 0.0, .y = -1.0 });
+
+    rl.beginBlendMode(.additive);
+    if (projectile.life_timer >= 0.4) {
+        var seg_count = @as(i32, @intFromFloat(projectile.travel_budget));
+        if (seg_count < 0) seg_count = 0;
+        seg_count = @divTrunc(seg_count, 5);
+        if (seg_count > cfg.seg_limit) seg_count = cfg.seg_limit;
+
+        var idx: i32 = 0;
+        while (idx < seg_count) : (idx += 1) {
+            const pos = vecAdd(head, vecScale(direction, -@as(f32, @floatFromInt(idx)) * cfg.spacing));
+            drawTextureRegionCenteredRotated(
+                assets.texture(.particles),
+                src_rect,
+                pos,
+                cfg.tail_size,
+                cfg.tail_size,
+                0.0,
+                rgbfColor(cfg.rgb, alpha * 0.4),
+            );
+        }
+
+        drawTextureRegionCenteredRotated(
+            assets.texture(.particles),
+            src_rect,
+            head,
+            cfg.head_size,
+            cfg.head_size,
+            0.0,
+            rgbfColor(cfg.rgb, alpha * cfg.head_alpha_mul),
+        );
+        drawTextureRegionCenteredRotated(
+            assets.texture(.particles),
+            src_rect,
+            head,
+            cfg.aura_size,
+            cfg.aura_size,
+            0.0,
+            rgbfColor(cfg.aura_rgb, alpha * cfg.aura_alpha_mul),
+        );
+    } else {
+        drawTextureRegionCenteredRotated(
+            assets.texture(.particles),
+            src_rect,
+            head,
+            56.0,
+            56.0,
+            0.0,
+            colorWithAlpha(rl.Color.white, alpha),
+        );
+    }
+    rl.endBlendMode();
+    return true;
 }
 
 const TerrainTextureSet = struct {
@@ -798,64 +1257,6 @@ fn terrainTextureSet(quest_unlock_index: i32) TerrainTextureSet {
         .{ .base = .ter_q2_base, .overlay = .ter_q2_overlay }
     else
         .{ .base = .ter_q1_base, .overlay = .ter_q1_overlay };
-}
-
-fn creatureTextureId(creature: cz.creatures.CreatureState) ?window_assets.TextureId {
-    const creature_type = std.meta.intToEnum(spawn_runtime.CreatureTypeId, creature.type_id) catch return null;
-    return switch (creature_type) {
-        .alien => .alien,
-        .lizard => .lizard,
-        .spider_sp1 => .spider_sp1,
-        .spider_sp2 => .spider_sp2,
-        .trooper => .trooper,
-        .zombie => .zombie,
-    };
-}
-
-fn projectileTextureId(projectile_type_raw: i32) ?window_assets.TextureId {
-    const projectile_type = std.meta.intToEnum(game_ids.ProjectileTypeId, projectile_type_raw) catch return null;
-    return switch (projectile_type) {
-        .pistol,
-        .assault_rifle,
-        .shotgun,
-        .submachine_gun,
-        => .bullet_i,
-        .gauss_gun,
-        .plasma_rifle,
-        .plasma_minigun,
-        .pulse_gun,
-        .ion_rifle,
-        .ion_minigun,
-        .ion_cannon,
-        .shrinkifier,
-        .blade_gun,
-        .spider_plasma,
-        .plasma_cannon,
-        .splitter_gun,
-        .plague_spreader,
-        .rainbow_gun,
-        .fire_bullets,
-        => .bullet_trail,
-    };
-}
-
-fn projectileSpriteSize(projectile_type_raw: i32) f32 {
-    const projectile_type = std.meta.intToEnum(game_ids.ProjectileTypeId, projectile_type_raw) catch return 10.0;
-    return switch (projectile_type) {
-        .ion_cannon,
-        .plasma_cannon,
-        => 26.0,
-        .ion_rifle,
-        .ion_minigun,
-        .plasma_rifle,
-        .plasma_minigun,
-        .pulse_gun,
-        => 18.0,
-        .gauss_gun,
-        .blade_gun,
-        => 16.0,
-        else => 12.0,
-    };
 }
 
 fn secondaryProjectileTextureId(projectile_type: secondary_projectiles_runtime.SecondaryProjectileTypeId) ?window_assets.TextureId {
@@ -881,27 +1282,6 @@ fn secondaryProjectileAlpha(projectile: secondary_projectiles_runtime.SecondaryP
         .detonation => std.math.clamp(1.0 - projectile.detonation_t * 0.5, @as(f32, 0.15), @as(f32, 1.0)),
         else => 1.0,
     };
-}
-
-fn bonusTextureId(entry: bonuses_runtime.BonusEntry) ?window_assets.TextureId {
-    return switch (entry.bonus_id) {
-        .unused => null,
-        .points, .energizer, .double_experience => .ui_arrow,
-        .weapon, .weapon_power_up => .ui_ind_bullet,
-        .nuke => .ui_ind_rocket,
-        .shock_chain => .ui_ind_electric,
-        .fireblast, .fire_bullets => .ui_ind_fire,
-        .reflex_boost => .ui_icon_aim,
-        .shield, .medikit => .ui_ind_life,
-        .freeze => .ui_ind_panel,
-        .speed => .arrow,
-    };
-}
-
-fn bonusAlpha(entry: bonuses_runtime.BonusEntry) f32 {
-    if (entry.picked) return 0.42;
-    if (!(entry.time_max > 0.0)) return 1.0;
-    return std.math.clamp(entry.time_left / entry.time_max, @as(f32, 0.28), @as(f32, 1.0));
 }
 
 fn colorWithAlpha(color: rl.Color, alpha: f32) rl.Color {


### PR DESCRIPTION
## Summary

- port shared creature animation/frame selection into Zig
- switch the desktop renderer from whole-sheet stand-ins to atlas-based sprite rendering
- render troopers, creatures, bonuses, and projectile effects using the runtime asset atlases

## Details

- add `runtime/anim.zig` with creature animation phase advance, frame selection, and corpse frame mapping
- advance creature `anim_phase` in the deterministic runtime so rendering can match Python behavior
- add weapon icon index metadata for `ui_wicons`
- add `window_atlas.zig` for atlas rect helpers, projectile/effect lookup tables, and bonus/creature frame helpers
- update `window_main.zig` to render:
  - layered trooper legs/torso/death frames
  - creature atlas frames with death staging and shadow passes
  - bonus bubbles and weapon/non-weapon icons from the correct atlases
  - bullet trails, beam streaks, plasma glows, and known projectile atlas frames

## Verification

- `zig build test`
- `zig build window`
- `zig build asset-smoke`
- `zig build wasm`
