### PR TITLE
feat(zig): port weapon fire recipe runtime

### DIFF
--- a/crimson-zig/src/game_ids.zig
+++ b/crimson-zig/src/game_ids.zig
@@ -70,11 +70,19 @@ pub const ProjectileTypeId = enum(i32) {
     shrinkifier = 0x18,
     blade_gun = 0x19,
     spider_plasma = 0x1A,
+    evil_scythe = 0x1B,
     plasma_cannon = 0x1C,
     splitter_gun = 0x1D,
+    flameburst = 0x20,
+    raygun = 0x21,
     plague_spreader = 0x29,
     rainbow_gun = 0x2B,
+    grim_weapon = 0x2C,
     fire_bullets = 0x2D,
+    transmutator = 0x32,
+    blaster_r_300 = 0x33,
+    lightning_rifle = 0x34,
+    nuke_launcher = 0x35,
 };
 
 pub const BonusId = enum(i32) {

--- a/crimson-zig/src/root.zig
+++ b/crimson-zig/src/root.zig
@@ -6,6 +6,7 @@ pub const replay_codec = @import("replay_codec.zig");
 pub const replay_runner = @import("runtime/replay_runner.zig");
 pub const spawn = @import("runtime/spawn.zig");
 pub const anim = @import("runtime/anim.zig");
+pub const fire_recipes = @import("runtime/fire_recipes.zig");
 pub const creatures = @import("runtime/creatures.zig");
 pub const helpers = @import("runtime/helpers.zig");
 pub const native_math = @import("runtime/native_math.zig");

--- a/crimson-zig/src/runtime/fire_recipes.zig
+++ b/crimson-zig/src/runtime/fire_recipes.zig
@@ -1,0 +1,256 @@
+const game_ids = @import("../game_ids.zig");
+
+const particles_mod = @import("particles.zig");
+const secondary_projectiles_mod = @import("secondary_projectiles.zig");
+const weapon_data = @import("weapon_data.zig");
+
+pub const WeaponId = game_ids.WeaponId;
+pub const ProjectileTypeId = game_ids.ProjectileTypeId;
+
+pub const PelletJitterRule = union(enum) {
+    none,
+    modulo_centered: struct {
+        modulo: u32,
+        center: i32,
+        step: f32,
+    },
+    mask_centered: struct {
+        mask: u32,
+        center: i32,
+        step: f32,
+    },
+};
+
+pub const SpeedScaleRule = union(enum) {
+    none,
+    modulo: struct {
+        base: f32,
+        modulo: u32,
+        step: f32,
+    },
+};
+
+pub const SecondaryTargetingPolicy = enum {
+    none,
+    use_aim_target_hint,
+};
+
+pub const PrimaryPelletsMode = struct {
+    type_id: ?ProjectileTypeId = null,
+    count: i32 = 0,
+    jitter: PelletJitterRule = .none,
+    speed_scale: SpeedScaleRule = .none,
+};
+
+pub const SecondaryShotMode = struct {
+    type_id: secondary_projectiles_mod.SecondaryProjectileTypeId,
+    targeting: SecondaryTargetingPolicy = .none,
+};
+
+pub const ParticleStreamMode = struct {
+    style: ?particles_mod.ParticleStyleId = null,
+    slow: bool = false,
+};
+
+pub const FireMode = union(enum) {
+    primary_pellets: PrimaryPelletsMode,
+    secondary_shot: SecondaryShotMode,
+    particle_stream: ParticleStreamMode,
+    multi_plasma_fan: void,
+    swarmer_dump: void,
+};
+
+pub const FireRecipe = struct {
+    mode: FireMode,
+    ammo_cost: f32 = 1.0,
+};
+
+const default_spread_jitter: PelletJitterRule = .{
+    .modulo_centered = .{
+        .modulo = 200,
+        .center = 100,
+        .step = 0.0015,
+    },
+};
+
+const default_speed_scale: SpeedScaleRule = .{
+    .modulo = .{
+        .base = 1.0,
+        .modulo = 100,
+        .step = 0.01,
+    },
+};
+
+const gauss_ion_speed_scale: SpeedScaleRule = .{
+    .modulo = .{
+        .base = 1.4,
+        .modulo = 0x50,
+        .step = 0.01,
+    },
+};
+
+pub fn pelletJitterStepForWeapon(weapon_id: WeaponId) f32 {
+    return switch (weapon_id) {
+        .shotgun, .jackhammer => 0.0013,
+        .sawed_off_shotgun => 0.004,
+        else => 0.0015,
+    };
+}
+
+pub fn resolveFireRecipe(
+    weapon_id: WeaponId,
+    pellet_count: i32,
+    fire_bullets_active: bool,
+) FireRecipe {
+    if (fire_bullets_active) {
+        return .{
+            .mode = .{
+                .primary_pellets = .{
+                    .type_id = .fire_bullets,
+                    .count = @max(0, pellet_count),
+                    .jitter = default_spread_jitter,
+                    .speed_scale = .none,
+                },
+            },
+        };
+    }
+
+    return switch (weapon_id) {
+        .rocket_launcher => .{
+            .mode = .{
+                .secondary_shot = .{
+                    .type_id = .rocket,
+                },
+            },
+        },
+        .seeker_rockets => .{
+            .mode = .{
+                .secondary_shot = .{
+                    .type_id = .homing_rocket,
+                    .targeting = .use_aim_target_hint,
+                },
+            },
+        },
+        .rocket_minigun => .{
+            .mode = .{
+                .secondary_shot = .{
+                    .type_id = .rocket_minigun,
+                },
+            },
+        },
+        .flamethrower => .{
+            .mode = .{
+                .particle_stream = .{},
+            },
+            .ammo_cost = 0.1,
+        },
+        .blow_torch => .{
+            .mode = .{
+                .particle_stream = .{
+                    .style = .blow_torch,
+                },
+            },
+            .ammo_cost = 0.05,
+        },
+        .hr_flamer => .{
+            .mode = .{
+                .particle_stream = .{
+                    .style = .hr_flamer,
+                },
+            },
+            .ammo_cost = 0.1,
+        },
+        .bubblegun => .{
+            .mode = .{
+                .particle_stream = .{
+                    .slow = true,
+                },
+            },
+            .ammo_cost = 0.15,
+        },
+        .multi_plasma => .{
+            .mode = .{ .multi_plasma_fan = {} },
+        },
+        .mini_rocket_swarmers => .{
+            .mode = .{ .swarmer_dump = {} },
+        },
+        .plasma_shotgun => .{
+            .mode = .{
+                .primary_pellets = .{
+                    .type_id = .plasma_minigun,
+                    .count = 14,
+                    .jitter = .{
+                        .mask_centered = .{
+                            .mask = 0xff,
+                            .center = 0x80,
+                            .step = 0.002,
+                        },
+                    },
+                    .speed_scale = default_speed_scale,
+                },
+            },
+        },
+        .gauss_shotgun => .{
+            .mode = .{
+                .primary_pellets = .{
+                    .type_id = .gauss_gun,
+                    .count = 6,
+                    .jitter = .{
+                        .modulo_centered = .{
+                            .modulo = 200,
+                            .center = 100,
+                            .step = 0.002,
+                        },
+                    },
+                    .speed_scale = gauss_ion_speed_scale,
+                },
+            },
+        },
+        .ion_shotgun => .{
+            .mode = .{
+                .primary_pellets = .{
+                    .type_id = .ion_minigun,
+                    .count = 8,
+                    .jitter = .{
+                        .modulo_centered = .{
+                            .modulo = 200,
+                            .center = 100,
+                            .step = 0.0026,
+                        },
+                    },
+                    .speed_scale = gauss_ion_speed_scale,
+                },
+            },
+        },
+        else => blk: {
+            const pellets = @max(1, pellet_count);
+            const jitter: PelletJitterRule = if (pellets > 1)
+                .{
+                    .modulo_centered = .{
+                        .modulo = 200,
+                        .center = 100,
+                        .step = pelletJitterStepForWeapon(weapon_id),
+                    },
+                }
+            else
+                .none;
+
+            const speed_scale: SpeedScaleRule = if (pellets > 1 and
+                (weapon_id == .shotgun or weapon_id == .sawed_off_shotgun or weapon_id == .jackhammer))
+                default_speed_scale
+            else
+                .none;
+
+            break :blk .{
+                .mode = .{
+                    .primary_pellets = .{
+                        .type_id = weapon_data.projectileTypeIdFromWeaponId(weapon_id),
+                        .count = pellets,
+                        .jitter = jitter,
+                        .speed_scale = speed_scale,
+                    },
+                },
+            };
+        },
+    };
+}

--- a/crimson-zig/src/runtime/weapon_data.zig
+++ b/crimson-zig/src/runtime/weapon_data.zig
@@ -133,18 +133,14 @@ pub fn weaponIdFromInt(value: i32) WeaponId {
 }
 
 pub fn projectileTypeIdFromWeaponId(weapon_id: WeaponId) ?ProjectileTypeId {
+    // Mirror Python/native `PROJECTILE_TEMPLATE_OVERRIDES`: explicit remaps and
+    // non-primary paths live here; other projectile-backed weapons default to
+    // `type_id == weapon_id` when the projectile enum has that slot.
     return switch (weapon_id) {
-        .pistol => ProjectileTypeId.pistol,
-        .assault_rifle => ProjectileTypeId.assault_rifle,
-        .shotgun => ProjectileTypeId.shotgun,
         .sawed_off_shotgun => ProjectileTypeId.shotgun,
-        .submachine_gun => ProjectileTypeId.submachine_gun,
-        .gauss_gun => ProjectileTypeId.gauss_gun,
         .mean_minigun => ProjectileTypeId.pistol,
         .flamethrower => null,
-        .plasma_rifle => ProjectileTypeId.plasma_rifle,
         .multi_plasma => ProjectileTypeId.plasma_rifle,
-        .plasma_minigun => ProjectileTypeId.plasma_minigun,
         .rocket_launcher => null,
         .seeker_rockets => null,
         .plasma_shotgun => ProjectileTypeId.plasma_minigun,
@@ -152,23 +148,11 @@ pub fn projectileTypeIdFromWeaponId(weapon_id: WeaponId) ?ProjectileTypeId {
         .hr_flamer => null,
         .mini_rocket_swarmers => null,
         .rocket_minigun => null,
-        .pulse_gun => ProjectileTypeId.pulse_gun,
         .jackhammer => ProjectileTypeId.shotgun,
-        .ion_rifle => ProjectileTypeId.ion_rifle,
-        .ion_minigun => ProjectileTypeId.ion_minigun,
-        .ion_cannon => ProjectileTypeId.ion_cannon,
-        .shrinkifier_5k => ProjectileTypeId.shrinkifier,
-        .blade_gun => ProjectileTypeId.blade_gun,
-        .spider_plasma => ProjectileTypeId.spider_plasma,
-        .plasma_cannon => ProjectileTypeId.plasma_cannon,
-        .splitter_gun => ProjectileTypeId.splitter_gun,
         .gauss_shotgun => ProjectileTypeId.gauss_gun,
         .ion_shotgun => ProjectileTypeId.ion_minigun,
-        .plague_spreader_gun => ProjectileTypeId.plague_spreader,
         .bubblegun => null,
-        .rainbow_gun => ProjectileTypeId.rainbow_gun,
-        .fire_bullets => ProjectileTypeId.fire_bullets,
-        else => null,
+        else => std.meta.intToEnum(ProjectileTypeId, @intFromEnum(weapon_id)) catch null,
     };
 }
 
@@ -223,13 +207,21 @@ test "projectile type id mapping mirrors native fire paths" {
         .{ .weapon_id = 24, .type_id = .shrinkifier },
         .{ .weapon_id = 25, .type_id = .blade_gun },
         .{ .weapon_id = 26, .type_id = .spider_plasma },
+        .{ .weapon_id = 27, .type_id = .evil_scythe },
         .{ .weapon_id = 28, .type_id = .plasma_cannon },
         .{ .weapon_id = 29, .type_id = .splitter_gun },
         .{ .weapon_id = 30, .type_id = .gauss_gun },
         .{ .weapon_id = 31, .type_id = .ion_minigun },
+        .{ .weapon_id = 32, .type_id = .flameburst },
+        .{ .weapon_id = 33, .type_id = .raygun },
         .{ .weapon_id = 41, .type_id = .plague_spreader },
         .{ .weapon_id = 43, .type_id = .rainbow_gun },
+        .{ .weapon_id = 44, .type_id = .grim_weapon },
         .{ .weapon_id = 45, .type_id = .fire_bullets },
+        .{ .weapon_id = 50, .type_id = .transmutator },
+        .{ .weapon_id = 51, .type_id = .blaster_r_300 },
+        .{ .weapon_id = 52, .type_id = .lightning_rifle },
+        .{ .weapon_id = 53, .type_id = .nuke_launcher },
     };
 
     for (cases) |case| {

--- a/crimson-zig/src/runtime/weapons.zig
+++ b/crimson-zig/src/runtime/weapons.zig
@@ -3,6 +3,7 @@ const game_ids = @import("../game_ids.zig");
 const native_math = @import("native_math.zig");
 
 const creatures_mod = @import("creatures.zig");
+const fire_recipes = @import("fire_recipes.zig");
 const owner_ref = @import("owner_ref.zig");
 const particles_mod = @import("particles.zig");
 const perks = @import("perks.zig");
@@ -37,25 +38,9 @@ inline fn weaponId(value: i32) WeaponId {
 
 inline fn weaponIdFromProjectileTypeId(type_id: ProjectileTypeId) WeaponId {
     return switch (type_id) {
-        .pistol => .pistol,
-        .assault_rifle => .assault_rifle,
-        .shotgun => .shotgun,
-        .submachine_gun => .submachine_gun,
-        .gauss_gun => .gauss_gun,
-        .plasma_rifle => .plasma_rifle,
-        .plasma_minigun => .plasma_minigun,
-        .pulse_gun => .pulse_gun,
-        .ion_rifle => .ion_rifle,
-        .ion_minigun => .ion_minigun,
-        .ion_cannon => .ion_cannon,
         .shrinkifier => .shrinkifier_5k,
-        .blade_gun => .blade_gun,
-        .spider_plasma => .spider_plasma,
-        .plasma_cannon => .plasma_cannon,
-        .splitter_gun => .splitter_gun,
         .plague_spreader => .plague_spreader_gun,
-        .rainbow_gun => .rainbow_gun,
-        .fire_bullets => .fire_bullets,
+        else => @enumFromInt(@intFromEnum(type_id)),
     };
 }
 
@@ -388,22 +373,70 @@ fn tryFireWeaponWithForce(
         consumeMuzzleSpriteRng(state, player.weapon.weapon_id, is_fire_bullets);
     }
 
-    if (is_fire_bullets) {
-        const meta = weapon_data.weapon_stats.get(.fire_bullets).travel_budget;
-        for (0..@as(usize, @intCast(shot_count))) |_| {
-            const jitter_roll = state.rng.rand();
-            const jitter = @as(f32, @floatFromInt(@as(i32, @intCast(jitter_roll % 200)) - 100)) * 0.0015;
-            _ = projectiles.spawn(
+    const recipe = fire_recipes.resolveFireRecipe(
+        player.weapon.weapon_id,
+        pellet_count,
+        is_fire_bullets,
+    );
+    var ammo_cost = recipe.ammo_cost;
+
+    switch (recipe.mode) {
+        .primary_pellets => |mode| {
+            const type_id = mode.type_id orelse return error.UnsupportedWeaponFirePath;
+            const type_id_i32 = @intFromEnum(type_id);
+            const pellets = @max(0, mode.count);
+            shot_count = pellets;
+            const meta = projectileTravelBudgetFromTypeId(type_id);
+            for (0..@as(usize, @intCast(pellets))) |_| {
+                const angle = applyPelletJitter(state, shot_angle, mode.jitter);
+                const id = projectiles.spawn(
+                    muzzle,
+                    angle,
+                    type_id_i32,
+                    projectile_owner,
+                    meta,
+                    false,
+                );
+                applySpeedScaleRule(state, projectiles, id, mode.speed_scale);
+            }
+        },
+        .secondary_shot => |mode| {
+            const target_hint = if (mode.targeting == .use_aim_target_hint) player.aim else null;
+            _ = secondary_projectiles.spawn(
                 muzzle,
-                shot_angle + jitter,
-                @intFromEnum(game_ids.ProjectileTypeId.fire_bullets),
-                projectile_owner,
-                meta,
-                false,
+                narrowF32(shot_angle),
+                mode.type_id,
+                secondary_owner,
+                2.0,
+                target_hint,
+                if (target_hint != null) creatures else null,
             );
-        }
-    } else switch (player.weapon.weapon_id) {
-        .multi_plasma => {
+            shot_count = 1;
+        },
+        .particle_stream => |mode| {
+            if (mode.slow) {
+                _ = particles.spawnParticleSlow(
+                    state,
+                    muzzle,
+                    directionFromHeading(shot_angle).toAngle(),
+                    owner_ref.OwnerRef.fromLocalPlayer(0),
+                );
+            } else {
+                const particle_id = particles.spawnParticle(
+                    state,
+                    muzzle,
+                    particle_angle,
+                    1.0,
+                    owner_ref.OwnerRef.fromLocalPlayer(0),
+                );
+                if (mode.style) |style| {
+                    particles.entries[particle_id].style_id = style;
+                }
+            }
+            shot_count = 1;
+        },
+        .multi_plasma_fan => {
+            shot_count = 5;
             const spread_small = std.math.pi / 10.0;
             const spread_large = std.math.pi / 6.0;
             _ = projectiles.spawn(muzzle, narrowF32(shot_angle - spread_small), @intFromEnum(game_ids.ProjectileTypeId.plasma_rifle), projectile_owner, weapon_data.weapon_stats.get(.plasma_rifle).travel_budget, false);
@@ -412,118 +445,18 @@ fn tryFireWeaponWithForce(
             _ = projectiles.spawn(muzzle, narrowF32(shot_angle + spread_large), @intFromEnum(game_ids.ProjectileTypeId.plasma_minigun), projectile_owner, weapon_data.weapon_stats.get(.plasma_minigun).travel_budget, false);
             _ = projectiles.spawn(muzzle, narrowF32(shot_angle + spread_small), @intFromEnum(game_ids.ProjectileTypeId.plasma_rifle), projectile_owner, weapon_data.weapon_stats.get(.plasma_rifle).travel_budget, false);
         },
-        .plasma_shotgun => {
-            const meta = weapon_data.weapon_stats.get(.plasma_minigun).travel_budget;
-            for (0..14) |_| {
-                const jitter = @as(f32, @floatFromInt(@as(i32, @intCast(state.rng.rand() & 0xff)) - 0x80)) * 0.002;
-                const id = projectiles.spawn(
-                    muzzle,
-                    shot_angle + jitter,
-                    @intFromEnum(game_ids.ProjectileTypeId.plasma_minigun),
-                    projectile_owner,
-                    meta,
-                    false,
-                );
-                projectiles.entries[id].speed_scale = narrowF32(1.0 + @as(f32, @floatFromInt(state.rng.rand() % 100)) * 0.01);
-            }
-        },
-        .gauss_shotgun => {
-            const meta = weapon_data.weapon_stats.get(.gauss_gun).travel_budget;
-            for (0..6) |_| {
-                const jitter = @as(f32, @floatFromInt(@as(i32, @intCast(state.rng.rand() % 200)) - 100)) * 0.002;
-                const id = projectiles.spawn(
-                    muzzle,
-                    shot_angle + jitter,
-                    @intFromEnum(game_ids.ProjectileTypeId.gauss_gun),
-                    projectile_owner,
-                    meta,
-                    false,
-                );
-                projectiles.entries[id].speed_scale = narrowF32(1.4 + @as(f32, @floatFromInt(state.rng.rand() % 0x50)) * 0.01);
-            }
-        },
-        .ion_shotgun => {
-            const meta = weapon_data.weapon_stats.get(.ion_minigun).travel_budget;
-            for (0..8) |_| {
-                const jitter = @as(f32, @floatFromInt(@as(i32, @intCast(state.rng.rand() % 200)) - 100)) * 0.0026;
-                const id = projectiles.spawn(
-                    muzzle,
-                    shot_angle + jitter,
-                    @intFromEnum(game_ids.ProjectileTypeId.ion_minigun),
-                    projectile_owner,
-                    meta,
-                    false,
-                );
-                projectiles.entries[id].speed_scale = narrowF32(1.4 + @as(f32, @floatFromInt(state.rng.rand() % 0x50)) * 0.01);
-            }
-        },
-        .flamethrower => {
-            _ = particles.spawnParticle(
-                state,
-                muzzle,
-                particle_angle,
-                1.0,
-                owner_ref.OwnerRef.fromLocalPlayer(0),
-            );
-        },
-        .blow_torch => {
-            const particle_id = particles.spawnParticle(
-                state,
-                muzzle,
-                particle_angle,
-                1.0,
-                owner_ref.OwnerRef.fromLocalPlayer(0),
-            );
-            particles.entries[particle_id].style_id = particles_mod.ParticleStyleId.blow_torch;
-        },
-        .hr_flamer => {
-            const particle_id = particles.spawnParticle(
-                state,
-                muzzle,
-                particle_angle,
-                1.0,
-                owner_ref.OwnerRef.fromLocalPlayer(0),
-            );
-            particles.entries[particle_id].style_id = particles_mod.ParticleStyleId.hr_flamer;
-        },
-        .bubblegun => {
-            _ = particles.spawnParticleSlow(
-                state,
-                muzzle,
-                directionFromHeading(shot_angle).toAngle(),
-                owner_ref.OwnerRef.fromLocalPlayer(0),
-            );
-        },
-        .rocket_launcher => {
-            _ = secondary_projectiles.spawn(
-                muzzle,
-                narrowF32(shot_angle),
-                secondary_projectiles_mod.SecondaryProjectileTypeId.rocket,
-                secondary_owner,
-                2.0,
-                null,
-                creatures,
-            );
-        },
-        .seeker_rockets => {
-            _ = secondary_projectiles.spawn(
-                muzzle,
-                narrowF32(shot_angle),
-                secondary_projectiles_mod.SecondaryProjectileTypeId.homing_rocket,
-                secondary_owner,
-                2.0,
-                player.aim,
-                creatures,
-            );
-        },
-        .mini_rocket_swarmers => {
+        .swarmer_dump => {
             const rocket_count = shot_count;
-            const spread = native_pi * (2.0 / 3.0);
-            const step = if (rocket_count <= 1)
+            const step = if (state.preserve_bugs)
+                narrowF32(@as(f32, @floatFromInt(rocket_count)) * (native_pi / 3.0))
+            else if (rocket_count <= 1)
                 0.0
             else
-                spread / @as(f32, @floatFromInt(rocket_count - 1));
-            var angle = shot_angle - spread * 0.5;
+                narrowF32((native_pi * (2.0 / 3.0)) / @as(f32, @floatFromInt(rocket_count - 1)));
+            var angle = if (state.preserve_bugs)
+                narrowF32((shot_angle - native_pi) - step * @as(f32, @floatFromInt(rocket_count)) * 0.5)
+            else
+                narrowF32(shot_angle - native_pi * (1.0 / 3.0));
             for (0..@as(usize, @intCast(rocket_count))) |_| {
                 _ = secondary_projectiles.spawn(
                     muzzle,
@@ -536,43 +469,7 @@ fn tryFireWeaponWithForce(
                 );
                 angle = narrowF32(angle + step);
             }
-        },
-        .rocket_minigun => {
-            _ = secondary_projectiles.spawn(
-                muzzle,
-                narrowF32(shot_angle),
-                secondary_projectiles_mod.SecondaryProjectileTypeId.rocket_minigun,
-                secondary_owner,
-                2.0,
-                null,
-                creatures,
-            );
-        },
-        else => {
-            const type_id = weapon_data.projectileTypeIdFromWeaponId(player.weapon.weapon_id) orelse return error.UnsupportedWeaponFirePath;
-            const type_id_i32 = @intFromEnum(type_id);
-            const meta = projectileTravelBudgetFromTypeId(type_id);
-            const pellets = @max(1, weapon_data.weapon_stats.get(player.weapon.weapon_id).pellet_count);
-            for (0..@as(usize, @intCast(pellets))) |_| {
-                var angle = shot_angle;
-                if (pellets > 1) {
-                    const jitter_step = pelletJitterStep(player.weapon.weapon_id);
-                    angle += narrowF32(@as(f32, @floatFromInt(@as(i32, @intCast(state.rng.rand() % 200)) - 100)) * jitter_step);
-                }
-                const id = projectiles.spawn(
-                    muzzle,
-                    angle,
-                    type_id_i32,
-                    projectile_owner,
-                    meta,
-                    false,
-                );
-                if (pellets > 1 and
-                    (player.weapon.weapon_id == .shotgun or player.weapon.weapon_id == .sawed_off_shotgun or player.weapon.weapon_id == .jackhammer))
-                {
-                    projectiles.entries[id].speed_scale = narrowF32(1.0 + @as(f32, @floatFromInt(state.rng.rand() % 100)) * 0.01);
-                }
-            }
+            ammo_cost = @floatFromInt(rocket_count);
         },
     }
 
@@ -591,7 +488,6 @@ fn tryFireWeaponWithForce(
     }
     state.shots_fired_total += shot_count;
 
-    const ammo_cost = computeAmmoCost(player.weapon.weapon_id, shot_count);
     if (state.bonuses.reflex_boost <= 0.0 and !is_fire_bullets) {
         player.weapon.ammo -= ammo_cost;
     }
@@ -814,12 +710,43 @@ fn spawnPerkProjectile(
     }
 }
 
-fn pelletJitterStep(weapon_id: WeaponId) f32 {
-    return switch (weapon_id) {
-        .shotgun, .jackhammer => 0.0013,
-        .sawed_off_shotgun => 0.004,
-        else => 0.0015,
+fn applyPelletJitter(
+    state: *state_mod.GameplayState,
+    shot_angle: f32,
+    rule: fire_recipes.PelletJitterRule,
+) f32 {
+    return switch (rule) {
+        .none => shot_angle,
+        .modulo_centered => |jitter| {
+            const jitter_roll = state.rng.rand();
+            return shot_angle + narrowF32(
+                @as(f32, @floatFromInt(@as(i32, @intCast(jitter_roll % jitter.modulo)) - jitter.center)) * jitter.step,
+            );
+        },
+        .mask_centered => |jitter| {
+            const jitter_roll = state.rng.rand();
+            return shot_angle + narrowF32(
+                @as(f32, @floatFromInt(@as(i32, @intCast(jitter_roll & jitter.mask)) - jitter.center)) * jitter.step,
+            );
+        },
     };
+}
+
+fn applySpeedScaleRule(
+    state: *state_mod.GameplayState,
+    projectiles: *projectiles_mod.ProjectilePool,
+    projectile_idx: usize,
+    rule: fire_recipes.SpeedScaleRule,
+) void {
+    switch (rule) {
+        .none => {},
+        .modulo => |speed| {
+            const speed_roll = state.rng.rand();
+            projectiles.entries[projectile_idx].speed_scale = narrowF32(
+                speed.base + @as(f32, @floatFromInt(speed_roll % speed.modulo)) * speed.step,
+            );
+        },
+    }
 }
 
 fn consumeMuzzleSpriteRng(
@@ -879,20 +806,6 @@ fn computeShotCount(
         .gauss_shotgun => 6,
         .ion_shotgun => 8,
         else => @max(1, weapon_data.weapon_stats.get(weapon_id).pellet_count),
-    };
-}
-
-fn computeAmmoCost(
-    weapon_id: WeaponId,
-    shot_count: i32,
-) f32 {
-    return switch (weapon_id) {
-        .flamethrower => 0.1,
-        .blow_torch => 0.05,
-        .hr_flamer => 0.1,
-        .mini_rocket_swarmers => @floatFromInt(shot_count),
-        .bubblegun => 0.15,
-        else => 1.0,
     };
 }
 
@@ -2269,4 +2182,106 @@ test "ammunition within fire ammo class costs less health and spends fractional 
     try expectFloatClose(narrowF32(9.85), player.health);
     try std.testing.expect(particles.entries[0].active);
     try expectFloatClose(4.9, player.weapon.ammo);
+}
+
+test "same-id primary dev weapons fire through the main projectile pool" {
+    const cases = [_]WeaponId{
+        .evil_scythe,
+        .flameburst,
+        .raygun,
+        .grim_weapon,
+        .transmutator,
+        .blaster_r_300,
+        .lightning_rifle,
+        .nuke_launcher,
+    };
+
+    for (cases) |weapon_id| {
+        var state = state_mod.GameplayState.init(1);
+        var projectiles: projectiles_mod.ProjectilePool = .{};
+        var secondary_projectiles: secondary_projectiles_mod.SecondaryProjectilePool = .{};
+        var creatures: creatures_mod.CreaturePool = .{};
+        var particles: particles_mod.ParticlePool = .{};
+        var player: state_mod.PlayerState = .{
+            .index = 0,
+            .pos = .{},
+            .aim = .{ .x = 200.0, .y = 0.0 },
+            .aim_dir = .{ .x = 1.0, .y = 0.0 },
+            .spread_heat = 0.0,
+        };
+
+        player_runtime.weaponAssignPlayer(&player, weapon_id);
+        try std.testing.expect(try tryFireWeapon(
+            &state,
+            &player,
+            &projectiles,
+            &secondary_projectiles,
+            &creatures,
+            &particles,
+        ));
+
+        try std.testing.expectEqual(@as(usize, 1), activeProjectileCount(&projectiles));
+        try std.testing.expectEqual(@as(usize, 0), activeSecondaryProjectileCount(&secondary_projectiles));
+        try std.testing.expect(!particles.entries[0].active);
+        try std.testing.expectEqual(@intFromEnum(weapon_id), projectiles.entries[0].type_id);
+        try std.testing.expectEqual(@as(i32, 1), state.weapon_shots_fired[0][@intCast(@intFromEnum(weapon_id))]);
+    }
+}
+
+test "mini rocket swarmers preserve bugged spread when requested" {
+    var fixed_state = state_mod.GameplayState.init(1);
+    var fixed_projectiles: projectiles_mod.ProjectilePool = .{};
+    var fixed_secondary_projectiles: secondary_projectiles_mod.SecondaryProjectilePool = .{};
+    var fixed_creatures: creatures_mod.CreaturePool = .{};
+    var fixed_particles: particles_mod.ParticlePool = .{};
+    var fixed_player: state_mod.PlayerState = .{
+        .index = 0,
+        .pos = .{},
+        .aim = .{ .x = 200.0, .y = 0.0 },
+        .aim_dir = .{ .x = 1.0, .y = 0.0 },
+        .spread_heat = 0.0,
+    };
+
+    player_runtime.weaponAssignPlayer(&fixed_player, .mini_rocket_swarmers);
+    fixed_player.weapon.ammo = 6.0;
+    try std.testing.expect(try tryFireWeapon(
+        &fixed_state,
+        &fixed_player,
+        &fixed_projectiles,
+        &fixed_secondary_projectiles,
+        &fixed_creatures,
+        &fixed_particles,
+    ));
+
+    var bug_state = state_mod.GameplayState.init(1);
+    bug_state.preserve_bugs = true;
+    var bug_projectiles: projectiles_mod.ProjectilePool = .{};
+    var bug_secondary_projectiles: secondary_projectiles_mod.SecondaryProjectilePool = .{};
+    var bug_creatures: creatures_mod.CreaturePool = .{};
+    var bug_particles: particles_mod.ParticlePool = .{};
+    var bug_player = fixed_player;
+    bug_player.weapon.shot_cooldown = 0.0;
+    bug_player.weapon.reload_timer = 0.0;
+    bug_player.weapon.ammo = 6.0;
+
+    try std.testing.expect(try tryFireWeapon(
+        &bug_state,
+        &bug_player,
+        &bug_projectiles,
+        &bug_secondary_projectiles,
+        &bug_creatures,
+        &bug_particles,
+    ));
+
+    const shot_angle = std.math.pi / 2.0;
+    const rocket_count: f32 = 6.0;
+    const fixed_step = (native_pi * (2.0 / 3.0)) / (rocket_count - 1.0);
+    const fixed_first_angle = shot_angle - native_pi * (1.0 / 3.0);
+    try expectFloatClose(fixed_first_angle, fixed_secondary_projectiles.entries[0].angle);
+    try expectFloatClose(fixed_first_angle + fixed_step, fixed_secondary_projectiles.entries[1].angle);
+
+    const bug_step = rocket_count * (native_pi / 3.0);
+    const bug_first_angle = (shot_angle - native_pi) - bug_step * rocket_count * 0.5;
+    try expectFloatClose(bug_first_angle, bug_secondary_projectiles.entries[0].angle);
+    try expectFloatClose(bug_first_angle + bug_step, bug_secondary_projectiles.entries[1].angle);
 }


### PR DESCRIPTION
## Summary
- port Zig weapon fire selection onto a dedicated recipe layer that mirrors the Python/native split between primary pellets, secondaries, particle streams, and special modes
- restore native default `type_id == weapon_id` projectile support for projectile-backed dev/late weapons that were still missing from Zig's projectile enum and mapping layer
- port the native preserve-bugs `mini_rocket_swarmers` spread path and pin the new behavior with focused runtime tests

## Testing
- zig build test
- zig build window
- zig build wasm
