### PR TITLE
ci: update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - "master"
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -88,7 +91,7 @@ jobs:
 
       - name: Setup Node
         if: ${{ matrix.task == 'ast-grep' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -6,6 +6,9 @@ on:
       - "master"
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -28,7 +31,7 @@ jobs:
           version: "0.15.2"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 


### PR DESCRIPTION
## Summary
- upgrade `actions/setup-node` from `v4` to `v6` in the CI workflows
- force JavaScript actions onto Node 24 at workflow scope to avoid the GitHub Actions Node 20 deprecation path
- keep `node-version: 20` unchanged so this only addresses the action runtime transition

## Verification
- `git diff --check -- .github/workflows/zig.yml .github/workflows/ci.yml`
