### PR TITLE
fix(zig): share perk apply effects across runtimes

### DIFF
--- a/crimson-zig/src/runtime/live_runner.zig
+++ b/crimson-zig/src/runtime/live_runner.zig
@@ -9,6 +9,7 @@ const runtime_session = @import("session.zig");
 const session_builders = @import("session_builders.zig");
 const state_mod = @import("state.zig");
 const creatures = @import("creatures.zig");
+const survival_progression = @import("survival_progression.zig");
 
 pub const LiveRunnerError = runtime_session.DeterministicSessionError ||
     replay_step.StepError ||
@@ -141,8 +142,9 @@ pub const LiveSurvivalRunner = struct {
     }
 
     pub fn stepFrame(self: *LiveSurvivalRunner, frame_dt: f32, input: FrameInput) LiveRunnerError!FrameUpdate {
+        const clamped_dt = std.math.clamp(frame_dt, @as(f32, 0.0), max_frame_dt);
         if (input.perk_choice_index) |choice_index| {
-            _ = try self.pickPerk(choice_index);
+            _ = try self.pickPerk(choice_index, clamped_dt);
         }
 
         const paused_for_perk_pick = self.perkPendingCount() > 0;
@@ -150,7 +152,6 @@ pub const LiveSurvivalRunner = struct {
             return self.snapshot(0, paused_for_perk_pick, .{});
         }
 
-        const clamped_dt = std.math.clamp(frame_dt, @as(f32, 0.0), max_frame_dt);
         self.accumulator = std.math.clamp(self.accumulator + clamped_dt, @as(f32, 0.0), max_frame_dt);
 
         var ticks_advanced: usize = 0;
@@ -211,14 +212,23 @@ pub const LiveSurvivalRunner = struct {
         );
     }
 
-    pub fn pickPerk(self: *LiveSurvivalRunner, choice_index: i32) LiveRunnerError!bool {
-        const picked = try perks.perkSelectionPick(
+    pub fn pickPerk(self: *LiveSurvivalRunner, choice_index: i32, frame_dt: f32) LiveRunnerError!bool {
+        const dt_sim = survival_progression.timeScaleReflexBoostBonus(
+            self.session.state.bonuses.reflex_boost,
+            self.session.state.time_scale_active,
+            frame_dt,
+        );
+        const picked = try perks.perkSelectionPickWithContext(
             &self.session.state,
             self.session.players(),
             choice_index,
             self.session.game_mode,
             self.session.player_count,
             self.session.quest_unlock_index,
+            .{
+                .creatures = &self.session.creatures,
+                .dt_frame = dt_sim,
+            },
         );
         return picked != null;
     }
@@ -320,7 +330,7 @@ test "live survival runner pauses for pending perk picks" {
 
     const choices = runner.currentPerkChoices();
     try std.testing.expect(choices.len > 0);
-    try std.testing.expect(try runner.pickPerk(0));
+    try std.testing.expect(try runner.pickPerk(0, runner.session.dt_nominal));
     try std.testing.expectEqual(@as(i32, 0), runner.perkPendingCount());
 }
 
@@ -331,4 +341,17 @@ test "live survival runner reports dead run state" {
     const update = try runner.stepFrame(runner.session.dt_nominal, .{});
     try std.testing.expect(update.all_players_dead);
     try std.testing.expectEqual(@as(usize, 0), update.ticks_advanced);
+}
+
+test "live survival runner perk picks apply immediate creature effects" {
+    var runner = try LiveSurvivalRunner.init(.{});
+    runner.session.state.perk_selection.pending_count = 1;
+    runner.session.state.perk_selection.choice_count = 1;
+    runner.session.state.perk_selection.choices[0] = .breathing_room;
+    runner.session.state.perk_selection.choices_dirty = false;
+    runner.session.creatures.entries[0].active = true;
+    runner.session.creatures.entries[0].lifecycle_stage = 5.0;
+
+    try std.testing.expect(try runner.pickPerk(0, 0.25));
+    try std.testing.expectApproxEqAbs(@as(f32, 4.75), runner.session.creatures.entries[0].lifecycle_stage, 1e-6);
 }

--- a/crimson-zig/src/runtime/perks.zig
+++ b/crimson-zig/src/runtime/perks.zig
@@ -20,6 +20,11 @@ pub const PerkApplyError = error{
 pub const PerkId = game_ids.PerkId;
 pub const GameModeId = game_ids.GameModeId;
 
+pub const PerkApplyContext = struct {
+    creatures: ?*creatures_mod.CreaturePool = null,
+    dt_frame: ?f32 = null,
+};
+
 const PerkFlag = enum {
     quest_mode_allowed,
     two_player_allowed,
@@ -208,6 +213,26 @@ pub fn perkSelectionPick(
     player_count: i32,
     quest_unlock_index: i32,
 ) PerkApplyError!?PerkId {
+    return perkSelectionPickWithContext(
+        state,
+        players,
+        choice_index,
+        game_mode,
+        player_count,
+        quest_unlock_index,
+        .{},
+    );
+}
+
+pub fn perkSelectionPickWithContext(
+    state: *state_mod.GameplayState,
+    players: []state_mod.PlayerState,
+    choice_index: i32,
+    game_mode: GameModeId,
+    player_count: i32,
+    quest_unlock_index: i32,
+    context: PerkApplyContext,
+) PerkApplyError!?PerkId {
     if (players.len == 0) return null;
     if (state.perk_selection.pending_count <= 0) return null;
 
@@ -222,7 +247,7 @@ pub fn perkSelectionPick(
     if (choice_index < 0 or choice_index >= choices.len) return null;
 
     const perk_id = choices[@intCast(choice_index)];
-    try applyPerk(state, players, perk_id);
+    try applyPerkWithContext(state, players, perk_id, context);
 
     state.perk_selection.pending_count = @max(0, state.perk_selection.pending_count - 1);
     state.perk_selection.choices_dirty = true;
@@ -241,6 +266,15 @@ pub fn applyPerk(
     state: *state_mod.GameplayState,
     players: []state_mod.PlayerState,
     perk_id: PerkId,
+) PerkApplyError!void {
+    return applyPerkWithContext(state, players, perk_id, .{});
+}
+
+pub fn applyPerkWithContext(
+    state: *state_mod.GameplayState,
+    players: []state_mod.PlayerState,
+    perk_id: PerkId,
+    context: PerkApplyContext,
 ) PerkApplyError!void {
     if (players.len == 0) return;
     players[0].perk_counts.set(perk_id, players[0].perk_counts.get(perk_id) + 1);
@@ -324,6 +358,7 @@ pub fn applyPerk(
                 const reduction = narrowF32(player.health * (2.0 / 3.0));
                 player.health = narrowF32(player.health - reduction);
             }
+            applyPerkImmediateCreatureEffects(perk_id, state, context);
             state.bonus_spawn_guard = false;
         },
         PerkId.bandage => {
@@ -339,7 +374,7 @@ pub fn applyPerk(
                 }
             }
         },
-        PerkId.lifeline_50_50 => {},
+        PerkId.lifeline_50_50 => applyPerkImmediateCreatureEffects(perk_id, state, context),
         else => {},
     }
 }
@@ -350,6 +385,19 @@ pub fn applyReplayPerkCreatureEffects(
     creatures: *creatures_mod.CreaturePool,
     dt_frame: f32,
 ) void {
+    applyPerkImmediateCreatureEffects(perk_id, state, .{
+        .creatures = creatures,
+        .dt_frame = dt_frame,
+    });
+}
+
+fn applyPerkImmediateCreatureEffects(
+    perk_id: PerkId,
+    state: *state_mod.GameplayState,
+    context: PerkApplyContext,
+) void {
+    const creatures = context.creatures orelse return;
+    const dt_frame = context.dt_frame orelse 0.0;
     switch (perk_id) {
         PerkId.breathing_room => {
             for (&creatures.entries) |*creature| {
@@ -1396,6 +1444,22 @@ test "breathing room reduces player health and clears bonus spawn guard" {
     try std.testing.expect(!state.bonus_spawn_guard);
 }
 
+test "breathing room applies immediate creature lifecycle step when context is provided" {
+    var state = state_mod.GameplayState.init(1);
+    var players = [_]state_mod.PlayerState{
+        .{ .index = 0, .pos = .{}, .health = 90.0 },
+    };
+    var creatures: creatures_mod.CreaturePool = .{};
+    creatures.entries[0].active = true;
+    creatures.entries[0].lifecycle_stage = 3.5;
+
+    try applyPerkWithContext(&state, players[0..], PerkId.breathing_room, .{
+        .creatures = &creatures,
+        .dt_frame = 0.2,
+    });
+    try std.testing.expectApproxEqAbs(@as(f32, 3.3), creatures.entries[0].lifecycle_stage, 1e-6);
+}
+
 test "thick skinned clamps health floor at one" {
     var state = state_mod.GameplayState.init(1);
     var players = [_]state_mod.PlayerState{
@@ -1489,6 +1553,29 @@ test "lifeline 50-50 replay perk effect deactivates every other eligible creatur
         try std.testing.expectEqual(active_expected, creatures.entries[idx].active);
     }
     try std.testing.expect(before_rng != state.rng.state);
+}
+
+test "lifeline 50-50 immediate apply uses shared creature-effect path" {
+    var state = state_mod.GameplayState.init(1);
+    var players = [_]state_mod.PlayerState{
+        .{ .index = 0, .pos = .{} },
+    };
+    var creatures: creatures_mod.CreaturePool = .{};
+
+    for (0..4) |idx| {
+        creatures.entries[idx].active = true;
+        creatures.entries[idx].hp = 100.0;
+        creatures.entries[idx].flags = 0;
+    }
+
+    try applyPerkWithContext(&state, players[0..], PerkId.lifeline_50_50, .{
+        .creatures = &creatures,
+        .dt_frame = 0.016,
+    });
+    try std.testing.expect(creatures.entries[0].active);
+    try std.testing.expect(!creatures.entries[1].active);
+    try std.testing.expect(creatures.entries[2].active);
+    try std.testing.expect(!creatures.entries[3].active);
 }
 
 test "evil eyes targeting defaults to alive player slot" {

--- a/crimson-zig/src/runtime/replay/events.zig
+++ b/crimson-zig/src/runtime/replay/events.zig
@@ -100,13 +100,17 @@ pub fn applyReplayEvent(
             if (pick.player_index < 0 or pick.player_index >= @as(i32, @intCast(players.len))) {
                 return error.UnsupportedEventPlayerIndex;
             }
-            const applied = perks.perkSelectionPick(
+            const applied = perks.perkSelectionPickWithContext(
                 state,
                 players,
                 pick.choice_index,
                 options.game_mode,
                 options.player_count,
                 options.quest_unlock_index,
+                .{
+                    .creatures = creatures,
+                    .dt_frame = dt_frame,
+                },
             ) catch |err| switch (err) {
                 error.UnsupportedPerkApplyHandler => return error.UnsupportedPerkApplyHandler,
             };
@@ -119,12 +123,6 @@ pub fn applyReplayEvent(
                 }
                 return error.InvalidPerkPickEvent;
             }
-            perks.applyReplayPerkCreatureEffects(
-                applied.?,
-                state,
-                creatures,
-                dt_frame,
-            );
             outcome.perk_pick_count_delta = 1;
             return outcome;
         },
@@ -156,15 +154,17 @@ pub fn applyReplayEvent(
                 if (options.strict_events) return error.UnsupportedEventKind;
                 return outcome;
             };
-            perks.applyPerk(state, players, perk_id) catch |err| switch (err) {
+            perks.applyPerkWithContext(
+                state,
+                players,
+                perk_id,
+                .{
+                    .creatures = creatures,
+                    .dt_frame = dt_frame,
+                },
+            ) catch |err| switch (err) {
                 error.UnsupportedPerkApplyHandler => return error.UnsupportedPerkApplyHandler,
             };
-            perks.applyReplayPerkCreatureEffects(
-                perk_id,
-                state,
-                creatures,
-                dt_frame,
-            );
             if (capture_perk_apply.outside_before) {
                 if (capture_perk_apply.pending_after) |pending_after| {
                     state.perk_selection.pending_count = pending_after;
@@ -323,4 +323,42 @@ test "lifeline 50-50 replay perk effect deactivates every other eligible creatur
         try std.testing.expectEqual(active_expected, creatures.entries[idx].active);
     }
     try std.testing.expect(before_rng != state.rng.state);
+}
+
+test "perk pick event applies immediate creature perk effects through shared path" {
+    var state = state_mod.GameplayState.init(1);
+    var creatures: creatures_mod.CreaturePool = .{};
+    var players = [_]state_mod.PlayerState{
+        .{ .index = 0, .pos = .{}, .health = 90.0 },
+    };
+    var quest_spawn_timeline_ms: f32 = 0.0;
+    var quest_no_creatures_timer_ms: f32 = 0.0;
+    var quest_completion_transition_ms: f32 = -1.0;
+
+    state.perk_selection.pending_count = 1;
+    state.perk_selection.choice_count = 1;
+    state.perk_selection.choices[0] = .breathing_room;
+    state.perk_selection.choices_dirty = false;
+    creatures.entries[0].active = true;
+    creatures.entries[0].lifecycle_stage = 5.0;
+
+    const outcome = try applyReplayEvent(
+        .{ .perk_pick = .{ .tick_index = 0, .player_index = 0, .choice_index = 0 } },
+        &state,
+        players[0..],
+        &creatures,
+        0.075,
+        &quest_spawn_timeline_ms,
+        &quest_no_creatures_timer_ms,
+        &quest_completion_transition_ms,
+        .{
+            .game_mode = .survival,
+            .player_count = 1,
+            .quest_unlock_index = 0,
+            .strict_events = true,
+        },
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), outcome.perk_pick_count_delta);
+    try std.testing.expectApproxEqAbs(@as(f32, 4.925), creatures.entries[0].lifecycle_stage, 1e-6);
 }

--- a/crimson-zig/src/runtime/replay/step.zig
+++ b/crimson-zig/src/runtime/replay/step.zig
@@ -196,11 +196,16 @@ pub fn stepTick(
     }
 
     callPhaseHook(options.hooks, context, .pre_events, &frame);
+    const perk_event_dt = survival_progression.timeScaleReflexBoostBonus(
+        context.state.bonuses.reflex_boost,
+        context.state.time_scale_active,
+        frame.dt,
+    );
     frame.pre_events_applied = try applyEventsForPhase(
         context,
         tick_events,
         .pre_step,
-        frame.dt,
+        perk_event_dt,
         &frame.menu_open_seen_this_tick,
     );
     try ensureSupportedReplayFeatureFlags(&context.state);
@@ -596,7 +601,7 @@ pub fn stepTick(
                 context,
                 tick_events,
                 post_phase,
-                frame.dt,
+                perk_event_dt,
                 &frame.menu_open_seen_this_tick,
             );
             try ensureSupportedReplayFeatureFlags(&context.state);


### PR DESCRIPTION
## Summary
- thread immediate perk apply context through both live gameplay and replay event paths instead of keeping creature-side apply effects replay-only
- make live perk picks use the same time-scaled apply dt model as replay/session timing for immediate breathing-room and lifeline behavior
- add regression tests covering shared perk apply context in `perks.zig`, `replay/events.zig`, and `live_runner.zig`

## Verification
- `zig build test`
- `zig build window`
- `zig build wasm`
