### PR TITLE
feat(zig): add live rush and quest modes

### DIFF
--- a/crimson-zig/README.md
+++ b/crimson-zig/README.md
@@ -46,8 +46,8 @@ This wave is intentionally codec-only:
   - full deterministic run-result generation on supported native paths.
 - Replay-side validation remains a primary parity harness, but it is now a consumer of shared runtime code rather than the whole point of the workspace.
 - Native CLI still hard-fails for unsupported or unported native paths instead of falling back.
-- `zig build run-window` now boots a real desktop Survival slice:
-  boot screen -> main menu -> live 1-player Survival run -> results.
+- `zig build run-window` now boots a real desktop gameplay slice:
+  boot screen -> main menu -> live 1-player Survival / Rush / Quest 1.1 runs -> results.
 - `zig build run-window` now looks for runtime assets using the same default
   runtime-dir policy as Python first:
   `CRIMSON_ASSETS_DIR`, then `CRIMSON_RUNTIME_DIR` / `CRIMSON_BASE_DIR`, then
@@ -90,10 +90,11 @@ zig build wasm
   execution when audio archives are missing or disabled in `crimson.cfg`.
 - `zig build web-window` builds an HTML+WASM placeholder window for browser use.
 - `zig build run-web-window` serves the web build through `emrun` (`--no_browser`).
-- The desktop target is currently a menu-to-gameplay Survival slice with a
+- The desktop target is currently a menu-to-gameplay live mode slice with a
   mixed renderer: gameplay world surfaces now use archive-backed textures when
   `crimson.paq` is available, with primitive fallback where exact sprite atlas
-  mapping is still incomplete.
+  mapping is still incomplete. Quest mode currently boots a fixed `1.1` run
+  from the main menu until the wider quest-select UI is ported.
 - `zig build wasm` remains the freestanding ABI module (`wasm32-freestanding`) and
   is intentionally separate from the raylib web target (`wasm32-emscripten`).
 

--- a/crimson-zig/src/runtime/bootstrap.zig
+++ b/crimson-zig/src/runtime/bootstrap.zig
@@ -118,6 +118,40 @@ pub fn previewUnlockTerrain(
     );
 }
 
+pub fn previewExplicitTerrain(
+    seed: u32,
+    terrain_slots: TerrainSlotTriplet,
+    terrain_width: i32,
+    terrain_height: i32,
+) TerrainSetup {
+    var rng = spawn_mod.Crand.init(seed);
+    return advanceExplicitTerrain(
+        &rng,
+        terrain_slots,
+        terrain_width,
+        terrain_height,
+    );
+}
+
+pub fn terrainSlotsForQuestLevelKey(level_key: i32) ?TerrainSlotTriplet {
+    const major = @divTrunc(level_key, 100);
+    const minor = @mod(level_key, 100);
+    if (major < 1 or major > 5 or minor < 1 or minor > 10) return null;
+
+    if (major <= 4) {
+        const base: u8 = @intCast((major - 1) * 2);
+        const alt: u8 = base + 1;
+        if (minor < 6) return .{ base, alt, base };
+        return .{ base, base, alt };
+    }
+
+    return .{
+        @intCast(minor & 3),
+        1,
+        3,
+    };
+}
+
 fn terrainStampingDraws(width: i32, height: i32) usize {
     const clamped_width: u64 = @intCast(@max(width, 0));
     const clamped_height: u64 = @intCast(@max(height, 0));
@@ -141,7 +175,7 @@ fn advanceUnlockTerrainRng(
     _ = advanceUnlockTerrain(rng, unlock_index, width, height);
 }
 
-fn advanceUnlockTerrain(
+pub fn advanceUnlockTerrain(
     rng: *spawn_mod.Crand,
     unlock_index: i32,
     width: i32,
@@ -149,6 +183,20 @@ fn advanceUnlockTerrain(
 ) TerrainSetup {
     advanceRng(rng, terrain_random_prelude_draws);
     const terrain_slots = chooseUnlockTerrainSlots(rng, unlock_index);
+    const terrain_seed = rng.state;
+    advanceRng(rng, terrainStampingDraws(width, height));
+    return .{
+        .terrain_slots = terrain_slots,
+        .terrain_seed = terrain_seed,
+    };
+}
+
+pub fn advanceExplicitTerrain(
+    rng: *spawn_mod.Crand,
+    terrain_slots: TerrainSlotTriplet,
+    width: i32,
+    height: i32,
+) TerrainSetup {
     const terrain_seed = rng.state;
     advanceRng(rng, terrainStampingDraws(width, height));
     return .{
@@ -184,4 +232,31 @@ test "preview unlock terrain matches replay bootstrap rng advance for survival" 
     try std.testing.expectEqualDeep(expected_slots, terrain.terrain_slots);
     try std.testing.expectEqual(expected_seed, terrain.terrain_seed);
     try std.testing.expectEqual(expected_rng.state, rng.state);
+}
+
+test "terrain slots for quest level key mirror quest stage mapping" {
+    try std.testing.expectEqualDeep(@as(TerrainSlotTriplet, .{ 0, 1, 0 }), terrainSlotsForQuestLevelKey(101).?);
+    try std.testing.expectEqualDeep(@as(TerrainSlotTriplet, .{ 0, 0, 1 }), terrainSlotsForQuestLevelKey(106).?);
+    try std.testing.expectEqualDeep(@as(TerrainSlotTriplet, .{ 2, 3, 2 }), terrainSlotsForQuestLevelKey(201).?);
+    try std.testing.expectEqualDeep(@as(TerrainSlotTriplet, .{ 2, 2, 3 }), terrainSlotsForQuestLevelKey(206).?);
+    try std.testing.expectEqualDeep(@as(TerrainSlotTriplet, .{ 1, 1, 3 }), terrainSlotsForQuestLevelKey(505).?);
+    try std.testing.expect(terrainSlotsForQuestLevelKey(0) == null);
+    try std.testing.expect(terrainSlotsForQuestLevelKey(511) == null);
+}
+
+test "preview explicit terrain preserves slot choice and advances stamping rng" {
+    const slots: TerrainSlotTriplet = .{ 2, 2, 3 };
+    const terrain = previewExplicitTerrain(0xBEEF, slots, 1024, 1024);
+
+    var rng = spawn_mod.Crand.init(0xBEEF);
+    const expected_seed = rng.state;
+    advanceRng(&rng, terrainStampingDraws(1024, 1024));
+
+    try std.testing.expectEqualDeep(slots, terrain.terrain_slots);
+    try std.testing.expectEqual(expected_seed, terrain.terrain_seed);
+    try std.testing.expectEqual(rng.state, blk: {
+        var verify_rng = spawn_mod.Crand.init(0xBEEF);
+        _ = advanceExplicitTerrain(&verify_rng, slots, 1024, 1024);
+        break :blk verify_rng.state;
+    });
 }

--- a/crimson-zig/src/runtime/live_runner.zig
+++ b/crimson-zig/src/runtime/live_runner.zig
@@ -4,9 +4,12 @@ const game_ids = @import("../game_ids.zig");
 const perks = @import("perks.zig");
 const player_runtime = @import("player.zig");
 const projectiles = @import("projectiles.zig");
+const quest_spawn_logic = @import("../quest_spawn/logic_full.zig");
 const replay_step = @import("replay/step.zig");
+const runtime_bootstrap = @import("bootstrap.zig");
 const runtime_session = @import("session.zig");
 const session_builders = @import("session_builders.zig");
+const spawn_mod = @import("spawn.zig");
 const state_mod = @import("state.zig");
 const creatures = @import("creatures.zig");
 const survival_progression = @import("survival_progression.zig");
@@ -18,8 +21,10 @@ pub const LiveRunnerError = runtime_session.DeterministicSessionError ||
 const max_frame_dt: f32 = 0.25;
 const epsilon_dt: f32 = 1e-6;
 
-pub const LiveSurvivalConfig = struct {
+pub const LiveModeConfig = struct {
     seed: u32 = 1,
+    game_mode: game_ids.GameModeId = .survival,
+    quest_level_key: i32 = 101,
     player_count: i32 = 1,
     world_size: f32 = 1024.0,
     tick_rate: i32 = 60,
@@ -30,6 +35,8 @@ pub const LiveSurvivalConfig = struct {
     status_quest_unlock_index: i32 = 0,
     status_quest_unlock_index_full: i32 = 0,
 };
+
+pub const LiveSurvivalConfig = LiveModeConfig;
 
 pub const FrameInput = struct {
     player: player_runtime.GameInput = defaultGameInput(),
@@ -111,37 +118,120 @@ pub fn defaultGameInput() player_runtime.GameInput {
     };
 }
 
-pub const LiveSurvivalRunner = struct {
+pub const LiveRunner = struct {
     seed: u32,
+    terrain_setup: runtime_bootstrap.TerrainSetup,
+    quest_level_key: ?i32 = null,
     session: runtime_session.DeterministicSession,
     accumulator: f32 = 0.0,
     max_substeps_per_frame: usize = 8,
 
-    pub fn init(config: LiveSurvivalConfig) LiveRunnerError!LiveSurvivalRunner {
-        const session = try session_builders.buildSurvivalSession(
-            .{
-                .seed = config.seed,
-                .game_mode = .survival,
-                .player_count = config.player_count,
-                .world_size = config.world_size,
-                .tick_rate = config.tick_rate,
-                .detail_preset = config.detail_preset,
-                .gore_disabled = config.gore_disabled,
-                .hardcore = config.hardcore,
-                .preserve_bugs = config.preserve_bugs,
-                .status_quest_unlock_index = config.status_quest_unlock_index,
-                .status_quest_unlock_index_full = config.status_quest_unlock_index_full,
+    pub fn init(config: LiveModeConfig) LiveRunnerError!LiveRunner {
+        const base_config: runtime_session.SessionConfig = .{
+            .seed = config.seed,
+            .game_mode = config.game_mode,
+            .player_count = config.player_count,
+            .world_size = config.world_size,
+            .tick_rate = config.tick_rate,
+            .detail_preset = config.detail_preset,
+            .gore_disabled = config.gore_disabled,
+            .hardcore = config.hardcore,
+            .preserve_bugs = config.preserve_bugs,
+            .status_quest_unlock_index = config.status_quest_unlock_index,
+            .status_quest_unlock_index_full = config.status_quest_unlock_index_full,
+        };
+        const terrain_size = @max(1, @as(i32, @intFromFloat(@floor(config.world_size))));
+
+        var terrain_setup: runtime_bootstrap.TerrainSetup = undefined;
+        var quest_level_key: ?i32 = null;
+        var quest_spawn_entries_storage: [runtime_session.max_sim_quest_spawn_entries]spawn_mod.QuestSpawnEntry = undefined;
+        const session = switch (config.game_mode) {
+            .survival => blk: {
+                terrain_setup = runtime_bootstrap.previewUnlockTerrain(
+                    config.seed,
+                    config.status_quest_unlock_index,
+                    terrain_size,
+                    terrain_size,
+                );
+                break :blk try session_builders.buildSurvivalSession(base_config, .{});
             },
-            .{},
-        );
+            .rush => blk: {
+                terrain_setup = runtime_bootstrap.previewUnlockTerrain(
+                    config.seed,
+                    config.status_quest_unlock_index,
+                    terrain_size,
+                    terrain_size,
+                );
+                break :blk try session_builders.buildRushSession(base_config, .{});
+            },
+            .quests => blk: {
+                quest_level_key = config.quest_level_key;
+                const terrain_slots = runtime_bootstrap.terrainSlotsForQuestLevelKey(config.quest_level_key) orelse
+                    return error.UnsupportedQuestSpawnTable;
+                const built = quest_spawn_logic.buildQuestSpawnTable(
+                    config.quest_level_key,
+                    config.player_count,
+                    config.seed,
+                    config.world_size,
+                    quest_spawn_entries_storage[0..],
+                ) catch |err| switch (err) {
+                    error.UnsupportedQuestSpawnTable => return error.UnsupportedQuestSpawnTable,
+                    error.OutOfSpace => return error.UnsupportedQuestSpawnTable,
+                };
+                const quest_entries = quest_spawn_entries_storage[0..built.entries.len];
+                if (config.hardcore) {
+                    spawn_mod.applyHardcoreQuestSpawnTableAdjustment(quest_entries);
+                }
+
+                var terrain_rng = spawn_mod.Crand.init(config.seed);
+                _ = runtime_bootstrap.advanceUnlockTerrain(
+                    &terrain_rng,
+                    config.status_quest_unlock_index,
+                    terrain_size,
+                    terrain_size,
+                );
+                _ = terrain_rng.rand();
+                terrain_setup = runtime_bootstrap.advanceExplicitTerrain(
+                    &terrain_rng,
+                    terrain_slots,
+                    terrain_size,
+                    terrain_size,
+                );
+
+                break :blk try session_builders.buildQuestSession(
+                    .{
+                        .seed = base_config.seed,
+                        .game_mode = .quests,
+                        .player_count = base_config.player_count,
+                        .world_size = base_config.world_size,
+                        .tick_rate = base_config.tick_rate,
+                        .detail_preset = base_config.detail_preset,
+                        .gore_disabled = base_config.gore_disabled,
+                        .hardcore = base_config.hardcore,
+                        .preserve_bugs = base_config.preserve_bugs,
+                        .status_quest_unlock_index = base_config.status_quest_unlock_index,
+                        .status_quest_unlock_index_full = base_config.status_quest_unlock_index_full,
+                        .quest_stage_major = @divTrunc(config.quest_level_key, 100),
+                        .quest_stage_minor = @mod(config.quest_level_key, 100),
+                    },
+                    .{
+                        .quest_spawn_entries = quest_entries,
+                        .quest_start_weapon_id = @intFromEnum(built.start_weapon_id),
+                    },
+                );
+            },
+            else => return error.UnsupportedGameMode,
+        };
 
         return .{
             .seed = config.seed,
+            .terrain_setup = terrain_setup,
+            .quest_level_key = quest_level_key,
             .session = session,
         };
     }
 
-    pub fn stepFrame(self: *LiveSurvivalRunner, frame_dt: f32, input: FrameInput) LiveRunnerError!FrameUpdate {
+    pub fn stepFrame(self: *LiveRunner, frame_dt: f32, input: FrameInput) LiveRunnerError!FrameUpdate {
         const clamped_dt = std.math.clamp(frame_dt, @as(f32, 0.0), max_frame_dt);
         if (input.perk_choice_index) |choice_index| {
             _ = try self.pickPerk(choice_index, clamped_dt);
@@ -198,11 +288,11 @@ pub const LiveSurvivalRunner = struct {
         return self.snapshot(ticks_advanced, self.perkPendingCount() > 0, frame_audio);
     }
 
-    pub fn perkPendingCount(self: *const LiveSurvivalRunner) i32 {
+    pub fn perkPendingCount(self: *const LiveRunner) i32 {
         return self.session.state.perk_selection.pending_count;
     }
 
-    pub fn currentPerkChoices(self: *LiveSurvivalRunner) []const game_ids.PerkId {
+    pub fn currentPerkChoices(self: *LiveRunner) []const game_ids.PerkId {
         return perks.perkSelectionCurrentChoices(
             &self.session.state,
             self.session.players(),
@@ -212,7 +302,7 @@ pub const LiveSurvivalRunner = struct {
         );
     }
 
-    pub fn pickPerk(self: *LiveSurvivalRunner, choice_index: i32, frame_dt: f32) LiveRunnerError!bool {
+    pub fn pickPerk(self: *LiveRunner, choice_index: i32, frame_dt: f32) LiveRunnerError!bool {
         const dt_sim = survival_progression.timeScaleReflexBoostBonus(
             self.session.state.bonuses.reflex_boost,
             self.session.state.time_scale_active,
@@ -233,7 +323,7 @@ pub const LiveSurvivalRunner = struct {
         return picked != null;
     }
 
-    pub fn allPlayersDead(self: *const LiveSurvivalRunner) bool {
+    pub fn allPlayersDead(self: *const LiveRunner) bool {
         const players = self.session.playersConst();
         if (players.len == 0) return true;
         for (players) |player| {
@@ -242,24 +332,24 @@ pub const LiveSurvivalRunner = struct {
         return true;
     }
 
-    pub fn player0(self: *LiveSurvivalRunner) ?*state_mod.PlayerState {
+    pub fn player0(self: *LiveRunner) ?*state_mod.PlayerState {
         const players = self.session.players();
         if (players.len == 0) return null;
         return &players[0];
     }
 
-    pub fn player0Const(self: *const LiveSurvivalRunner) ?*const state_mod.PlayerState {
+    pub fn player0Const(self: *const LiveRunner) ?*const state_mod.PlayerState {
         const players = self.session.playersConst();
         if (players.len == 0) return null;
         return &players[0];
     }
 
-    pub fn summary(self: *const LiveSurvivalRunner) runtime_session.SessionSummary {
+    pub fn summary(self: *const LiveRunner) runtime_session.SessionSummary {
         return self.session.finalize();
     }
 
     fn snapshot(
-        self: *const LiveSurvivalRunner,
+        self: *const LiveRunner,
         ticks_advanced: usize,
         paused_for_perk_pick: bool,
         audio: FrameAudioEvents,
@@ -288,11 +378,35 @@ pub const LiveSurvivalRunner = struct {
     }
 };
 
+pub const LiveSurvivalRunner = LiveRunner;
+
 test "live survival runner bootstraps pistol survival session" {
     var runner = try LiveSurvivalRunner.init(.{});
     try std.testing.expectEqual(game_ids.GameModeId.survival, runner.session.game_mode);
     try std.testing.expectEqual(@as(usize, 1), runner.session.players().len);
     try std.testing.expectEqual(game_ids.WeaponId.pistol, runner.session.players()[0].weapon.weapon_id);
+}
+
+test "live runner bootstraps rush session with forced assault rifle" {
+    var runner = try LiveRunner.init(.{
+        .game_mode = .rush,
+    });
+    try std.testing.expectEqual(game_ids.GameModeId.rush, runner.session.game_mode);
+    try std.testing.expectEqual(game_ids.WeaponId.assault_rifle, runner.session.players()[0].weapon.weapon_id);
+    try std.testing.expectEqual(@as(f32, 30.0), runner.session.players()[0].weapon.ammo);
+}
+
+test "live runner bootstraps quest session from level key" {
+    var runner = try LiveRunner.init(.{
+        .game_mode = .quests,
+        .quest_level_key = 205,
+    });
+    try std.testing.expectEqual(game_ids.GameModeId.quests, runner.session.game_mode);
+    try std.testing.expectEqual(@as(?i32, 205), runner.quest_level_key);
+    try std.testing.expectEqual(@as(i32, 2), runner.session.state.quest_stage_major);
+    try std.testing.expectEqual(@as(i32, 5), runner.session.state.quest_stage_minor);
+    try std.testing.expectEqual(game_ids.WeaponId.gauss_gun, runner.session.players()[0].weapon.weapon_id);
+    try std.testing.expectEqualDeep(@as(runtime_bootstrap.TerrainSlotTriplet, .{ 2, 3, 2 }), runner.terrain_setup.terrain_slots);
 }
 
 test "live survival runner advances fixed ticks from frame time" {

--- a/crimson-zig/src/window_ground.zig
+++ b/crimson-zig/src/window_ground.zig
@@ -103,6 +103,15 @@ pub const GroundRenderer = struct {
         height: i32,
     ) GroundRenderError!GroundRenderer {
         const terrain = runtime_bootstrap.previewUnlockTerrain(seed, unlock_index, width, height);
+        return initForTerrainSetup(runtime_assets, terrain, width, height);
+    }
+
+    pub fn initForTerrainSetup(
+        runtime_assets: *const window_assets.RuntimeAssets,
+        terrain: runtime_bootstrap.TerrainSetup,
+        width: i32,
+        height: i32,
+    ) GroundRenderError!GroundRenderer {
         const texture_ids = terrainTextureSet(terrain.terrain_slots);
 
         var renderer: GroundRenderer = .{

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -53,6 +53,7 @@ const Screen = enum {
 
 const ResultsReason = enum {
     dead,
+    completed,
     runtime_error,
     abandoned,
 };
@@ -69,7 +70,8 @@ const UiButton = struct {
 };
 
 const GameplayScreen = struct {
-    runner: live_runner.LiveSurvivalRunner,
+    runner: live_runner.LiveRunner,
+    run_config: live_runner.LiveModeConfig,
     last_update: live_runner.FrameUpdate,
     ground: ?window_ground.GroundRenderer = null,
     terrain_fx: window_terrain_fx.TerrainFxTracker = .{},
@@ -85,6 +87,7 @@ const GameplayScreen = struct {
 
 const ResultsScreen = struct {
     reason: ResultsReason,
+    run_config: live_runner.LiveModeConfig,
     summary: runtime_session.SessionSummary,
     player_health: f32,
     runtime_error: ?[]const u8 = null,
@@ -183,8 +186,10 @@ const App = struct {
         self.audio.playUiButtonClick();
 
         switch (self.menu_selection) {
-            0 => self.startNewRun(),
-            1 => self.quit_requested = true,
+            0 => self.startNewRun(runConfigForMenuSelection(0, &self.next_seed_state)),
+            1 => self.startNewRun(runConfigForMenuSelection(1, &self.next_seed_state)),
+            2 => self.startNewRun(runConfigForMenuSelection(2, &self.next_seed_state)),
+            3 => self.quit_requested = true,
             else => {},
         }
     }
@@ -215,6 +220,10 @@ const App = struct {
                 }
             }
 
+            if (gameplay.runner.session.game_mode == .quests and gameplay.runner.session.quest_completed) {
+                self.finishRun(gameplay, .completed, null);
+                return;
+            }
             if (gameplay.last_update.all_players_dead) {
                 self.finishRun(gameplay, .dead, null);
             }
@@ -236,7 +245,9 @@ const App = struct {
         self.audio.playUiButtonClick();
 
         switch (self.results_selection) {
-            0 => self.startNewRun(),
+            0 => if (self.results) |results| {
+                self.startNewRun(results.run_config);
+            },
             1 => {
                 if (self.gameplay) |*gameplay| {
                     gameplay.deinit();
@@ -250,13 +261,12 @@ const App = struct {
         }
     }
 
-    fn startNewRun(self: *App) void {
+    fn startNewRun(self: *App, run_config: live_runner.LiveModeConfig) void {
         self.audio.stopGameplayMusic();
-        var runner = live_runner.LiveSurvivalRunner.init(.{
-            .seed = nextRunSeed(&self.next_seed_state),
-        }) catch |err| {
+        var runner = live_runner.LiveRunner.init(run_config) catch |err| {
             self.results = .{
                 .reason = .runtime_error,
+                .run_config = run_config,
                 .summary = zeroSessionSummary(),
                 .player_health = 0.0,
                 .runtime_error = @errorName(err),
@@ -273,14 +283,14 @@ const App = struct {
 
         var gameplay: GameplayScreen = .{
             .runner = runner,
+            .run_config = run_config,
             .last_update = last_update,
             .terrain_fx = window_terrain_fx.TerrainFxTracker.init(runner.seed),
         };
         if (self.runtime_assets) |*runtime_assets| {
-            gameplay.ground = window_ground.GroundRenderer.initForUnlockTerrain(
+            gameplay.ground = window_ground.GroundRenderer.initForTerrainSetup(
                 runtime_assets,
-                gameplay.runner.seed,
-                gameplay.runner.session.quest_unlock_index,
+                gameplay.runner.terrain_setup,
                 gameplay.runner.session.terrain_size,
                 gameplay.runner.session.terrain_size,
             ) catch null;
@@ -303,6 +313,7 @@ const App = struct {
         const player_health = if (runner.player0Const()) |player| player.health else 0.0;
         self.results = .{
             .reason = reason,
+            .run_config = gameplay.run_config,
             .summary = runner.summary(),
             .player_health = player_health,
             .runtime_error = runtime_error,
@@ -320,7 +331,7 @@ const App = struct {
             drawBootAssets(runtime_assets, bootProgress(self.boot_elapsed));
         }
         drawCenteredText("CRIMSON-ZIG", 144, 72, accent_color);
-        drawCenteredText("Desktop survival slice booting", 232, 24, text_color);
+        drawCenteredText("Desktop gameplay slice booting", 232, 24, text_color);
         drawCenteredText("raylib shell + live Zig runtime + archive-backed assets", 270, 18, muted_text);
         drawAssetsStatus(self);
         drawAudioStatus(&self.audio);
@@ -331,13 +342,13 @@ const App = struct {
         drawBackdrop();
         if (self.runtime_assets) |*runtime_assets| {
             drawMenuAssets(runtime_assets);
-            drawSmallTextCentered(runtime_assets, "NATIVE MENU-TO-GAMEPLAY SURVIVAL SLICE", 204.0, HudTextColor.primary);
-            drawSmallTextCentered(runtime_assets, "REPLAY TOOLING IS NO LONGER THE ONLY REAL SURFACE.", 234.0, HudTextColor.dim);
+            drawSmallTextCentered(runtime_assets, "NATIVE SURVIVAL / RUSH / QUEST GAMEPLAY SLICE", 204.0, HudTextColor.primary);
+            drawSmallTextCentered(runtime_assets, "LIVE ZIG RUNTIME NOW BOOTS MULTIPLE REAL MODES.", 234.0, HudTextColor.dim);
         }
         if (self.runtime_assets == null) {
             drawCenteredText("CRIMSON-ZIG", 118, 68, accent_color);
-            drawCenteredText("Native menu-to-gameplay survival slice", 198, 24, text_color);
-            drawCenteredText("Replay tooling is no longer the only real surface.", 232, 18, muted_text);
+            drawCenteredText("Native survival / rush / quest gameplay slice", 198, 24, text_color);
+            drawCenteredText("Live Zig runtime now boots multiple real modes.", 232, 18, muted_text);
         }
         drawAssetsStatus(self);
         drawAudioStatus(&self.audio);
@@ -349,9 +360,9 @@ const App = struct {
         }
 
         if (self.runtime_assets) |*runtime_assets| {
-            drawSmallTextCentered(runtime_assets, "ENTER STARTS. MOUSE CLICK ALSO WORKS. ESC CLOSES THE WINDOW.", 624.0, HudTextColor.dim);
+            drawSmallTextCentered(runtime_assets, "ENTER STARTS. QUEST CURRENTLY BOOTS LEVEL 1.1. ESC CLOSES THE WINDOW.", 624.0, HudTextColor.dim);
         } else {
-            drawCenteredText("Enter starts. Mouse click also works. Esc closes the window.", 620, 18, muted_text);
+            drawCenteredText("Enter starts. Quest currently boots level 1.1. Esc closes the window.", 620, 18, muted_text);
         }
     }
 
@@ -391,7 +402,7 @@ const App = struct {
                 drawTextureFit(runtime_assets.texture(.ui_menu_panel), rl.Rectangle.init(262.0, 116.0, 756.0, 392.0), colorWithAlpha(rl.Color.white, 0.96));
                 switch (results.reason) {
                     .dead => drawTextureFit(runtime_assets.texture(.ui_text_reaper), rl.Rectangle.init(464.0, 136.0, 354.0, 48.0), colorWithAlpha(rl.Color.white, 0.96)),
-                    .abandoned, .runtime_error => drawSmallTextCentered(runtime_assets, resultsTitle(results.reason), 152.0, HudTextColor.accent),
+                    .completed, .abandoned, .runtime_error => drawSmallTextCentered(runtime_assets, resultsTitle(results.reason), 152.0, HudTextColor.accent),
                 }
                 drawSmallTextCentered(runtime_assets, resultsSubtitle(results.reason), 196.0, HudTextColor.primary);
                 drawSmallTextFmt("ELAPSED_MS {d}", runtime_assets, .{results.summary.elapsed_ms_sim}, 330.0, 258.0, HudTextColor.primary);
@@ -658,11 +669,13 @@ fn drawTextureTiled(texture: rl.Texture2D, area: rl.Rectangle, tint: rl.Color) v
     }
 }
 
-fn mainMenuButtons() [2]UiButton {
+fn mainMenuButtons() [4]UiButton {
     const center_x: f32 = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
     return .{
-        .{ .label = "START SURVIVAL", .rect = centeredRect(center_x, 300.0, ui_button_width, ui_button_height) },
-        .{ .label = "QUIT", .rect = centeredRect(center_x, 372.0, ui_button_width, ui_button_height) },
+        .{ .label = "START SURVIVAL", .rect = centeredRect(center_x, 264.0, ui_button_width, ui_button_height) },
+        .{ .label = "START RUSH", .rect = centeredRect(center_x, 336.0, ui_button_width, ui_button_height) },
+        .{ .label = "START QUEST 1.1", .rect = centeredRect(center_x, 408.0, ui_button_width, ui_button_height) },
+        .{ .label = "QUIT", .rect = centeredRect(center_x, 480.0, ui_button_width, ui_button_height) },
     };
 }
 
@@ -778,7 +791,7 @@ fn buildWorldCamera(world_size: f32, shake_offset: state_mod.Vec2) rl.Camera2D {
     };
 }
 
-fn collectGameplayInput(runner: *live_runner.LiveSurvivalRunner, camera: rl.Camera2D) live_runner.FrameInput {
+fn collectGameplayInput(runner: *live_runner.LiveRunner, camera: rl.Camera2D) live_runner.FrameInput {
     const move_x = axisFromKeys(.a, .d);
     const move_y = axisFromKeys(.w, .s);
     const mouse_world = rl.getScreenToWorld2D(rl.getMousePosition(), camera);
@@ -820,7 +833,7 @@ fn axisFromKeys(negative: rl.KeyboardKey, positive: rl.KeyboardKey) f32 {
 }
 
 fn drawWorld(
-    runner: *const live_runner.LiveSurvivalRunner,
+    runner: *const live_runner.LiveRunner,
     runtime_assets: ?*const window_assets.RuntimeAssets,
     ground: ?*const window_ground.GroundRenderer,
 ) void {
@@ -853,7 +866,7 @@ fn drawWorld(
     }, 4.0, border_color);
 }
 
-fn drawPlayers(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+fn drawPlayers(runner: *const live_runner.LiveRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     for (runner.session.playersConst()) |player| {
         const center = toRlVec(player.pos);
         const radius = @max(10.0, player.size * 0.28);
@@ -1005,7 +1018,7 @@ fn drawPlayers(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*
     }
 }
 
-fn drawCreatures(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+fn drawCreatures(runner: *const live_runner.LiveRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     const monster_vision_active = if (runner.player0Const()) |player|
         runtime_perks.perkActive(player, .monster_vision)
     else
@@ -1081,7 +1094,7 @@ fn drawCreatures(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: 
     }
 }
 
-fn drawProjectiles(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+fn drawProjectiles(runner: *const live_runner.LiveRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     for (runner.session.projectiles.entries, 0..) |projectile, proj_index| {
         if (!projectile.active) continue;
         if (runtime_assets) |assets| {
@@ -1104,7 +1117,7 @@ fn drawProjectiles(runner: *const live_runner.LiveSurvivalRunner, runtime_assets
     }
 }
 
-fn drawBonuses(runner: *const live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+fn drawBonuses(runner: *const live_runner.LiveRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     const bonus_phase = runner.session.elapsed_ms_sim * 0.001 * 1.3;
     for (runner.session.bonuses.entries, 0..) |entry, idx| {
         if (entry.bonus_id == .unused) continue;
@@ -1332,7 +1345,7 @@ fn drawSmallTextCentered(
 }
 
 fn drawGameplayHud(
-    runner: *live_runner.LiveSurvivalRunner,
+    runner: *live_runner.LiveRunner,
     update: live_runner.FrameUpdate,
     runtime_assets: ?*const window_assets.RuntimeAssets,
 ) void {
@@ -1417,7 +1430,7 @@ fn drawGameplayHud(
     drawTextSlice("WASD move  mouse aim/fire  R reload  Esc end run", 24, rl.getScreenHeight() - 34, 18, muted_text);
 }
 
-fn drawPerkOverlay(runner: *live_runner.LiveSurvivalRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+fn drawPerkOverlay(runner: *live_runner.LiveRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     rl.drawRectangle(0, 0, rl.getScreenWidth(), rl.getScreenHeight(), overlay_color);
     if (runtime_assets) |assets| {
         drawTextureFit(assets.texture(.ui_menu_panel), rl.Rectangle.init(262.0, 152.0, 756.0, 360.0), colorWithAlpha(rl.Color.white, 0.96));
@@ -1497,9 +1510,29 @@ fn nextRunSeed(seed_state: *u32) u32 {
     return if (seed_state.* == 0) 1 else seed_state.*;
 }
 
+fn runConfigForMenuSelection(selection: usize, seed_state: *u32) live_runner.LiveModeConfig {
+    const seed = nextRunSeed(seed_state);
+    return switch (selection) {
+        1 => .{
+            .seed = seed,
+            .game_mode = .rush,
+        },
+        2 => .{
+            .seed = seed,
+            .game_mode = .quests,
+            .quest_level_key = 101,
+        },
+        else => .{
+            .seed = seed,
+            .game_mode = .survival,
+        },
+    };
+}
+
 fn resultsTitle(reason: ResultsReason) [:0]const u8 {
     return switch (reason) {
         .dead => "Run Over",
+        .completed => "Quest Complete",
         .runtime_error => "Run Interrupted",
         .abandoned => "Run Abandoned",
     };
@@ -1508,6 +1541,7 @@ fn resultsTitle(reason: ResultsReason) [:0]const u8 {
 fn resultsSubtitle(reason: ResultsReason) [:0]const u8 {
     return switch (reason) {
         .dead => "All players are down.",
+        .completed => "Quest objectives cleared.",
         .abandoned => "Run returned to menu before completion.",
         .runtime_error => "Runtime hit an unported or invalid path.",
     };


### PR DESCRIPTION
## Summary
- generalize the live Zig runner so desktop gameplay is no longer Survival-only, with shared session startup for Survival, Rush, and Quest runs
- port quest terrain bootstrap for explicit quest terrain slots and wire the desktop window to boot Survival, Rush, and Quest 1.1 from the main menu
- preserve restart/results flow across modes and add runtime coverage tests for rush and quest startup paths

## Verification
- `zig build test`
- `zig build window`
- `zig build wasm`
- `just docs-check`
