### PR TITLE
feat(zig): own runtime config and status

### DIFF
--- a/crimson-zig/README.md
+++ b/crimson-zig/README.md
@@ -61,6 +61,17 @@ This wave is intentionally codec-only:
   - menu theme + intro playback,
   - first-hit Survival game-tune trigger,
   - cfg-driven music/sfx enable and volume behavior.
+- The desktop slice now also owns real runtime config/status files under the
+  Python-compatible runtime dir:
+  - missing `crimson.cfg` and `game.cfg` are created from Zig using the same
+    native defaults/codecs,
+  - window size/fullscreen and current Survival runtime defaults are read from
+    `crimson.cfg`,
+  - `game.cfg` mode-play counters, weapon usage counts, unlock indices, and
+    global playtime counters are now mutated and saved back out by the Zig app.
+- For the current 1-player desktop slice, player 1 movement/fire plus global
+  reload bindings now come from the encoded `crimson.cfg` control blocks rather
+  than hardcoded `WASD` / `Mouse1` / `R`.
 - The freestanding WASM ABI now runs the same replay verification core for
   byte-input payloads, with JSON output and JSON error reporting via
   `crimson_last_error_json`.
@@ -88,6 +99,9 @@ zig build wasm
 - `zig build run-window` now initializes audio from `music.paq` / `sfx.paq`
   when they are present in the resolved runtime dir, and falls back to silent
   execution when audio archives are missing or disabled in `crimson.cfg`.
+- `zig build run-window` now creates/loads `crimson.cfg` + `game.cfg` in the
+  resolved runtime dir before booting the window target, and writes back status
+  mutations on run end / app exit.
 - `zig build web-window` builds an HTML+WASM placeholder window for browser use.
 - `zig build run-web-window` serves the web build through `emrun` (`--no_browser`).
 - The desktop target is currently a menu-to-gameplay Survival slice with a

--- a/crimson-zig/src/app_runtime.zig
+++ b/crimson-zig/src/app_runtime.zig
@@ -1,0 +1,248 @@
+const std = @import("std");
+
+const cz = @import("crimson_zig");
+const game_ids = cz.game_ids;
+const formats = cz.formats;
+const runtime_paths = @import("runtime_paths.zig");
+const runtime_session = cz.session;
+
+pub const game_cfg_name = "game.cfg";
+pub const crimson_cfg_name = "crimson.cfg";
+
+pub const DesktopRuntimeError = std.mem.Allocator.Error ||
+    std.process.GetEnvVarOwnedError ||
+    std.fs.Dir.AccessError ||
+    std.fs.Dir.MakeError ||
+    std.fs.File.OpenError ||
+    std.fs.File.ReadError ||
+    std.fs.File.WriteError ||
+    formats.crimson_cfg.CrimsonCfgError ||
+    formats.game_cfg.GameCfgError ||
+    error{
+        MissingRuntimeDir,
+        InvalidGameCfgChecksum,
+    };
+
+pub const DesktopRuntime = struct {
+    allocator: std.mem.Allocator,
+    base_dir: []u8,
+    config_path: []u8,
+    status_path: []u8,
+    config: formats.crimson_cfg.CrimsonCfg,
+    status: formats.game_cfg.Status,
+    config_dirty: bool = false,
+    status_dirty: bool = false,
+
+    pub fn init(allocator: std.mem.Allocator) DesktopRuntimeError!DesktopRuntime {
+        const base_dir = (try runtime_paths.defaultRuntimeDir(allocator)) orelse return error.MissingRuntimeDir;
+        errdefer allocator.free(base_dir);
+        try std.fs.cwd().makePath(base_dir);
+
+        const config_path = try std.fs.path.join(allocator, &.{ base_dir, crimson_cfg_name });
+        errdefer allocator.free(config_path);
+
+        const status_path = try std.fs.path.join(allocator, &.{ base_dir, game_cfg_name });
+        errdefer allocator.free(status_path);
+
+        return .{
+            .allocator = allocator,
+            .base_dir = base_dir,
+            .config_path = config_path,
+            .status_path = status_path,
+            .config = try loadOrCreateConfig(allocator, config_path),
+            .status = try loadOrCreateStatus(allocator, status_path),
+        };
+    }
+
+    pub fn deinit(self: *DesktopRuntime) void {
+        self.allocator.free(self.status_path);
+        self.allocator.free(self.config_path);
+        self.allocator.free(self.base_dir);
+        self.* = undefined;
+    }
+
+    pub fn saveConfigIfDirty(self: *DesktopRuntime) DesktopRuntimeError!void {
+        if (!self.config_dirty) return;
+        try writeConfig(self.config_path, self.config);
+        self.config_dirty = false;
+    }
+
+    pub fn saveStatusIfDirty(self: *DesktopRuntime) DesktopRuntimeError!void {
+        if (!self.status_dirty) return;
+        try writeStatus(self.status_path, self.status);
+        self.status_dirty = false;
+    }
+
+    pub fn saveAllIfDirty(self: *DesktopRuntime) DesktopRuntimeError!void {
+        try self.saveConfigIfDirty();
+        try self.saveStatusIfDirty();
+    }
+
+    pub fn primaryBindBlock(self: *const DesktopRuntime) formats.crimson_cfg.PlayerBindBlock {
+        return formats.crimson_cfg.playerBindBlock(&self.config, 0);
+    }
+
+    pub fn recordModeStart(self: *DesktopRuntime, mode: game_ids.GameModeId) void {
+        switch (mode) {
+            .survival => self.status.mode_play_survival +%= 1,
+            .rush => self.status.mode_play_rush +%= 1,
+            .typo => self.status.mode_play_typo +%= 1,
+            else => self.status.mode_play_other +%= 1,
+        }
+        self.status_dirty = true;
+    }
+
+    pub fn recordGameplayFrame(self: *DesktopRuntime, frame_dt: f32) void {
+        if (!(frame_dt > 0.0) or !std.math.isFinite(frame_dt)) return;
+        const delta_ms_f32 = frame_dt * 1000.0;
+        if (!(delta_ms_f32 > 0.0)) return;
+        const delta_ms: u32 = @intFromFloat(delta_ms_f32);
+        if (delta_ms == 0) return;
+        self.status.game_sequence_id +%= delta_ms;
+        self.status_dirty = true;
+    }
+
+    pub fn absorbSessionState(self: *DesktopRuntime, session: *const runtime_session.DeterministicSession) void {
+        const unlock_index: u16 = @intCast(std.math.clamp(session.state.status_quest_unlock_index, @as(i32, 0), @as(i32, std.math.maxInt(u16))));
+        const unlock_index_full: u16 = @intCast(std.math.clamp(session.state.status_quest_unlock_index_full, @as(i32, 0), @as(i32, std.math.maxInt(u16))));
+
+        if (self.status.quest_unlock_index != unlock_index) {
+            self.status.quest_unlock_index = unlock_index;
+            self.status_dirty = true;
+        }
+        if (self.status.quest_unlock_index_full != unlock_index_full) {
+            self.status.quest_unlock_index_full = unlock_index_full;
+            self.status_dirty = true;
+        }
+
+        for (0..formats.game_cfg.weapon_usage_count) |idx| {
+            const weapon_id: game_ids.WeaponId = @enumFromInt(idx);
+            const count = session.state.status_weapon_usage_counts.get(weapon_id);
+            if (self.status.weapon_usage_counts[idx] != count) {
+                self.status.weapon_usage_counts[idx] = count;
+                self.status_dirty = true;
+            }
+        }
+    }
+
+    pub fn windowWidth(self: *const DesktopRuntime, fallback: i32) i32 {
+        return sanitizedWindowDimension(self.config.screen_width, fallback);
+    }
+
+    pub fn windowHeight(self: *const DesktopRuntime, fallback: i32) i32 {
+        return sanitizedWindowDimension(self.config.screen_height, fallback);
+    }
+};
+
+fn loadOrCreateConfig(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+) DesktopRuntimeError!formats.crimson_cfg.CrimsonCfg {
+    const bytes = std.fs.cwd().readFileAlloc(allocator, path, std.math.maxInt(usize)) catch |err| switch (err) {
+        error.FileNotFound => {
+            const cfg = formats.crimson_cfg.defaultConfig();
+            try writeConfig(path, cfg);
+            return cfg;
+        },
+        else => return err,
+    };
+    defer allocator.free(bytes);
+
+    return formats.crimson_cfg.decode(bytes);
+}
+
+fn writeConfig(path: []const u8, cfg: formats.crimson_cfg.CrimsonCfg) DesktopRuntimeError!void {
+    const bytes = formats.crimson_cfg.encode(cfg);
+    try std.fs.cwd().writeFile(.{
+        .sub_path = path,
+        .data = bytes[0..],
+    });
+}
+
+fn loadOrCreateStatus(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+) DesktopRuntimeError!formats.game_cfg.Status {
+    const bytes = std.fs.cwd().readFileAlloc(allocator, path, std.math.maxInt(usize)) catch |err| switch (err) {
+        error.FileNotFound => {
+            const status = std.mem.zeroes(formats.game_cfg.Status);
+            try writeStatus(path, status);
+            return status;
+        },
+        else => return err,
+    };
+    defer allocator.free(bytes);
+
+    const parsed = try formats.game_cfg.parseFile(bytes);
+    if (!parsed.checksumValid()) return error.InvalidGameCfgChecksum;
+    return formats.game_cfg.parseStatusBlob(parsed.decoded[0..]);
+}
+
+fn writeStatus(path: []const u8, status: formats.game_cfg.Status) DesktopRuntimeError!void {
+    const decoded = formats.game_cfg.buildStatusBlob(status);
+    const bytes = try formats.game_cfg.buildFile(decoded[0..]);
+    try std.fs.cwd().writeFile(.{
+        .sub_path = path,
+        .data = bytes[0..],
+    });
+}
+
+fn sanitizedWindowDimension(value: u32, fallback: i32) i32 {
+    const clamped_default = @max(fallback, 1);
+    if (value == 0) return clamped_default;
+    return @intCast(@min(value, @as(u32, @intCast(std.math.maxInt(i32)))));
+}
+
+test "desktop runtime creates default config and status files" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base_dir = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(base_dir);
+
+    const config_path = try std.fs.path.join(allocator, &.{ base_dir, crimson_cfg_name });
+    defer allocator.free(config_path);
+    const status_path = try std.fs.path.join(allocator, &.{ base_dir, game_cfg_name });
+    defer allocator.free(status_path);
+
+    const cfg = try loadOrCreateConfig(allocator, config_path);
+    const status = try loadOrCreateStatus(allocator, status_path);
+
+    try std.testing.expectEqual(@as(u32, 1024), cfg.screen_width);
+    try std.testing.expectEqual(@as(u32, 768), cfg.screen_height);
+    try std.testing.expectEqual(@as(u16, 0), status.quest_unlock_index);
+    try std.testing.expectEqual(@as(u32, 0), status.game_sequence_id);
+}
+
+test "desktop runtime status absorb mirrors session unlock and usage state" {
+    var runtime: DesktopRuntime = .{
+        .allocator = std.testing.allocator,
+        .base_dir = &.{},
+        .config_path = &.{},
+        .status_path = &.{},
+        .config = formats.crimson_cfg.defaultConfig(),
+        .status = std.mem.zeroes(formats.game_cfg.Status),
+    };
+
+    var session = try runtime_session.DeterministicSession.init(.{
+        .seed = 1,
+        .game_mode = .survival,
+        .player_count = 1,
+        .world_size = 1024.0,
+        .tick_rate = 60,
+    }, .{});
+    session.state.status_quest_unlock_index = 17;
+    session.state.status_quest_unlock_index_full = 23;
+    session.state.status_weapon_usage_counts.set(.shotgun, 9);
+
+    runtime.absorbSessionState(&session);
+
+    try std.testing.expectEqual(@as(u16, 17), runtime.status.quest_unlock_index);
+    try std.testing.expectEqual(@as(u16, 23), runtime.status.quest_unlock_index_full);
+    try std.testing.expectEqual(@as(u32, 9), runtime.status.weapon_usage_counts[@intFromEnum(game_ids.WeaponId.shotgun)]);
+    try std.testing.expect(runtime.status_dirty);
+}

--- a/crimson-zig/src/audio/audio.zig
+++ b/crimson-zig/src/audio/audio.zig
@@ -47,7 +47,19 @@ pub const LoadRuntimeAudioError = std.mem.Allocator.Error ||
 
 pub fn loadRuntimeAudioFromDefaultSearch(allocator: std.mem.Allocator) LoadRuntimeAudioError!?AudioState {
     const config = try loadAudioConfig(allocator);
-    const assets_dir = (try resolveAudioAssetsDir(allocator)) orelse {
+    return loadRuntimeAudio(allocator, null, config);
+}
+
+pub fn loadRuntimeAudio(
+    allocator: std.mem.Allocator,
+    resolved_assets_dir: ?[]const u8,
+    config: AudioConfig,
+) LoadRuntimeAudioError!?AudioState {
+    const owned_assets_dir = if (resolved_assets_dir) |dir|
+        try allocator.dupe(u8, dir)
+    else
+        try resolveAudioAssetsDir(allocator);
+    const assets_dir = owned_assets_dir orelse {
         if (!config.music_enabled and !config.sfx_enabled) {
             const disabled_state = try initAudioState(allocator, "", config);
             return disabled_state;
@@ -57,6 +69,15 @@ pub fn loadRuntimeAudioFromDefaultSearch(allocator: std.mem.Allocator) LoadRunti
     defer allocator.free(assets_dir);
     const state = try initAudioState(allocator, assets_dir, config);
     return state;
+}
+
+pub fn audioConfigFromCrimsonCfg(cfg: formats.crimson_cfg.CrimsonCfg) AudioConfig {
+    return .{
+        .music_enabled = cfg.music_disable == 0,
+        .sfx_enabled = cfg.sound_disable == 0,
+        .music_volume = clampVolume(cfg.music_volume),
+        .sfx_volume = clampVolume(cfg.sfx_volume),
+    };
 }
 
 pub fn playMusic(state: *AudioState, track_name: []const u8) void {
@@ -187,12 +208,7 @@ fn loadAudioConfig(allocator: std.mem.Allocator) LoadRuntimeAudioError!AudioConf
     defer allocator.free(bytes);
 
     const parsed = try formats.crimson_cfg.decode(bytes);
-    return .{
-        .music_enabled = parsed.music_disable == 0,
-        .sfx_enabled = parsed.sound_disable == 0,
-        .music_volume = clampVolume(parsed.music_volume),
-        .sfx_volume = clampVolume(parsed.sfx_volume),
-    };
+    return audioConfigFromCrimsonCfg(parsed);
 }
 
 fn runtimeArchiveReadConfig(

--- a/crimson-zig/src/audio/live_audio.zig
+++ b/crimson-zig/src/audio/live_audio.zig
@@ -21,9 +21,13 @@ pub const Bridge = struct {
     load_state: LoadState = .unavailable,
     message: ?[]u8 = null,
 
-    pub fn init(allocator: std.mem.Allocator) Bridge {
+    pub fn init(
+        allocator: std.mem.Allocator,
+        config: audio_mod.AudioConfig,
+        assets_dir: ?[]const u8,
+    ) Bridge {
         var bridge: Bridge = .{ .allocator = allocator };
-        bridge.load();
+        bridge.load(config, assets_dir);
         return bridge;
     }
 
@@ -39,8 +43,8 @@ pub const Bridge = struct {
         self.* = undefined;
     }
 
-    pub fn load(self: *Bridge) void {
-        self.state = audio_mod.loadRuntimeAudioFromDefaultSearch(self.allocator) catch |err| {
+    pub fn load(self: *Bridge, config: audio_mod.AudioConfig, assets_dir: ?[]const u8) void {
+        self.state = audio_mod.loadRuntimeAudio(self.allocator, assets_dir, config) catch |err| {
             self.load_state = .failed;
             self.replaceMessage(@errorName(err));
             return;

--- a/crimson-zig/src/formats/crimson_cfg.zig
+++ b/crimson-zig/src/formats/crimson_cfg.zig
@@ -2,9 +2,41 @@ const std = @import("std");
 const binary = @import("binary.zig");
 
 pub const file_size: usize = 0x480;
+pub const player_name_size: usize = 0x20;
+pub const player_name_max_bytes: usize = player_name_size - 1;
+pub const saved_name_slot_count: usize = 8;
+pub const saved_name_entry_size: usize = 0x1B;
+pub const saved_names_blob_size: usize = saved_name_slot_count * saved_name_entry_size;
+pub const player_bind_block_dwords: usize = 0x10;
+pub const player_bind_block_size: usize = player_bind_block_dwords * 4;
+pub const player_bind_block_count_primary: usize = 2;
+pub const player_bind_block_count_total: usize = 4;
+pub const reserved_keybind_slot_count: usize = 2;
+pub const padding_keybind_slot_count: usize = 3;
+pub const extended_direction_arrow_flag_count: usize = 2;
+pub const ext_direction_arrow_unset: u8 = 0;
+pub const ext_direction_arrow_off: u8 = 1;
+pub const ext_direction_arrow_on: u8 = 2;
+pub const keybind_unbound_code: i32 = 0x17E;
 
 pub const CrimsonCfgError = binary.BinaryError || error{
     InvalidSize,
+};
+
+pub const PlayerBindBlock = struct {
+    move_forward: i32,
+    move_backward: i32,
+    turn_left: i32,
+    turn_right: i32,
+    fire: i32,
+    reserved_keys: [reserved_keybind_slot_count]i32,
+    aim_left: i32,
+    aim_right: i32,
+    axis_aim_y: i32,
+    axis_aim_x: i32,
+    axis_move_y: i32,
+    axis_move_x: i32,
+    padding: [padding_keybind_slot_count]i32,
 };
 
 pub const CrimsonCfg = struct {
@@ -74,6 +106,258 @@ pub const CrimsonCfg = struct {
     keybind_pick_perk: u32,
     keybind_reload: u32,
 };
+
+pub fn decodePlayerBindBlock(bytes: []const u8) CrimsonCfgError!PlayerBindBlock {
+    if (bytes.len != player_bind_block_size) return error.InvalidSize;
+
+    var reader = binary.Reader.init(bytes);
+    return .{
+        .move_forward = @bitCast(try reader.readU32Le()),
+        .move_backward = @bitCast(try reader.readU32Le()),
+        .turn_left = @bitCast(try reader.readU32Le()),
+        .turn_right = @bitCast(try reader.readU32Le()),
+        .fire = @bitCast(try reader.readU32Le()),
+        .reserved_keys = .{
+            @bitCast(try reader.readU32Le()),
+            @bitCast(try reader.readU32Le()),
+        },
+        .aim_left = @bitCast(try reader.readU32Le()),
+        .aim_right = @bitCast(try reader.readU32Le()),
+        .axis_aim_y = @bitCast(try reader.readU32Le()),
+        .axis_aim_x = @bitCast(try reader.readU32Le()),
+        .axis_move_y = @bitCast(try reader.readU32Le()),
+        .axis_move_x = @bitCast(try reader.readU32Le()),
+        .padding = .{
+            @bitCast(try reader.readU32Le()),
+            @bitCast(try reader.readU32Le()),
+            @bitCast(try reader.readU32Le()),
+        },
+    };
+}
+
+pub fn encodePlayerBindBlock(block: PlayerBindBlock) [player_bind_block_size]u8 {
+    var bytes: [player_bind_block_size]u8 = undefined;
+    var writer = binary.Writer.init(bytes[0..]);
+
+    writer.writeU32Le(@bitCast(block.move_forward)) catch unreachable;
+    writer.writeU32Le(@bitCast(block.move_backward)) catch unreachable;
+    writer.writeU32Le(@bitCast(block.turn_left)) catch unreachable;
+    writer.writeU32Le(@bitCast(block.turn_right)) catch unreachable;
+    writer.writeU32Le(@bitCast(block.fire)) catch unreachable;
+    for (block.reserved_keys) |value| {
+        writer.writeU32Le(@bitCast(value)) catch unreachable;
+    }
+    writer.writeU32Le(@bitCast(block.aim_left)) catch unreachable;
+    writer.writeU32Le(@bitCast(block.aim_right)) catch unreachable;
+    writer.writeU32Le(@bitCast(block.axis_aim_y)) catch unreachable;
+    writer.writeU32Le(@bitCast(block.axis_aim_x)) catch unreachable;
+    writer.writeU32Le(@bitCast(block.axis_move_y)) catch unreachable;
+    writer.writeU32Le(@bitCast(block.axis_move_x)) catch unreachable;
+    for (block.padding) |value| {
+        writer.writeU32Le(@bitCast(value)) catch unreachable;
+    }
+
+    std.debug.assert(writer.pos == player_bind_block_size);
+    return bytes;
+}
+
+pub fn defaultPlayerBindBlock(player_index: usize) PlayerBindBlock {
+    return switch (player_index) {
+        0 => .{
+            .move_forward = 0x11,
+            .move_backward = 0x1F,
+            .turn_left = 0x1E,
+            .turn_right = 0x20,
+            .fire = 0x100,
+            .reserved_keys = [_]i32{ keybind_unbound_code, keybind_unbound_code },
+            .aim_left = 0x10,
+            .aim_right = 0x12,
+            .axis_aim_y = 0x13F,
+            .axis_aim_x = 0x140,
+            .axis_move_y = 0x141,
+            .axis_move_x = 0x153,
+            .padding = [_]i32{ keybind_unbound_code, keybind_unbound_code, keybind_unbound_code },
+        },
+        1 => .{
+            .move_forward = 0xC8,
+            .move_backward = 0xD0,
+            .turn_left = 0xCB,
+            .turn_right = 0xCD,
+            .fire = 0x9D,
+            .reserved_keys = [_]i32{ keybind_unbound_code, keybind_unbound_code },
+            .aim_left = 0xD3,
+            .aim_right = 0xD1,
+            .axis_aim_y = 0x13F,
+            .axis_aim_x = 0x140,
+            .axis_move_y = 0x141,
+            .axis_move_x = 0x153,
+            .padding = [_]i32{ keybind_unbound_code, keybind_unbound_code, keybind_unbound_code },
+        },
+        2 => .{
+            .move_forward = 0x17,
+            .move_backward = 0x25,
+            .turn_left = 0x24,
+            .turn_right = 0x26,
+            .fire = 0x36,
+            .reserved_keys = [_]i32{ keybind_unbound_code, keybind_unbound_code },
+            .aim_left = 0x16,
+            .aim_right = 0x18,
+            .axis_aim_y = keybind_unbound_code,
+            .axis_aim_x = keybind_unbound_code,
+            .axis_move_y = keybind_unbound_code,
+            .axis_move_x = keybind_unbound_code,
+            .padding = [_]i32{ keybind_unbound_code, keybind_unbound_code, keybind_unbound_code },
+        },
+        3 => .{
+            .move_forward = 0x131,
+            .move_backward = 0x132,
+            .turn_left = 0x133,
+            .turn_right = 0x134,
+            .fire = 0x11F,
+            .reserved_keys = [_]i32{ keybind_unbound_code, keybind_unbound_code },
+            .aim_left = keybind_unbound_code,
+            .aim_right = keybind_unbound_code,
+            .axis_aim_y = 0x140,
+            .axis_aim_x = 0x13F,
+            .axis_move_y = 0x153,
+            .axis_move_x = 0x154,
+            .padding = [_]i32{ keybind_unbound_code, keybind_unbound_code, keybind_unbound_code },
+        },
+        else => unreachable,
+    };
+}
+
+fn playerBindBlockOffsets(player_index: usize) struct { start: usize, extended: bool } {
+    return switch (player_index) {
+        0 => .{ .start = 0, .extended = false },
+        1 => .{ .start = player_bind_block_size, .extended = false },
+        2 => .{ .start = 0, .extended = true },
+        3 => .{ .start = player_bind_block_size, .extended = true },
+        else => unreachable,
+    };
+}
+
+fn playerBindBlockBytes(cfg: *const CrimsonCfg, player_index: usize) [player_bind_block_size]u8 {
+    const offsets = playerBindBlockOffsets(player_index);
+    var bytes: [player_bind_block_size]u8 = undefined;
+    if (offsets.extended) {
+        @memcpy(bytes[0..], cfg.unknown_248[offsets.start .. offsets.start + player_bind_block_size]);
+    } else {
+        @memcpy(bytes[0..], cfg.keybinds[offsets.start .. offsets.start + player_bind_block_size]);
+    }
+    return bytes;
+}
+
+fn playerBindBlockIsUninitialized(bytes: [player_bind_block_size]u8) bool {
+    for (bytes) |byte| {
+        if (byte != 0) return false;
+    }
+    return true;
+}
+
+pub fn playerBindBlock(cfg: *const CrimsonCfg, player_index: usize) PlayerBindBlock {
+    const bytes = playerBindBlockBytes(cfg, player_index);
+    if (playerBindBlockIsUninitialized(bytes)) {
+        return defaultPlayerBindBlock(player_index);
+    }
+    return decodePlayerBindBlock(bytes[0..]) catch unreachable;
+}
+
+pub fn setPlayerBindBlock(cfg: *CrimsonCfg, player_index: usize, block: PlayerBindBlock) void {
+    const offsets = playerBindBlockOffsets(player_index);
+    const bytes = encodePlayerBindBlock(block);
+    if (offsets.extended) {
+        @memcpy(cfg.unknown_248[offsets.start .. offsets.start + player_bind_block_size], bytes[0..]);
+    } else {
+        @memcpy(cfg.keybinds[offsets.start .. offsets.start + player_bind_block_size], bytes[0..]);
+    }
+}
+
+pub fn playerMovement(cfg: *const CrimsonCfg, player_index: usize) u32 {
+    return switch (player_index) {
+        0 => cfg.player_mode_flag_p1,
+        1 => cfg.player_mode_flag_p2,
+        2 => cfg.player_mode_flag_p3,
+        3 => cfg.player_mode_flag_p4,
+        else => unreachable,
+    };
+}
+
+pub fn playerAimScheme(cfg: *const CrimsonCfg, player_index: usize) u32 {
+    return switch (player_index) {
+        0 => cfg.aim_scheme_p1,
+        1 => cfg.aim_scheme_p2,
+        2 => cfg.aim_scheme_p3,
+        3 => cfg.aim_scheme_p4,
+        else => unreachable,
+    };
+}
+
+pub fn playerShowDirectionArrow(cfg: *const CrimsonCfg, player_index: usize) bool {
+    return switch (player_index) {
+        0 => cfg.hud_indicators[0] != 0,
+        1 => cfg.hud_indicators[1] != 0,
+        2 => cfg.unknown_248[player_bind_block_size * 2] != ext_direction_arrow_off,
+        3 => cfg.unknown_248[player_bind_block_size * 2 + 1] != ext_direction_arrow_off,
+        else => unreachable,
+    };
+}
+
+pub fn defaultConfig() CrimsonCfg {
+    var cfg = std.mem.zeroes(CrimsonCfg);
+    cfg.hud_indicators = [_]u8{ 1, 1 };
+    cfg.fx_detail_0 = 1;
+    cfg.fx_detail_1 = 1;
+    cfg.fx_detail_2 = 1;
+    cfg.player_count = 1;
+    cfg.game_mode = 1;
+    cfg.player_mode_flag_p1 = 2;
+    cfg.player_mode_flag_p2 = 2;
+    cfg.player_mode_flag_p3 = 2;
+    cfg.player_mode_flag_p4 = 2;
+    cfg.texture_scale = 1.0;
+    cfg.selected_name_slot = 0;
+    cfg.saved_name_index = 1;
+    cfg.player_name_len = 0;
+    cfg.unknown_1a4 = 100;
+    cfg.aim_pov_right = 9000;
+    cfg.aim_pov_left = 27000;
+    cfg.screen_bpp = 32;
+    cfg.screen_width = 1024;
+    cfg.screen_height = 768;
+    cfg.windowed_flag = 1;
+    cfg.hardcore_flag = 0;
+    cfg.ui_info_texts = 1;
+    cfg.unknown_450 = 1;
+    cfg.unknown_460 = 1;
+    cfg.sfx_volume = 1.0;
+    cfg.music_volume = 1.0;
+    cfg.gore_disabled = 0;
+    cfg.score_load_gate = 0;
+    cfg.detail_preset = 5;
+    cfg.mouse_sensitivity = 0.5;
+    cfg.keybind_pick_perk = 0x101;
+    cfg.keybind_reload = 0x102;
+
+    for (0..saved_name_slot_count) |idx| {
+        std.mem.writeInt(u32, cfg.saved_name_order[idx * 4 ..][0..4], @intCast(idx), .little);
+        const start = idx * saved_name_entry_size;
+        @memset(cfg.saved_names[start .. start + saved_name_entry_size], 0);
+        @memcpy(cfg.saved_names[start .. start + "default".len], "default");
+    }
+
+    @memset(cfg.player_name[0..], 0);
+    @memcpy(cfg.player_name[0.."10tons".len], "10tons");
+
+    cfg.unknown_248[player_bind_block_size * 2] = ext_direction_arrow_on;
+    cfg.unknown_248[player_bind_block_size * 2 + 1] = ext_direction_arrow_on;
+
+    inline for (0..player_bind_block_count_total) |idx| {
+        setPlayerBindBlock(&cfg, idx, defaultPlayerBindBlock(idx));
+    }
+
+    return cfg;
+}
 
 pub fn decode(bytes: []const u8) CrimsonCfgError!CrimsonCfg {
     if (bytes.len != file_size) return error.InvalidSize;
@@ -274,4 +558,54 @@ test "crimson.cfg maps representative field offsets" {
     try std.testing.expectEqual(@as(u8, 1), encoded[0x1C4]);
     try std.testing.expectEqual(@as(u32, 0x101), std.mem.readInt(u32, encoded[0x478..0x47C], .little));
     try std.testing.expectEqual(@as(u32, 0x102), std.mem.readInt(u32, encoded[0x47C..0x480], .little));
+}
+
+test "crimson.cfg default config mirrors python defaults" {
+    const cfg = defaultConfig();
+
+    try std.testing.expectEqual(@as(u32, 1), cfg.player_count);
+    try std.testing.expectEqual(@as(u32, 1), cfg.game_mode);
+    try std.testing.expectEqual(@as(u32, 32), cfg.screen_bpp);
+    try std.testing.expectEqual(@as(u32, 1024), cfg.screen_width);
+    try std.testing.expectEqual(@as(u32, 768), cfg.screen_height);
+    try std.testing.expectEqual(@as(u8, 1), cfg.windowed_flag);
+    try std.testing.expectEqual(@as(u32, 5), cfg.detail_preset);
+    try std.testing.expectEqual(@as(f32, 1.0), cfg.texture_scale);
+    try std.testing.expectEqual(@as(f32, 0.5), cfg.mouse_sensitivity);
+    try std.testing.expectEqual(@as(u32, 0x101), cfg.keybind_pick_perk);
+    try std.testing.expectEqual(@as(u32, 0x102), cfg.keybind_reload);
+    try std.testing.expectEqualStrings("10tons", std.mem.sliceTo(cfg.player_name[0..], 0));
+    try std.testing.expectEqualStrings("default", cfg.saved_names[0.."default".len]);
+
+    const p1 = playerBindBlock(&cfg, 0);
+    try std.testing.expectEqual(defaultPlayerBindBlock(0).move_forward, p1.move_forward);
+    try std.testing.expectEqual(defaultPlayerBindBlock(0).fire, p1.fire);
+
+    const p4 = playerBindBlock(&cfg, 3);
+    try std.testing.expectEqual(defaultPlayerBindBlock(3).move_forward, p4.move_forward);
+    try std.testing.expectEqual(defaultPlayerBindBlock(3).fire, p4.fire);
+    try std.testing.expect(playerShowDirectionArrow(&cfg, 3));
+}
+
+test "crimson.cfg bind block helpers roundtrip" {
+    const expected: PlayerBindBlock = .{
+        .move_forward = 0x11,
+        .move_backward = 0x1F,
+        .turn_left = 0x1E,
+        .turn_right = 0x20,
+        .fire = 0x100,
+        .reserved_keys = [_]i32{ keybind_unbound_code, keybind_unbound_code },
+        .aim_left = 0x10,
+        .aim_right = 0x12,
+        .axis_aim_y = 0x13F,
+        .axis_aim_x = 0x140,
+        .axis_move_y = 0x141,
+        .axis_move_x = 0x153,
+        .padding = [_]i32{ keybind_unbound_code, keybind_unbound_code, keybind_unbound_code },
+    };
+
+    const encoded = encodePlayerBindBlock(expected);
+    const decoded = try decodePlayerBindBlock(encoded[0..]);
+
+    try std.testing.expectEqualDeep(expected, decoded);
 }

--- a/crimson-zig/src/input_codes.zig
+++ b/crimson-zig/src/input_codes.zig
@@ -1,0 +1,121 @@
+const std = @import("std");
+const rl = @import("raylib");
+
+pub const input_code_unbound: i32 = 0x17E;
+
+pub fn raylibKeyFromInputCode(code: i32) ?rl.KeyboardKey {
+    return switch (code) {
+        0x01 => @enumFromInt(256),
+        0x02 => @enumFromInt(49),
+        0x03 => @enumFromInt(50),
+        0x04 => @enumFromInt(51),
+        0x05 => @enumFromInt(52),
+        0x06 => @enumFromInt(53),
+        0x07 => @enumFromInt(54),
+        0x08 => @enumFromInt(55),
+        0x09 => @enumFromInt(56),
+        0x0A => @enumFromInt(57),
+        0x0B => @enumFromInt(48),
+        0x0C => @enumFromInt(45),
+        0x0D => @enumFromInt(61),
+        0x0E => @enumFromInt(259),
+        0x0F => @enumFromInt(258),
+        0x10 => @enumFromInt(81),
+        0x11 => @enumFromInt(87),
+        0x12 => @enumFromInt(69),
+        0x13 => @enumFromInt(82),
+        0x14 => @enumFromInt(84),
+        0x15 => @enumFromInt(89),
+        0x16 => @enumFromInt(85),
+        0x17 => @enumFromInt(73),
+        0x18 => @enumFromInt(79),
+        0x19 => @enumFromInt(80),
+        0x1A => @enumFromInt(91),
+        0x1B => @enumFromInt(93),
+        0x1C => @enumFromInt(257),
+        0x1D => @enumFromInt(341),
+        0x1E => @enumFromInt(65),
+        0x1F => @enumFromInt(83),
+        0x20 => @enumFromInt(68),
+        0x21 => @enumFromInt(70),
+        0x22 => @enumFromInt(71),
+        0x23 => @enumFromInt(72),
+        0x24 => @enumFromInt(74),
+        0x25 => @enumFromInt(75),
+        0x26 => @enumFromInt(76),
+        0x27 => @enumFromInt(59),
+        0x28 => @enumFromInt(39),
+        0x29 => @enumFromInt(96),
+        0x2A => @enumFromInt(340),
+        0x2B => @enumFromInt(92),
+        0x2C => @enumFromInt(90),
+        0x2D => @enumFromInt(88),
+        0x2E => @enumFromInt(67),
+        0x2F => @enumFromInt(86),
+        0x30 => @enumFromInt(66),
+        0x31 => @enumFromInt(78),
+        0x32 => @enumFromInt(77),
+        0x33 => @enumFromInt(44),
+        0x34 => @enumFromInt(46),
+        0x35 => @enumFromInt(47),
+        0x36 => @enumFromInt(344),
+        0x38 => @enumFromInt(342),
+        0x39 => @enumFromInt(32),
+        0x3B => @enumFromInt(290),
+        0x3C => @enumFromInt(291),
+        0x3D => @enumFromInt(292),
+        0x3E => @enumFromInt(293),
+        0x3F => @enumFromInt(294),
+        0x40 => @enumFromInt(295),
+        0x41 => @enumFromInt(296),
+        0x42 => @enumFromInt(297),
+        0x43 => @enumFromInt(298),
+        0x44 => @enumFromInt(299),
+        0x57 => @enumFromInt(300),
+        0x58 => @enumFromInt(301),
+        0x9D => @enumFromInt(345),
+        0xC7 => @enumFromInt(268),
+        0xC8 => @enumFromInt(265),
+        0xC9 => @enumFromInt(266),
+        0xCB => @enumFromInt(263),
+        0xCD => @enumFromInt(262),
+        0xCF => @enumFromInt(269),
+        0xD0 => @enumFromInt(264),
+        0xD1 => @enumFromInt(267),
+        0xD2 => @enumFromInt(260),
+        0xD3 => @enumFromInt(261),
+        else => null,
+    };
+}
+
+pub fn raylibMouseButtonFromInputCode(code: i32) ?rl.MouseButton {
+    return switch (code) {
+        0x100 => .left,
+        0x101 => .right,
+        0x102 => .middle,
+        0x103 => .side,
+        0x104 => .extra,
+        else => null,
+    };
+}
+
+pub fn inputCodeIsDown(code: i32) bool {
+    if (raylibKeyFromInputCode(code)) |key| return rl.isKeyDown(key);
+    if (raylibMouseButtonFromInputCode(code)) |button| return rl.isMouseButtonDown(button);
+    return false;
+}
+
+pub fn inputCodeIsPressed(code: i32) bool {
+    if (raylibKeyFromInputCode(code)) |key| return rl.isKeyPressed(key);
+    if (raylibMouseButtonFromInputCode(code)) |button| return rl.isMouseButtonPressed(button);
+    return false;
+}
+
+test "input code mapping covers default gameplay bindings" {
+    try std.testing.expectEqual(@as(?rl.KeyboardKey, @enumFromInt(87)), raylibKeyFromInputCode(0x11));
+    try std.testing.expectEqual(@as(?rl.KeyboardKey, @enumFromInt(83)), raylibKeyFromInputCode(0x1F));
+    try std.testing.expectEqual(@as(?rl.KeyboardKey, @enumFromInt(65)), raylibKeyFromInputCode(0x1E));
+    try std.testing.expectEqual(@as(?rl.KeyboardKey, @enumFromInt(68)), raylibKeyFromInputCode(0x20));
+    try std.testing.expectEqual(@as(?rl.MouseButton, .left), raylibMouseButtonFromInputCode(0x100));
+    try std.testing.expectEqual(@as(?rl.MouseButton, .right), raylibMouseButtonFromInputCode(0x101));
+}

--- a/crimson-zig/src/runtime/live_runner.zig
+++ b/crimson-zig/src/runtime/live_runner.zig
@@ -29,6 +29,7 @@ pub const LiveSurvivalConfig = struct {
     preserve_bugs: bool = false,
     status_quest_unlock_index: i32 = 0,
     status_quest_unlock_index_full: i32 = 0,
+    status_weapon_usage_counts: [state_mod.weapon_count_size]u32 = [_]u32{0} ** state_mod.weapon_count_size,
 };
 
 pub const FrameInput = struct {
@@ -131,6 +132,7 @@ pub const LiveSurvivalRunner = struct {
                 .preserve_bugs = config.preserve_bugs,
                 .status_quest_unlock_index = config.status_quest_unlock_index,
                 .status_quest_unlock_index_full = config.status_quest_unlock_index_full,
+                .status_weapon_usage_counts = config.status_weapon_usage_counts,
             },
             .{},
         );

--- a/crimson-zig/src/test_root.zig
+++ b/crimson-zig/src/test_root.zig
@@ -1,13 +1,15 @@
 test {
     const cz = @import("crimson_zig");
 
-    _ = @import("audio/mod.zig");
+    _ = @import("app_runtime.zig");
     _ = cz.anim;
+    _ = @import("audio/mod.zig");
     _ = cz.bonuses;
     _ = cz.creatures;
     _ = cz.hash;
     _ = cz.formats;
     _ = cz.helpers;
+    _ = @import("input_codes.zig");
     _ = cz.lifecycle;
     _ = cz.live_runner;
     _ = cz.perks;

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -2,8 +2,12 @@ const std = @import("std");
 const rl = @import("raylib");
 
 const cz = @import("crimson_zig");
+const formats = cz.formats;
 const runtime_anim = cz.anim;
 const weapon_data = cz.weapon_data;
+const app_runtime = @import("app_runtime.zig");
+const audio_mod = @import("audio/audio.zig");
+const input_codes = @import("input_codes.zig");
 const live_audio = @import("audio/live_audio.zig");
 const window_assets = @import("window_assets.zig");
 const window_atlas = cz.window_atlas;
@@ -92,6 +96,7 @@ const ResultsScreen = struct {
 
 const App = struct {
     allocator: std.mem.Allocator,
+    runtime: app_runtime.DesktopRuntime,
     screen: Screen = .boot,
     boot_elapsed: f32 = 0.0,
     menu_selection: usize = 0,
@@ -105,10 +110,11 @@ const App = struct {
     next_seed_state: u32 = 0xC0FFEE,
     quit_requested: bool = false,
 
-    fn init(allocator: std.mem.Allocator) App {
+    fn init(allocator: std.mem.Allocator, runtime: app_runtime.DesktopRuntime) App {
         var app: App = .{
             .allocator = allocator,
-            .audio = live_audio.Bridge.init(allocator),
+            .runtime = runtime,
+            .audio = live_audio.Bridge.init(allocator, audio_mod.audioConfigFromCrimsonCfg(runtime.config), null),
         };
         app.loadAssets();
         return app;
@@ -128,7 +134,15 @@ const App = struct {
             self.allocator.free(message);
             self.assets_message = null;
         }
+        self.runtime.deinit();
         self.* = undefined;
+    }
+
+    fn saveAllIfDirty(self: *App) !void {
+        if (self.gameplay) |*gameplay| {
+            self.runtime.absorbSessionState(&gameplay.runner.session);
+        }
+        try self.runtime.saveAllIfDirty();
     }
 
     fn loadAssets(self: *App) void {
@@ -200,7 +214,8 @@ const App = struct {
                 gameplay.runner.session.world_size,
                 gameplay.runner.session.state.camera_shake_offset,
             );
-            const input = collectGameplayInput(&gameplay.runner, camera);
+            self.runtime.recordGameplayFrame(frame_dt);
+            const input = collectGameplayInput(&gameplay.runner, camera, &self.runtime);
             if (input.perk_choice_index != null) {
                 self.audio.playUiButtonClick();
             }
@@ -252,8 +267,15 @@ const App = struct {
 
     fn startNewRun(self: *App) void {
         self.audio.stopGameplayMusic();
+        self.runtime.recordModeStart(.survival);
         var runner = live_runner.LiveSurvivalRunner.init(.{
             .seed = nextRunSeed(&self.next_seed_state),
+            .detail_preset = @intCast(std.math.clamp(self.runtime.config.detail_preset, @as(u32, 1), @as(u32, 5))),
+            .gore_disabled = @intCast(self.runtime.config.gore_disabled),
+            .hardcore = self.runtime.config.hardcore_flag != 0,
+            .status_quest_unlock_index = self.runtime.status.quest_unlock_index,
+            .status_quest_unlock_index_full = self.runtime.status.quest_unlock_index_full,
+            .status_weapon_usage_counts = statusWeaponUsageCounts(self.runtime.status),
         }) catch |err| {
             self.results = .{
                 .reason = .runtime_error,
@@ -300,12 +322,17 @@ const App = struct {
     fn finishRun(self: *App, gameplay: *GameplayScreen, reason: ResultsReason, runtime_error: ?[]const u8) void {
         self.audio.stopGameplayMusic();
         const runner = &gameplay.runner;
+        self.runtime.absorbSessionState(&runner.session);
         const player_health = if (runner.player0Const()) |player| player.health else 0.0;
+        const save_error: ?[]const u8 = save_err: {
+            self.runtime.saveStatusIfDirty() catch |err| break :save_err @errorName(err);
+            break :save_err null;
+        };
         self.results = .{
             .reason = reason,
             .summary = runner.summary(),
             .player_health = player_health,
-            .runtime_error = runtime_error,
+            .runtime_error = runtime_error orelse save_error,
         };
         gameplay.deinit();
         self.gameplay = null;
@@ -431,15 +458,20 @@ const App = struct {
 };
 
 pub fn main() !void {
-    rl.initWindow(window_width, window_height, "crimson-zig");
+    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
+    defer _ = gpa.deinit();
+
+    var runtime = try app_runtime.DesktopRuntime.init(gpa.allocator());
+
+    rl.setConfigFlags(.{
+        .fullscreen_mode = runtime.config.windowed_flag == 0,
+    });
+    rl.initWindow(runtime.windowWidth(window_width), runtime.windowHeight(window_height), "crimson-zig");
     defer rl.closeWindow();
 
     rl.setTargetFPS(60);
 
-    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
-    defer _ = gpa.deinit();
-
-    var app = App.init(gpa.allocator());
+    var app = App.init(gpa.allocator(), runtime);
     defer app.deinit();
 
     while (!rl.windowShouldClose() and !app.quit_requested) {
@@ -450,6 +482,8 @@ pub fn main() !void {
         defer rl.endDrawing();
         app.draw();
     }
+
+    try app.saveAllIfDirty();
 }
 
 fn bootProgress(boot_elapsed: f32) f32 {
@@ -778,23 +812,34 @@ fn buildWorldCamera(world_size: f32, shake_offset: state_mod.Vec2) rl.Camera2D {
     };
 }
 
-fn collectGameplayInput(runner: *live_runner.LiveSurvivalRunner, camera: rl.Camera2D) live_runner.FrameInput {
-    const move_x = axisFromKeys(.a, .d);
-    const move_y = axisFromKeys(.w, .s);
+fn collectGameplayInput(
+    runner: *live_runner.LiveSurvivalRunner,
+    camera: rl.Camera2D,
+    runtime: *const app_runtime.DesktopRuntime,
+) live_runner.FrameInput {
+    const binds = runtime.primaryBindBlock();
+    const move_up_pressed = inputCodeIsDownWithAlt(binds.move_forward, 0xC8);
+    const move_down_pressed = inputCodeIsDownWithAlt(binds.move_backward, 0xD0);
+    const move_left_pressed = inputCodeIsDownWithAlt(binds.turn_left, 0xCB);
+    const move_right_pressed = inputCodeIsDownWithAlt(binds.turn_right, 0xCD);
     const mouse_world = rl.getScreenToWorld2D(rl.getMousePosition(), camera);
 
     var frame_input: live_runner.FrameInput = .{
         .player = .{
-            .move_x = move_x,
-            .move_y = move_y,
+            .move_x = boolAxis(move_left_pressed, move_right_pressed),
+            .move_y = boolAxis(move_up_pressed, move_down_pressed),
             .aim_x = mouse_world.x,
             .aim_y = mouse_world.y,
             .flags = .{
-                .fire_down = rl.isMouseButtonDown(.left) or rl.isKeyDown(.space),
-                .fire_pressed = rl.isMouseButtonPressed(.left) or rl.isKeyPressed(.space),
-                .reload_pressed = rl.isKeyPressed(.r),
-                .move_mode = 3,
+                .fire_down = input_codes.inputCodeIsDown(binds.fire),
+                .fire_pressed = input_codes.inputCodeIsPressed(binds.fire),
+                .reload_pressed = input_codes.inputCodeIsPressed(@intCast(runtime.config.keybind_reload)),
+                .move_mode = @intCast(runtime.config.player_mode_flag_p1),
                 .aim_scheme = 0,
+                .move_forward_pressed = move_up_pressed,
+                .move_backward_pressed = move_down_pressed,
+                .turn_left_pressed = move_left_pressed,
+                .turn_right_pressed = move_right_pressed,
             },
         },
     };
@@ -812,11 +857,20 @@ fn collectGameplayInput(runner: *live_runner.LiveSurvivalRunner, camera: rl.Came
     return frame_input;
 }
 
-fn axisFromKeys(negative: rl.KeyboardKey, positive: rl.KeyboardKey) f32 {
-    var value: f32 = 0.0;
-    if (rl.isKeyDown(negative)) value -= 1.0;
-    if (rl.isKeyDown(positive)) value += 1.0;
-    return value;
+fn boolAxis(negative: bool, positive: bool) f32 {
+    return @floatFromInt(@intFromBool(positive) - @intFromBool(negative));
+}
+
+fn inputCodeIsDownWithAlt(primary_code: i32, alt_code: i32) bool {
+    return input_codes.inputCodeIsDown(primary_code) or input_codes.inputCodeIsDown(alt_code);
+}
+
+fn statusWeaponUsageCounts(status: formats.game_cfg.Status) [state_mod.weapon_count_size]u32 {
+    var counts: [state_mod.weapon_count_size]u32 = [_]u32{0} ** state_mod.weapon_count_size;
+    for (0..@min(counts.len, status.weapon_usage_counts.len)) |idx| {
+        counts[idx] = status.weapon_usage_counts[idx];
+    }
+    return counts;
 }
 
 fn drawWorld(

--- a/docs/rewrite/zig-roadmap.md
+++ b/docs/rewrite/zig-roadmap.md
@@ -245,10 +245,23 @@ Definition of done for this workstream:
 The Zig tree has important codec groundwork here, but not the full application
 integration.
 
+Current progress:
+
+- [`crimson-zig/src/app_runtime.zig`](/Users/banteg/dev/banteg/crimson/crimson-zig/src/app_runtime.zig)
+  now gives the desktop slice a native owner for runtime-dir `crimson.cfg` and
+  `game.cfg`.
+- Missing `crimson.cfg` / `game.cfg` files are now created in Zig using the
+  existing codecs and Python-matching defaults.
+- [`crimson-zig/src/window_main.zig`](/Users/banteg/dev/banteg/crimson/crimson-zig/src/window_main.zig)
+  now reads `crimson.cfg` for current window/audio/gameplay defaults and writes
+  back `game.cfg` play counters, playtime, unlock indices, and weapon-usage
+  state from live runs.
+
 Remaining work:
 
-- use `crimson.cfg` and `game.cfg` codecs in real runtime boot/save flows,
-- wire unlocks, counters, highscores, and status mutation into the Zig app,
+- widen beyond the current Survival desktop slice:
+  Rush/Quest/Tutorial/Typ-o save semantics, quest counters, highscores,
+  and broader state ownership,
 - support in-product config editing rather than config-as-fixture only,
 - expose useful CLI/admin surfaces for inspecting and repairing local state.
 


### PR DESCRIPTION
## Summary
- add a native `app_runtime` owner for `crimson.cfg` and `game.cfg` in the Python-compatible runtime dir
- create missing config/status files from Zig defaults, thread current config defaults into the desktop Survival slice, and persist status mutations back out
- replace a few remaining hardcoded desktop bindings with `crimson.cfg`-driven player-1/fire/reload input handling for the current slice

## Testing
- zig build test
- zig build window
- zig build wasm
- zig build asset-smoke
- just docs-check
