### PR TITLE
feat(zig): port local input interpreter

### DIFF
--- a/crimson-zig/src/input_codes.zig
+++ b/crimson-zig/src/input_codes.zig
@@ -3,6 +3,94 @@ const rl = @import("raylib");
 
 pub const input_code_unbound: i32 = 0x17E;
 
+const axis_deadzone: f32 = 0.2;
+const axis_down_threshold: f32 = 0.5;
+const primary_edge_sentinel_player: i32 = -1;
+const primary_edge_sentinel_key: i32 = -1;
+const max_pressed_entries: usize = 96;
+
+const PressedEntry = struct {
+    player_index: i32,
+    key_code: i32,
+    value: bool,
+};
+
+const PressedState = struct {
+    prev_down: [max_pressed_entries]PressedEntry = undefined,
+    prev_down_len: usize = 0,
+    down: [max_pressed_entries]PressedEntry = undefined,
+    down_len: usize = 0,
+    pressed_cache: [max_pressed_entries]PressedEntry = undefined,
+    pressed_cache_len: usize = 0,
+    wheel_up: bool = false,
+    wheel_down: bool = false,
+
+    fn beginFrame(self: *PressedState, wheel_move: f32) void {
+        @memcpy(self.prev_down[0..self.down_len], self.down[0..self.down_len]);
+        self.prev_down_len = self.down_len;
+        self.pressed_cache_len = 0;
+        self.wheel_up = wheel_move > 0.0;
+        self.wheel_down = wheel_move < 0.0;
+    }
+
+    fn markDown(self: *PressedState, player_index: i32, key_code: i32, is_down: bool) bool {
+        self.setValue(&self.down, &self.down_len, player_index, key_code, is_down);
+        return is_down;
+    }
+
+    fn isPressed(self: *PressedState, player_index: i32, key_code: i32, is_down: bool) bool {
+        if (self.getValue(self.pressed_cache[0..self.pressed_cache_len], player_index, key_code)) |cached| {
+            return cached;
+        }
+        const prev = self.getValue(self.prev_down[0..self.prev_down_len], player_index, key_code) orelse false;
+        const pressed = is_down and !prev;
+        self.setValue(&self.down, &self.down_len, player_index, key_code, is_down);
+        self.setValue(&self.pressed_cache, &self.pressed_cache_len, player_index, key_code, pressed);
+        return pressed;
+    }
+
+    fn getValue(self: *const PressedState, entries: []const PressedEntry, player_index: i32, key_code: i32) ?bool {
+        _ = self;
+        for (entries) |entry| {
+            if (entry.player_index == player_index and entry.key_code == key_code) {
+                return entry.value;
+            }
+        }
+        return null;
+    }
+
+    fn setValue(
+        self: *PressedState,
+        entries: *[max_pressed_entries]PressedEntry,
+        len: *usize,
+        player_index: i32,
+        key_code: i32,
+        value: bool,
+    ) void {
+        _ = self;
+        var idx: usize = 0;
+        while (idx < len.*) : (idx += 1) {
+            if (entries[idx].player_index == player_index and entries[idx].key_code == key_code) {
+                entries[idx].value = value;
+                return;
+            }
+        }
+        if (len.* >= entries.len) return;
+        entries[len.*] = .{
+            .player_index = player_index,
+            .key_code = key_code,
+            .value = value,
+        };
+        len.* += 1;
+    }
+};
+
+var pressed_state: PressedState = .{};
+
+pub fn inputBeginFrame() void {
+    pressed_state.beginFrame(rl.getMouseWheelMove());
+}
+
 pub fn raylibKeyFromInputCode(code: i32) ?rl.KeyboardKey {
     return switch (code) {
         0x01 => @enumFromInt(256),
@@ -99,17 +187,321 @@ pub fn raylibMouseButtonFromInputCode(code: i32) ?rl.MouseButton {
     };
 }
 
-pub fn inputCodeIsDown(code: i32) bool {
-    if (raylibKeyFromInputCode(code)) |key| return rl.isKeyDown(key);
-    if (raylibMouseButtonFromInputCode(code)) |button| return rl.isMouseButtonDown(button);
+fn gamepadButtonFromInputCode(code: i32) ?rl.GamepadButton {
+    return switch (code) {
+        0x11F => .right_face_down,
+        0x120 => .right_face_right,
+        0x121 => .right_face_left,
+        0x122 => .right_face_up,
+        0x123 => .left_face_up,
+        0x124 => .left_face_right,
+        0x125 => .left_face_down,
+        0x126 => .left_face_left,
+        0x127 => .left_trigger_1,
+        0x128 => .right_trigger_1,
+        0x129 => .left_trigger_2,
+        0x12A => .right_trigger_2,
+        0x131 => .left_face_up,
+        0x132 => .left_face_down,
+        0x133 => .left_face_left,
+        0x134 => .left_face_right,
+        else => null,
+    };
+}
+
+fn gamepadAxisFromInputCode(code: i32) ?rl.GamepadAxis {
+    return switch (code) {
+        0x13F => .left_x,
+        0x140 => .left_y,
+        0x141 => .right_y,
+        0x153 => .right_x,
+        0x154 => .right_y,
+        0x155 => .right_trigger,
+        else => null,
+    };
+}
+
+fn rimAxisFromInputCode(code: i32) ?struct { player_index: i32, axis: rl.GamepadAxis } {
+    return switch (code) {
+        0x163 => .{ .player_index = 0, .axis = .left_x },
+        0x164 => .{ .player_index = 1, .axis = .left_x },
+        0x165 => .{ .player_index = 2, .axis = .left_x },
+        0x168 => .{ .player_index = 0, .axis = .left_y },
+        0x169 => .{ .player_index = 1, .axis = .left_y },
+        0x16A => .{ .player_index = 2, .axis = .left_y },
+        else => null,
+    };
+}
+
+fn rimButtonFromInputCode(code: i32) ?struct { player_index: i32, button: rl.GamepadButton } {
+    return switch (code) {
+        0x16D => .{ .player_index = 0, .button = .right_face_down },
+        0x16E => .{ .player_index = 0, .button = .right_face_right },
+        0x16F => .{ .player_index = 0, .button = .right_face_left },
+        0x170 => .{ .player_index = 0, .button = .right_face_up },
+        0x171 => .{ .player_index = 0, .button = .left_trigger_1 },
+        0x172 => .{ .player_index = 1, .button = .right_face_down },
+        0x173 => .{ .player_index = 1, .button = .right_face_right },
+        0x174 => .{ .player_index = 1, .button = .right_face_left },
+        0x175 => .{ .player_index = 1, .button = .right_face_up },
+        0x176 => .{ .player_index = 1, .button = .left_trigger_1 },
+        0x177 => .{ .player_index = 2, .button = .right_face_down },
+        0x178 => .{ .player_index = 2, .button = .right_face_right },
+        0x179 => .{ .player_index = 2, .button = .right_face_left },
+        0x17A => .{ .player_index = 2, .button = .right_face_up },
+        0x17B => .{ .player_index = 2, .button = .left_trigger_1 },
+        else => null,
+    };
+}
+
+fn playerGamepadIndex(player_index: i32) i32 {
+    return std.math.clamp(player_index, 0, 3);
+}
+
+fn axisValueForGamepad(gamepad_index: i32, axis: rl.GamepadAxis) f32 {
+    if (!rl.isGamepadAvailable(gamepad_index)) return 0.0;
+    const value = rl.getGamepadAxisMovement(gamepad_index, axis);
+    if (@abs(value) < axis_deadzone) return 0.0;
+    return std.math.clamp(value, @as(f32, -1.0), @as(f32, 1.0));
+}
+
+fn axisValueFromCode(key_code: i32, player_index: i32) f32 {
+    if (gamepadAxisFromInputCode(key_code)) |axis| {
+        return axisValueForGamepad(playerGamepadIndex(player_index), axis);
+    }
+    if (rimAxisFromInputCode(key_code)) |rim_axis| {
+        return axisValueForGamepad(rim_axis.player_index, rim_axis.axis);
+    }
+    return 0.0;
+}
+
+pub fn inputAxisValue(key_code: i32, player_index: i32) f32 {
+    return axisValueFromCode(key_code, player_index);
+}
+
+fn digitalDownForPlayer(key_code: i32, player_index: i32) bool {
+    if (key_code == input_code_unbound) return false;
+
+    if (raylibMouseButtonFromInputCode(key_code)) |button| {
+        return rl.isMouseButtonDown(button);
+    }
+    if (key_code < 0x100) {
+        if (raylibKeyFromInputCode(key_code)) |key| {
+            return rl.isKeyDown(key);
+        }
+        return false;
+    }
+    if (gamepadButtonFromInputCode(key_code)) |button| {
+        const gamepad = playerGamepadIndex(player_index);
+        return rl.isGamepadAvailable(gamepad) and rl.isGamepadButtonDown(gamepad, button);
+    }
+    if (rimButtonFromInputCode(key_code)) |rim_button| {
+        return rl.isGamepadAvailable(rim_button.player_index) and rl.isGamepadButtonDown(rim_button.player_index, rim_button.button);
+    }
+    if (gamepadAxisFromInputCode(key_code) != null or rimAxisFromInputCode(key_code) != null) {
+        return @abs(axisValueFromCode(key_code, player_index)) >= axis_down_threshold;
+    }
     return false;
 }
 
-pub fn inputCodeIsPressed(code: i32) bool {
-    if (raylibKeyFromInputCode(code)) |key| return rl.isKeyPressed(key);
-    if (raylibMouseButtonFromInputCode(code)) |button| return rl.isMouseButtonPressed(button);
+pub fn inputCodeIsDown(key_code: i32, player_index: i32) bool {
+    const down = digitalDownForPlayer(key_code, player_index);
+    return pressed_state.markDown(player_index, key_code, down);
+}
+
+pub fn inputCodeIsPressed(key_code: i32, player_index: i32) bool {
+    if (key_code == 0x109) return pressed_state.wheel_up;
+    if (key_code == 0x10A) return pressed_state.wheel_down;
+    const down = digitalDownForPlayer(key_code, player_index);
+    return pressed_state.isPressed(player_index, key_code, down);
+}
+
+pub fn captureFirstPressedInputCode(
+    player_index: i32,
+    include_keyboard: bool,
+    include_mouse: bool,
+    include_gamepad: bool,
+    include_axes: bool,
+    axis_threshold: f32,
+) ?i32 {
+    if (include_keyboard) {
+        while (true) {
+            const key = rl.getKeyPressed();
+            if (key <= 0) break;
+            inline for ([_]i32{
+                0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+                0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E,
+                0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D,
+                0x2E, 0x2F, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x38, 0x39, 0x3B, 0x3C, 0x3D, 0x3E,
+                0x3F, 0x40, 0x41, 0x42, 0x43, 0x44, 0x57, 0x58, 0x9D, 0xC7, 0xC8, 0xC9, 0xCB, 0xCD, 0xCF,
+                0xD0, 0xD1, 0xD2, 0xD3,
+            }) |code| {
+                if (raylibKeyFromInputCode(code)) |mapped_key| {
+                    if (@intFromEnum(mapped_key) == key) return code;
+                }
+            }
+        }
+    }
+
+    if (include_mouse) {
+        inline for ([_]i32{ 0x100, 0x101, 0x102, 0x103, 0x104 }) |code| {
+            if (raylibMouseButtonFromInputCode(code)) |button| {
+                if (rl.isMouseButtonPressed(button)) return code;
+            }
+        }
+        const wheel = rl.getMouseWheelMove();
+        if (wheel > 0.0) return 0x109;
+        if (wheel < 0.0) return 0x10A;
+    }
+
+    if (include_gamepad) {
+        const gamepad = playerGamepadIndex(player_index);
+        if (rl.isGamepadAvailable(gamepad)) {
+            inline for ([_]i32{
+                0x11F, 0x120, 0x121, 0x122, 0x123, 0x124, 0x125, 0x126, 0x127, 0x128, 0x129, 0x12A, 0x131, 0x132,
+                0x133, 0x134,
+            }) |code| {
+                if (gamepadButtonFromInputCode(code)) |button| {
+                    if (rl.isGamepadButtonPressed(gamepad, button)) return code;
+                }
+            }
+        }
+    }
+
+    if (include_axes) {
+        const gamepad = playerGamepadIndex(player_index);
+        if (rl.isGamepadAvailable(gamepad)) {
+            inline for ([_]i32{ 0x13F, 0x140, 0x141, 0x153, 0x154, 0x155 }) |code| {
+                if (gamepadAxisFromInputCode(code)) |axis| {
+                    if (@abs(rl.getGamepadAxisMovement(gamepad, axis)) >= axis_threshold) return code;
+                }
+            }
+        }
+    }
+    return null;
+}
+
+pub fn inputCodeName(key_code: i32) []const u8 {
+    return switch (key_code) {
+        input_code_unbound => "unbound",
+        0x100 => "Mouse1",
+        0x101 => "Mouse2",
+        0x102 => "Mouse3",
+        0x103 => "Mouse4",
+        0x104 => "Mouse5",
+        0x109 => "MWheelUp",
+        0x10A => "MWheelDown",
+        0x11F => "Joys1",
+        0x120 => "Joys2",
+        0x121 => "Joys3",
+        0x122 => "Joys4",
+        0x123 => "Joys5",
+        0x124 => "Joys6",
+        0x125 => "Joys7",
+        0x126 => "Joys8",
+        0x127 => "Joys9",
+        0x128 => "Joys10",
+        0x129 => "Joys11",
+        0x12A => "Joys12",
+        0x131 => "JoysUp",
+        0x132 => "JoysDown",
+        0x133 => "JoysLeft",
+        0x134 => "JoysRight",
+        0x13F => "JoyAxisX",
+        0x140 => "JoyAxisY",
+        0x141 => "JoyAxisZ",
+        0x153 => "JoyRotX",
+        0x154 => "JoyRotY",
+        0x155 => "JoyRotZ",
+        0x163 => "RIM0XAxis",
+        0x164 => "RIM1XAxis",
+        0x165 => "RIM2XAxis",
+        0x168 => "RIM0YAxis",
+        0x169 => "RIM1YAxis",
+        0x16A => "RIM2YAxis",
+        0x16D => "RIM0Btn1",
+        0x16E => "RIM0Btn2",
+        0x16F => "RIM0Btn3",
+        0x170 => "RIM0Btn4",
+        0x171 => "RIM0Btn5",
+        0x172 => "RIM1Btn1",
+        0x173 => "RIM1Btn2",
+        0x174 => "RIM1Btn3",
+        0x175 => "RIM1Btn4",
+        0x176 => "RIM1Btn5",
+        0x177 => "RIM2Btn1",
+        0x178 => "RIM2Btn2",
+        0x179 => "RIM2Btn3",
+        0x17A => "RIM2Btn4",
+        0x17B => "RIM2Btn5",
+        else => blk: {
+            if (key_code > 0x163) break :blk "RawInput ?";
+            break :blk switch (key_code) {
+                0x01 => "Escape",
+                0x0F => "Tab",
+                0x10 => "Q",
+                0x11 => "W",
+                0x12 => "E",
+                0x13 => "R",
+                0x1C => "Enter",
+                0x1D => "LControl",
+                0x1E => "A",
+                0x1F => "S",
+                0x20 => "D",
+                0x2A => "LShift",
+                0x36 => "RShift",
+                0x38 => "LAlt",
+                0x39 => "Space",
+                0x9D => "RControl",
+                0xC8 => "Up",
+                0xC9 => "PageUp",
+                0xCB => "Left",
+                0xCD => "Right",
+                0xD0 => "Down",
+                0xD1 => "PageDown",
+                0xD3 => "Delete",
+                else => "DIK",
+            };
+        },
+    };
+}
+
+fn inputPrimaryAnyDown(fire_codes: []const i32, player_count: i32) bool {
+    if (inputCodeIsDown(0x100, 0)) return true;
+
+    const clamped_count = std.math.clamp(player_count, 1, 4);
+    if (fire_codes.len < @as(usize, @intCast(clamped_count))) return false;
+    var player_index: i32 = 0;
+    while (player_index < clamped_count) : (player_index += 1) {
+        if (inputCodeIsDown(fire_codes[@intCast(player_index)], player_index)) return true;
+    }
     return false;
 }
+
+pub fn inputPrimaryIsDown(fire_codes: []const i32, player_count: i32) bool {
+    const down = inputPrimaryAnyDown(fire_codes, player_count);
+    _ = pressed_state.markDown(primary_edge_sentinel_player, primary_edge_sentinel_key, down);
+    return down;
+}
+
+pub fn inputPrimaryJustPressed(fire_codes: []const i32, player_count: i32) bool {
+    const down = inputPrimaryAnyDown(fire_codes, player_count);
+    return pressed_state.isPressed(primary_edge_sentinel_player, primary_edge_sentinel_key, down);
+}
+
+pub const RaylibInputSampler = struct {
+    pub fn codeIsDown(_: RaylibInputSampler, code: i32, player_index: i32) bool {
+        return inputCodeIsDown(code, player_index);
+    }
+
+    pub fn codeIsPressed(_: RaylibInputSampler, code: i32, player_index: i32) bool {
+        return inputCodeIsPressed(code, player_index);
+    }
+
+    pub fn axisValue(_: RaylibInputSampler, code: i32, player_index: i32) f32 {
+        return inputAxisValue(code, player_index);
+    }
+};
 
 test "input code mapping covers default gameplay bindings" {
     try std.testing.expectEqual(@as(?rl.KeyboardKey, @enumFromInt(87)), raylibKeyFromInputCode(0x11));
@@ -118,4 +510,63 @@ test "input code mapping covers default gameplay bindings" {
     try std.testing.expectEqual(@as(?rl.KeyboardKey, @enumFromInt(68)), raylibKeyFromInputCode(0x20));
     try std.testing.expectEqual(@as(?rl.MouseButton, .left), raylibMouseButtonFromInputCode(0x100));
     try std.testing.expectEqual(@as(?rl.MouseButton, .right), raylibMouseButtonFromInputCode(0x101));
+}
+
+test "input code name extended axes match original labels" {
+    try std.testing.expectEqualStrings("JoyAxisX", inputCodeName(0x13F));
+    try std.testing.expectEqualStrings("JoyAxisY", inputCodeName(0x140));
+    try std.testing.expectEqualStrings("JoyAxisZ", inputCodeName(0x141));
+    try std.testing.expectEqualStrings("JoyRotX", inputCodeName(0x153));
+    try std.testing.expectEqualStrings("JoyRotY", inputCodeName(0x154));
+    try std.testing.expectEqualStrings("JoyRotZ", inputCodeName(0x155));
+}
+
+test "input code name extended rim codes match original labels" {
+    try std.testing.expectEqualStrings("RIM0XAxis", inputCodeName(0x163));
+    try std.testing.expectEqualStrings("RIM2XAxis", inputCodeName(0x165));
+    try std.testing.expectEqualStrings("RIM0YAxis", inputCodeName(0x168));
+    try std.testing.expectEqualStrings("RIM2YAxis", inputCodeName(0x16A));
+    try std.testing.expectEqualStrings("RIM0Btn1", inputCodeName(0x16D));
+    try std.testing.expectEqualStrings("RIM1Btn5", inputCodeName(0x176));
+    try std.testing.expectEqualStrings("RIM2Btn5", inputCodeName(0x17B));
+}
+
+test "input code name unbound and rawinput fallback" {
+    try std.testing.expectEqualStrings("unbound", inputCodeName(input_code_unbound));
+    try std.testing.expectEqualStrings("RawInput ?", inputCodeName(0x17F));
+}
+
+test "axis z and rot x bindings use distinct raylib axes" {
+    try std.testing.expect(gamepadAxisFromInputCode(0x141).? != gamepadAxisFromInputCode(0x153).?);
+}
+
+test "pressed edge does not retrigger after unpolled held frame" {
+    var state: PressedState = .{};
+
+    state.beginFrame(0.0);
+    try std.testing.expect(state.isPressed(0, 0x11, true));
+
+    state.beginFrame(0.0);
+    state.beginFrame(0.0);
+
+    try std.testing.expect(!state.isPressed(0, 0x11, true));
+}
+
+test "primary edge latch is shared across all fire sources" {
+    var state: PressedState = .{};
+
+    state.beginFrame(0.0);
+    try std.testing.expect(state.isPressed(primary_edge_sentinel_player, primary_edge_sentinel_key, true));
+
+    state.beginFrame(0.0);
+    try std.testing.expect(!state.isPressed(primary_edge_sentinel_player, primary_edge_sentinel_key, true));
+
+    state.beginFrame(0.0);
+    try std.testing.expect(!state.isPressed(primary_edge_sentinel_player, primary_edge_sentinel_key, true));
+
+    state.beginFrame(0.0);
+    try std.testing.expect(!state.isPressed(primary_edge_sentinel_player, primary_edge_sentinel_key, false));
+
+    state.beginFrame(0.0);
+    try std.testing.expect(state.isPressed(primary_edge_sentinel_player, primary_edge_sentinel_key, true));
 }

--- a/crimson-zig/src/local_input.zig
+++ b/crimson-zig/src/local_input.zig
@@ -1,0 +1,854 @@
+const std = @import("std");
+
+const formats = @import("formats/mod.zig");
+const player_runtime = @import("runtime/player.zig");
+const state_mod = @import("runtime/state.zig");
+
+pub const aim_keyboard_turn_rate: f32 = 3.0;
+pub const aim_joystick_turn_rate: f32 = 4.0;
+
+pub const aim_radius_keyboard: f32 = 60.0;
+pub const aim_radius_pad_base: f32 = 42.0;
+pub const aim_radius_pad_scale: f32 = 96.0;
+pub const point_click_stop_radius: f32 = 20.0;
+pub const computer_target_switch_hysteresis: f32 = 64.0;
+pub const computer_arena_center: state_mod.Vec2 = .{ .x = 512.0, .y = 512.0 };
+pub const computer_move_target_radius: f32 = 300.0;
+pub const computer_aim_snap_distance: f32 = 4.0;
+pub const computer_aim_track_gain: f32 = 6.0;
+pub const computer_auto_fire_distance: f32 = 128.0;
+
+pub const movement_control_unknown: i32 = 0;
+pub const movement_control_relative: i32 = 1;
+pub const movement_control_static: i32 = 2;
+pub const movement_control_dual_action_pad: i32 = 3;
+pub const movement_control_mouse_point_click: i32 = 4;
+pub const movement_control_computer: i32 = 5;
+
+pub const aim_scheme_unknown: i32 = -1;
+pub const aim_scheme_mouse: i32 = 0;
+pub const aim_scheme_keyboard: i32 = 1;
+pub const aim_scheme_joystick: i32 = 2;
+pub const aim_scheme_mouse_relative: i32 = 3;
+pub const aim_scheme_dual_action_pad: i32 = 4;
+pub const aim_scheme_computer: i32 = 5;
+
+const alt_move_key_up: i32 = 0xC8;
+const alt_move_key_down: i32 = 0xD0;
+const alt_move_key_left: i32 = 0xCB;
+const alt_move_key_right: i32 = 0xCD;
+const aim_pov_left_code: i32 = 0x133;
+const aim_pov_right_code: i32 = 0x134;
+
+pub const PerPlayerInputState = struct {
+    aim_heading: f32 = 0.0,
+    move_target: state_mod.Vec2 = .{ .x = -1.0, .y = -1.0 },
+    computer_target_creature_index: i32 = -1,
+};
+
+pub const LocalInputInterpreter = struct {
+    states: [state_mod.max_players]PerPlayerInputState = [_]PerPlayerInputState{.{}} ** state_mod.max_players,
+    preserve_bugs: bool = false,
+
+    pub fn setPreserveBugs(self: *LocalInputInterpreter, enabled: bool) void {
+        self.preserve_bugs = enabled;
+    }
+
+    pub fn reset(self: *LocalInputInterpreter, players: ?[]const state_mod.PlayerState) void {
+        for (&self.states) |*state| {
+            state.* = .{};
+        }
+        if (players) |player_slice| {
+            for (player_slice, 0..) |player, idx| {
+                const slot = stateSlotForPlayer(idx, &player);
+                if (std.math.isFinite(player.aim_heading)) {
+                    self.states[slot].aim_heading = player.aim_heading;
+                }
+            }
+        }
+    }
+
+    pub fn buildPlayerInput(
+        self: *LocalInputInterpreter,
+        sampler: anytype,
+        player_index: usize,
+        player_count: usize,
+        player: *const state_mod.PlayerState,
+        config: *const formats.crimson_cfg.CrimsonCfg,
+        mouse_screen: state_mod.Vec2,
+        mouse_world: state_mod.Vec2,
+        screen_center: state_mod.Vec2,
+        dt: f32,
+        creatures: anytype,
+    ) player_runtime.GameInput {
+        const idx = @min(player_index, state_mod.max_players - 1);
+        const state = self.stateForPlayer(idx, player);
+        const binds = formats.crimson_cfg.playerBindBlock(config, idx);
+        const aim_scheme = resolveAimScheme(config, idx);
+        const move_mode_type = resolveMovementMode(config, idx);
+        const reload_key: i32 = @bitCast(config.keybind_reload);
+
+        const move_forward_key = binds.move_forward;
+        const move_backward_key = binds.move_backward;
+        const turn_left_key = binds.turn_left;
+        const turn_right_key = binds.turn_right;
+        const fire_key = binds.fire;
+        const aim_left_key = binds.aim_left;
+        const aim_right_key = binds.aim_right;
+        const aim_axis_y = binds.axis_aim_y;
+        const aim_axis_x = binds.axis_aim_x;
+        const move_axis_y = binds.axis_move_y;
+        const move_axis_x = binds.axis_move_x;
+
+        var move_vec: state_mod.Vec2 = .{};
+        var move_forward_pressed: ?bool = null;
+        var move_backward_pressed: ?bool = null;
+        var turn_left_pressed: ?bool = null;
+        var turn_right_pressed: ?bool = null;
+        var move_to_cursor_pressed = false;
+        var computer_target_index: ?i32 = null;
+
+        const computer_move_active = move_mode_type == movement_control_computer or aim_scheme == aim_scheme_computer;
+
+        if (computer_move_active) {
+            computer_target_index = self.selectComputerTarget(idx, player, creatures);
+            const center_delta = sub(computer_arena_center, player.pos);
+            const center_dist = length(center_delta);
+            const target_pos = blk: {
+                if (computer_target_index) |target_idx| {
+                    if (center_dist <= computer_move_target_radius) {
+                        if (creatureAt(creatures, target_idx)) |target| {
+                            break :blk target.pos;
+                        }
+                    }
+                }
+                break :blk computer_arena_center;
+            };
+
+            const move_delta = sub(target_pos, player.pos);
+            const move_dir = normalized(move_delta);
+            if (lengthSq(move_delta) > 1e-12) {
+                move_vec = move_dir;
+            }
+        } else if (move_mode_type == movement_control_relative) {
+            move_forward_pressed = keyDownWithSinglePlayerAlt(sampler, move_forward_key, alt_move_key_up, player_count, idx);
+            move_backward_pressed = keyDownWithSinglePlayerAlt(sampler, move_backward_key, alt_move_key_down, player_count, idx);
+            turn_left_pressed = keyDownWithSinglePlayerAlt(sampler, turn_left_key, alt_move_key_left, player_count, idx);
+            turn_right_pressed = keyDownWithSinglePlayerAlt(sampler, turn_right_key, alt_move_key_right, player_count, idx);
+            move_vec = .{
+                .x = boolToFloat(turnRightPressed(turn_right_pressed)) - boolToFloat(turnLeftPressed(turn_left_pressed)),
+                .y = boolToFloat(moveBackwardPressed(move_backward_pressed)) - boolToFloat(moveForwardPressed(move_forward_pressed)),
+            };
+        } else if (move_mode_type == movement_control_dual_action_pad) {
+            const axis_y = -sampler.axisValue(move_axis_y, @intCast(idx));
+            const axis_x = -sampler.axisValue(move_axis_x, @intCast(idx));
+            move_vec = .{
+                .x = clampUnit(axis_x),
+                .y = clampUnit(axis_y),
+            };
+        } else if (move_mode_type == movement_control_mouse_point_click) {
+            move_to_cursor_pressed = sampler.codeIsDown(reload_key, @intCast(idx));
+            if (move_to_cursor_pressed) {
+                state.move_target = mouse_world;
+            }
+            if (state.move_target.x >= 0.0 and state.move_target.y >= 0.0) {
+                const delta = sub(state.move_target, player.pos);
+                const dir = normalized(delta);
+                const dist = length(delta);
+                if (dist > point_click_stop_radius) {
+                    move_vec = dir;
+                }
+            }
+        } else if (move_mode_type == movement_control_static) {
+            const move_up_pressed = keyDownWithSinglePlayerAlt(sampler, move_forward_key, alt_move_key_up, player_count, idx);
+            const move_down_pressed = keyDownWithSinglePlayerAlt(sampler, move_backward_key, alt_move_key_down, player_count, idx);
+            const move_left_pressed = keyDownWithSinglePlayerAlt(sampler, turn_left_key, alt_move_key_left, player_count, idx);
+            const move_right_pressed = keyDownWithSinglePlayerAlt(sampler, turn_right_key, alt_move_key_right, player_count, idx);
+            move_forward_pressed = move_up_pressed;
+            move_backward_pressed = move_down_pressed;
+            turn_left_pressed = move_left_pressed;
+            turn_right_pressed = move_right_pressed;
+            move_vec = resolveStaticMoveVector(move_up_pressed, move_down_pressed, move_left_pressed, move_right_pressed);
+        } else {
+            move_vec = .{
+                .x = boolToFloat(sampler.codeIsDown(turn_right_key, @intCast(idx))) - boolToFloat(sampler.codeIsDown(turn_left_key, @intCast(idx))),
+                .y = boolToFloat(sampler.codeIsDown(move_backward_key, @intCast(idx))) - boolToFloat(sampler.codeIsDown(move_forward_key, @intCast(idx))),
+            };
+        }
+
+        var heading = if (std.math.isFinite(state.aim_heading)) state.aim_heading else player.aim_heading;
+        var aim = player.aim;
+        var computer_auto_fire = false;
+
+        switch (aim_scheme) {
+            aim_scheme_mouse => {
+                aim = mouse_world;
+                const delta = sub(aim, player.pos);
+                if (lengthSq(delta) > 1e-9) {
+                    heading = toHeading(delta);
+                }
+            },
+            aim_scheme_keyboard => {
+                if (move_mode_type == movement_control_relative or move_mode_type == movement_control_static) {
+                    if (sampler.codeIsDown(aim_right_key, @intCast(idx))) {
+                        heading += dt * aim_keyboard_turn_rate;
+                    }
+                    if (sampler.codeIsDown(aim_left_key, @intCast(idx))) {
+                        heading -= dt * aim_keyboard_turn_rate;
+                    }
+                    aim = aimPointFromHeading(player.pos, heading, aim_radius_keyboard);
+                }
+            },
+            aim_scheme_mouse_relative => {
+                const rel = sub(mouse_screen, screen_center);
+                if (lengthSq(rel) > 1.0) {
+                    heading = toHeading(rel);
+                    aim = aimPointFromHeading(player.pos, heading, aim_radius_keyboard);
+                }
+            },
+            aim_scheme_dual_action_pad => {
+                const axis_y = sampler.axisValue(aim_axis_y, @intCast(idx));
+                const axis_x = sampler.axisValue(aim_axis_x, @intCast(idx));
+                const axis_vec: state_mod.Vec2 = .{ .x = axis_x, .y = axis_y };
+                const mag_sq = lengthSq(axis_vec);
+                if (mag_sq > 1e-9) {
+                    const mag = length(axis_vec);
+                    const axis_dir = if (mag > 1e-9) axis_vec.mul(1.0 / mag) else state_mod.Vec2{};
+                    heading = toHeading(axis_dir);
+                    const radius = aim_radius_pad_base + mag * aim_radius_pad_scale;
+                    aim = add(player.pos, axis_dir.mul(radius));
+                } else {
+                    aim = aimPointFromHeading(player.pos, heading, aim_radius_keyboard);
+                }
+            },
+            aim_scheme_joystick => {
+                if (aimPovRightActive(sampler, idx, self.preserve_bugs)) {
+                    heading += dt * aim_joystick_turn_rate;
+                }
+                if (aimPovLeftActive(sampler, idx, self.preserve_bugs)) {
+                    heading -= dt * aim_joystick_turn_rate;
+                }
+                aim = aimPointFromHeading(player.pos, heading, aim_radius_keyboard);
+            },
+            aim_scheme_computer => {
+                var target_index = computer_target_index;
+                if (target_index == null) {
+                    target_index = self.selectComputerTarget(idx, player, creatures);
+                }
+                if (target_index) |resolved_idx| {
+                    if (creatureAt(creatures, resolved_idx)) |target| {
+                        aim = player.aim;
+                        const to_target = sub(target.pos, aim);
+                        const target_dist = length(to_target);
+                        if (target_dist >= computer_aim_snap_distance) {
+                            const target_dir = if (target_dist > 1e-9) to_target.mul(1.0 / target_dist) else state_mod.Vec2{};
+                            aim = add(aim, target_dir.mul(target_dist * computer_aim_track_gain * dt));
+                        } else {
+                            aim = target.pos;
+                        }
+                        const delta = sub(aim, player.pos);
+                        if (lengthSq(delta) > 1e-9) {
+                            heading = toHeading(delta);
+                        }
+                        computer_auto_fire = target_dist < computer_auto_fire_distance;
+                    } else {
+                        target_index = null;
+                    }
+                }
+                if (target_index == null) {
+                    var away = normalized(sub(player.pos, computer_arena_center));
+                    if (lengthSq(away) <= 1e-12) {
+                        away = .{ .x = 0.0, .y = -1.0 };
+                    }
+                    aim = add(player.pos, away.mul(aim_radius_keyboard));
+                    heading = toHeading(away);
+                }
+            },
+            else => {},
+        }
+
+        const aim_delta = sub(aim, player.pos);
+        if (lengthSq(aim_delta) > 1e-9) {
+            heading = toHeading(aim_delta);
+        }
+        state.aim_heading = heading;
+
+        var fire_down = sampler.codeIsDown(fire_key, @intCast(idx));
+        const fire_pressed = sampler.codeIsPressed(fire_key, @intCast(idx));
+        if (aim_scheme == aim_scheme_computer and computer_auto_fire) {
+            fire_down = true;
+        }
+        const reload_pressed = sampler.codeIsPressed(reload_key, @intCast(idx));
+        const reload_down = sampler.codeIsDown(reload_key, @intCast(idx));
+
+        return .{
+            .move_x = move_vec.x,
+            .move_y = move_vec.y,
+            .aim_x = aim.x,
+            .aim_y = aim.y,
+            .flags = .{
+                .fire_down = fire_down,
+                .fire_pressed = fire_pressed,
+                .reload_pressed = reload_pressed,
+                .reload_down = reload_down,
+                .move_to_cursor_pressed = move_to_cursor_pressed,
+                .move_mode = move_mode_type,
+                .aim_scheme = aim_scheme,
+                .move_forward_pressed = move_forward_pressed,
+                .move_backward_pressed = move_backward_pressed,
+                .turn_left_pressed = turn_left_pressed,
+                .turn_right_pressed = turn_right_pressed,
+            },
+        };
+    }
+
+    fn stateForPlayer(
+        self: *LocalInputInterpreter,
+        player_index: usize,
+        player: *const state_mod.PlayerState,
+    ) *PerPlayerInputState {
+        const slot = stateSlotForPlayer(player_index, player);
+        const state = &self.states[slot];
+        if (!std.math.isFinite(state.aim_heading)) {
+            state.aim_heading = player.aim_heading;
+        }
+        return state;
+    }
+
+    fn selectComputerTarget(
+        self: *LocalInputInterpreter,
+        player_index: usize,
+        player: *const state_mod.PlayerState,
+        creatures: anytype,
+    ) ?i32 {
+        const slot = stateSlotForPlayer(player_index, player);
+        const state = &self.states[slot];
+        const candidate = nearestLivingCreatureIndex(player.pos, creatures);
+        const current = state.computer_target_creature_index;
+
+        if (candidate == null) {
+            state.computer_target_creature_index = -1;
+            return null;
+        }
+        if (current < 0) {
+            state.computer_target_creature_index = candidate.?;
+            return candidate;
+        }
+
+        const current_creature = creatureAt(creatures, current) orelse {
+            state.computer_target_creature_index = candidate.?;
+            return candidate;
+        };
+        if (!current_creature.active or current_creature.hp <= 0.0) {
+            state.computer_target_creature_index = candidate.?;
+            return candidate;
+        }
+        if (candidate.? == current) return candidate;
+
+        const candidate_creature = creatureAt(creatures, candidate.?) orelse return current;
+        if (!candidate_creature.active or candidate_creature.hp <= 0.0) return current;
+
+        const current_dist = length(sub(current_creature.pos, player.pos));
+        const candidate_dist = length(sub(candidate_creature.pos, player.pos));
+        if (candidate_dist + computer_target_switch_hysteresis < current_dist) {
+            state.computer_target_creature_index = candidate.?;
+            return candidate;
+        }
+        return current;
+    }
+};
+
+fn resolveMovementMode(config: *const formats.crimson_cfg.CrimsonCfg, player_index: usize) i32 {
+    return @intCast(formats.crimson_cfg.playerMovement(config, player_index));
+}
+
+fn resolveAimScheme(config: *const formats.crimson_cfg.CrimsonCfg, player_index: usize) i32 {
+    return @bitCast(formats.crimson_cfg.playerAimScheme(config, player_index));
+}
+
+fn stateSlotForPlayer(player_index: usize, player: *const state_mod.PlayerState) usize {
+    const raw_slot = if (player.index >= 0) @as(usize, @intCast(player.index)) else player_index;
+    return @min(raw_slot, state_mod.max_players - 1);
+}
+
+fn singlePlayerAltKeysEnabled(player_count: usize, player_index: usize) bool {
+    return player_index == 0 and player_count == 1;
+}
+
+fn keyDownWithSinglePlayerAlt(
+    sampler: anytype,
+    primary_key: i32,
+    alt_key: i32,
+    player_count: usize,
+    player_index: usize,
+) bool {
+    if (sampler.codeIsDown(primary_key, @intCast(player_index))) return true;
+    if (singlePlayerAltKeysEnabled(player_count, player_index)) {
+        return sampler.codeIsDown(alt_key, @intCast(player_index));
+    }
+    return false;
+}
+
+fn aimPovLeftActive(sampler: anytype, player_index: usize, preserve_bugs: bool) bool {
+    const pov_index: i32 = if (preserve_bugs) 0 else @intCast(player_index);
+    return sampler.codeIsDown(aim_pov_left_code, pov_index);
+}
+
+fn aimPovRightActive(sampler: anytype, player_index: usize, preserve_bugs: bool) bool {
+    const pov_index: i32 = if (preserve_bugs) 0 else @intCast(player_index);
+    return sampler.codeIsDown(aim_pov_right_code, pov_index);
+}
+
+fn resolveStaticMoveVector(move_up: bool, move_down: bool, move_left: bool, move_right: bool) state_mod.Vec2 {
+    var move: state_mod.Vec2 = .{};
+    if (move_left) move = .{ .x = -1.0, .y = 0.0 };
+    if (move_right) move = .{ .x = 1.0, .y = 0.0 };
+
+    if (move_up) {
+        if (move_left) {
+            move = .{ .x = -1.0, .y = -1.0 };
+        } else if (move_right) {
+            move = .{ .x = 1.0, .y = -1.0 };
+        } else {
+            move = .{ .x = 0.0, .y = -1.0 };
+        }
+    }
+
+    if (move_down) {
+        if (move_left) {
+            move = .{ .x = -1.0, .y = 1.0 };
+        } else if (move_right) {
+            move = .{ .x = 1.0, .y = 1.0 };
+        } else {
+            move = .{ .x = 0.0, .y = 1.0 };
+        }
+    }
+
+    return move;
+}
+
+fn nearestLivingCreatureIndex(pos: state_mod.Vec2, creatures: anytype) ?i32 {
+    var best_idx: ?i32 = null;
+    var best_dist_sq: f32 = 0.0;
+    for (creatures, 0..) |creature, idx| {
+        if (!@field(creature, "active")) continue;
+        if (@field(creature, "hp") <= 0.0) continue;
+        const dist_sq = lengthSq(sub(@field(creature, "pos"), pos));
+        if (best_idx == null or dist_sq < best_dist_sq) {
+            best_idx = @intCast(idx);
+            best_dist_sq = dist_sq;
+        }
+    }
+    return best_idx;
+}
+
+fn creatureAt(creatures: anytype, index: i32) ?@TypeOf(&creatures[0]) {
+    if (index < 0) return null;
+    const idx: usize = @intCast(index);
+    if (idx >= creatures.len) return null;
+    return &creatures[idx];
+}
+
+fn boolToFloat(value: bool) f32 {
+    return if (value) 1.0 else 0.0;
+}
+
+fn moveForwardPressed(value: ?bool) bool {
+    return value orelse false;
+}
+
+fn moveBackwardPressed(value: ?bool) bool {
+    return value orelse false;
+}
+
+fn turnLeftPressed(value: ?bool) bool {
+    return value orelse false;
+}
+
+fn turnRightPressed(value: ?bool) bool {
+    return value orelse false;
+}
+
+fn clampUnit(v: f32) f32 {
+    return std.math.clamp(v, @as(f32, -1.0), @as(f32, 1.0));
+}
+
+fn aimPointFromHeading(pos: state_mod.Vec2, heading: f32, radius: f32) state_mod.Vec2 {
+    return add(pos, state_mod.Vec2.fromAngle(heading).mul(radius));
+}
+
+fn add(a: state_mod.Vec2, b: state_mod.Vec2) state_mod.Vec2 {
+    return state_mod.Vec2.add(a, b);
+}
+
+fn sub(a: state_mod.Vec2, b: state_mod.Vec2) state_mod.Vec2 {
+    return state_mod.Vec2.sub(a, b);
+}
+
+fn length(vec: state_mod.Vec2) f32 {
+    return vec.length();
+}
+
+fn lengthSq(vec: state_mod.Vec2) f32 {
+    return vec.lengthSq();
+}
+
+fn normalized(vec: state_mod.Vec2) state_mod.Vec2 {
+    const len = length(vec);
+    if (!(len > 1e-9)) return .{};
+    return vec.mul(1.0 / len);
+}
+
+fn toHeading(vec: state_mod.Vec2) f32 {
+    return vec.toHeading();
+}
+
+const FakeSampler = struct {
+    down: []const KeyState = &.{},
+    pressed: []const KeyState = &.{},
+    axes: []const AxisState = &.{},
+
+    const KeyState = struct {
+        player_index: i32,
+        code: i32,
+        value: bool,
+    };
+
+    const AxisState = struct {
+        player_index: i32,
+        code: i32,
+        value: f32,
+    };
+
+    fn codeIsDown(self: FakeSampler, code: i32, player_index: i32) bool {
+        for (self.down) |entry| {
+            if (entry.player_index == player_index and entry.code == code) return entry.value;
+        }
+        return false;
+    }
+
+    fn codeIsPressed(self: FakeSampler, code: i32, player_index: i32) bool {
+        for (self.pressed) |entry| {
+            if (entry.player_index == player_index and entry.code == code) return entry.value;
+        }
+        return false;
+    }
+
+    fn axisValue(self: FakeSampler, code: i32, player_index: i32) f32 {
+        for (self.axes) |entry| {
+            if (entry.player_index == player_index and entry.code == code) return entry.value;
+        }
+        return 0.0;
+    }
+};
+
+fn makePlayer(index: i32, pos: state_mod.Vec2, aim: state_mod.Vec2, aim_heading: f32) state_mod.PlayerState {
+    return .{
+        .index = index,
+        .pos = pos,
+        .aim = aim,
+        .aim_heading = aim_heading,
+    };
+}
+
+fn expectFloatClose(expected: f32, actual: f32) !void {
+    try std.testing.expectApproxEqAbs(expected, actual, 1e-4);
+}
+
+test "computer aim auto fires without fire pressed" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 512.0, .y = 512.0 }, .{ .x = 560.0, .y = 512.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.aim_scheme_p1 = @bitCast(@as(i32, aim_scheme_computer));
+
+    const creatures = [_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{
+        .{ .active = true, .hp = 20.0, .pos = .{ .x = 612.0, .y = 512.0 } },
+    };
+
+    const out = interpreter.buildPlayerInput(.{}, 0, 1, &player, &cfg, .{}, .{}, .{}, 0.1, creatures[0..]);
+
+    try std.testing.expect(out.flags.fire_down);
+    try std.testing.expect(!out.flags.fire_pressed);
+    try expectFloatClose(591.2, out.aim_x);
+    try expectFloatClose(512.0, out.aim_y);
+}
+
+test "static mode conflict precedence matches native" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 100.0, .y = 100.0 }, .{ .x = 160.0, .y = 100.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+
+    const sampler: FakeSampler = .{
+        .down = &.{
+            .{ .player_index = 0, .code = formats.crimson_cfg.playerBindBlock(&cfg, 0).move_forward, .value = true },
+            .{ .player_index = 0, .code = formats.crimson_cfg.playerBindBlock(&cfg, 0).turn_left, .value = true },
+            .{ .player_index = 0, .code = formats.crimson_cfg.playerBindBlock(&cfg, 0).turn_right, .value = true },
+        },
+    };
+    const out = interpreter.buildPlayerInput(sampler, 0, 1, &player, &cfg, .{}, .{}, .{}, 0.1, &[_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{});
+
+    try expectFloatClose(-1.0, out.move_x);
+    try expectFloatClose(-1.0, out.move_y);
+}
+
+test "relative mode single player uses alt arrow fallback" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 100.0, .y = 100.0 }, .{ .x = 160.0, .y = 100.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.player_mode_flag_p1 = @intCast(movement_control_relative);
+    formats.crimson_cfg.setPlayerBindBlock(&cfg, 0, .{
+        .move_forward = formats.crimson_cfg.keybind_unbound_code,
+        .move_backward = formats.crimson_cfg.keybind_unbound_code,
+        .turn_left = formats.crimson_cfg.keybind_unbound_code,
+        .turn_right = formats.crimson_cfg.keybind_unbound_code,
+        .fire = 0x100,
+        .reserved_keys = .{ formats.crimson_cfg.keybind_unbound_code, formats.crimson_cfg.keybind_unbound_code },
+        .aim_left = formats.crimson_cfg.keybind_unbound_code,
+        .aim_right = formats.crimson_cfg.keybind_unbound_code,
+        .axis_aim_y = formats.crimson_cfg.keybind_unbound_code,
+        .axis_aim_x = formats.crimson_cfg.keybind_unbound_code,
+        .axis_move_y = formats.crimson_cfg.keybind_unbound_code,
+        .axis_move_x = formats.crimson_cfg.keybind_unbound_code,
+        .padding = .{
+            formats.crimson_cfg.keybind_unbound_code,
+            formats.crimson_cfg.keybind_unbound_code,
+            formats.crimson_cfg.keybind_unbound_code,
+        },
+    });
+
+    const out = interpreter.buildPlayerInput(
+        .{ .down = &.{
+            .{ .player_index = 0, .code = alt_move_key_up, .value = true },
+            .{ .player_index = 0, .code = alt_move_key_left, .value = true },
+        } },
+        0,
+        1,
+        &player,
+        &cfg,
+        .{},
+        .{},
+        .{},
+        0.1,
+        &[_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{},
+    );
+
+    try std.testing.expect(out.flags.move_forward_pressed.?);
+    try std.testing.expect(out.flags.turn_left_pressed.?);
+    try expectFloatClose(-1.0, out.move_x);
+    try expectFloatClose(-1.0, out.move_y);
+}
+
+test "relative mode multiplayer does not use alt arrow fallback" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 100.0, .y = 100.0 }, .{ .x = 160.0, .y = 100.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.player_mode_flag_p1 = @intCast(movement_control_relative);
+    formats.crimson_cfg.setPlayerBindBlock(&cfg, 0, .{
+        .move_forward = formats.crimson_cfg.keybind_unbound_code,
+        .move_backward = formats.crimson_cfg.keybind_unbound_code,
+        .turn_left = formats.crimson_cfg.keybind_unbound_code,
+        .turn_right = formats.crimson_cfg.keybind_unbound_code,
+        .fire = 0x100,
+        .reserved_keys = .{ formats.crimson_cfg.keybind_unbound_code, formats.crimson_cfg.keybind_unbound_code },
+        .aim_left = formats.crimson_cfg.keybind_unbound_code,
+        .aim_right = formats.crimson_cfg.keybind_unbound_code,
+        .axis_aim_y = formats.crimson_cfg.keybind_unbound_code,
+        .axis_aim_x = formats.crimson_cfg.keybind_unbound_code,
+        .axis_move_y = formats.crimson_cfg.keybind_unbound_code,
+        .axis_move_x = formats.crimson_cfg.keybind_unbound_code,
+        .padding = .{
+            formats.crimson_cfg.keybind_unbound_code,
+            formats.crimson_cfg.keybind_unbound_code,
+            formats.crimson_cfg.keybind_unbound_code,
+        },
+    });
+
+    const out = interpreter.buildPlayerInput(
+        .{ .down = &.{
+            .{ .player_index = 0, .code = alt_move_key_up, .value = true },
+            .{ .player_index = 0, .code = alt_move_key_left, .value = true },
+        } },
+        0,
+        2,
+        &player,
+        &cfg,
+        .{},
+        .{},
+        .{},
+        0.1,
+        &[_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{},
+    );
+
+    try std.testing.expectEqual(@as(bool, false), out.flags.move_forward_pressed.?);
+    try std.testing.expectEqual(@as(bool, false), out.flags.turn_left_pressed.?);
+    try expectFloatClose(0.0, out.move_x);
+    try expectFloatClose(0.0, out.move_y);
+}
+
+test "mouse point click marks move to cursor press" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 100.0, .y = 100.0 }, .{ .x = 160.0, .y = 100.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.player_mode_flag_p1 = @intCast(movement_control_mouse_point_click);
+
+    const mouse_world: state_mod.Vec2 = .{ .x = 160.0, .y = 140.0 };
+    const out = interpreter.buildPlayerInput(
+        .{
+            .down = &.{.{ .player_index = 0, .code = @bitCast(cfg.keybind_reload), .value = true }},
+            .pressed = &.{.{ .player_index = 0, .code = @bitCast(cfg.keybind_reload), .value = true }},
+        },
+        0,
+        1,
+        &player,
+        &cfg,
+        .{},
+        mouse_world,
+        .{},
+        0.1,
+        &[_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{},
+    );
+
+    try std.testing.expect(out.flags.reload_pressed);
+    try std.testing.expect(out.flags.move_to_cursor_pressed);
+    const expected = normalized(sub(mouse_world, player.pos));
+    try expectFloatClose(expected.x, out.move_x);
+    try expectFloatClose(expected.y, out.move_y);
+}
+
+test "computer move mode near center heads toward target" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 500.0, .y = 500.0 }, .{ .x = 560.0, .y = 500.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.player_mode_flag_p1 = @intCast(movement_control_computer);
+    const creatures = [_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{
+        .{ .active = true, .hp = 20.0, .pos = .{ .x = 560.0, .y = 500.0 } },
+    };
+
+    const out = interpreter.buildPlayerInput(.{}, 0, 1, &player, &cfg, .{}, .{}, .{}, 0.1, creatures[0..]);
+
+    try expectFloatClose(1.0, out.move_x);
+    try expectFloatClose(0.0, out.move_y);
+}
+
+test "computer move mode far from center heads toward center" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 900.0, .y = 900.0 }, .{ .x = 960.0, .y = 900.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.player_mode_flag_p1 = @intCast(movement_control_computer);
+    const creatures = [_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{
+        .{ .active = true, .hp = 20.0, .pos = .{ .x = 960.0, .y = 900.0 } },
+    };
+
+    const out = interpreter.buildPlayerInput(.{}, 0, 1, &player, &cfg, .{}, .{}, .{}, 0.1, creatures[0..]);
+    const expected = normalized(sub(computer_arena_center, player.pos));
+    try expectFloatClose(expected.x, out.move_x);
+    try expectFloatClose(expected.y, out.move_y);
+}
+
+test "joystick aim uses pov not aim keybinds" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 100.0, .y = 100.0 }, .{ .x = 160.0, .y = 100.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.aim_scheme_p1 = @bitCast(@as(i32, aim_scheme_joystick));
+
+    const out = interpreter.buildPlayerInput(
+        .{ .down = &.{.{ .player_index = 0, .code = formats.crimson_cfg.playerBindBlock(&cfg, 0).aim_right, .value = true }} },
+        0,
+        1,
+        &player,
+        &cfg,
+        .{},
+        .{},
+        .{},
+        0.1,
+        &[_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{},
+    );
+
+    try expectFloatClose(100.0, out.aim_x);
+    try expectFloatClose(40.0, out.aim_y);
+}
+
+test "joystick aim turns with pov input" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 100.0, .y = 100.0 }, .{ .x = 160.0, .y = 100.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.aim_scheme_p1 = @bitCast(@as(i32, aim_scheme_joystick));
+
+    const out = interpreter.buildPlayerInput(
+        .{ .down = &.{.{ .player_index = 0, .code = aim_pov_right_code, .value = true }} },
+        0,
+        1,
+        &player,
+        &cfg,
+        .{},
+        .{},
+        .{},
+        0.1,
+        &[_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{},
+    );
+    const expected = aimPointFromHeading(player.pos, 0.4, aim_radius_keyboard);
+    try expectFloatClose(expected.x, out.aim_x);
+    try expectFloatClose(expected.y, out.aim_y);
+}
+
+test "dual action pad aim uses native radius scale" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 100.0, .y = 100.0 }, .{ .x = 160.0, .y = 100.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.aim_scheme_p1 = @bitCast(@as(i32, aim_scheme_dual_action_pad));
+
+    const binds = formats.crimson_cfg.playerBindBlock(&cfg, 0);
+    const out = interpreter.buildPlayerInput(
+        .{ .axes = &.{.{ .player_index = 0, .code = binds.axis_aim_x, .value = 1.0 }} },
+        0,
+        1,
+        &player,
+        &cfg,
+        .{},
+        .{},
+        .{},
+        0.1,
+        &[_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{},
+    );
+
+    try expectFloatClose(238.0, out.aim_x);
+    try expectFloatClose(100.0, out.aim_y);
+}
+
+test "keyboard aim in static mode reanchors to heading" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 100.0, .y = 100.0 }, .{ .x = 180.0, .y = 130.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.aim_scheme_p1 = @bitCast(@as(i32, aim_scheme_keyboard));
+
+    const out = interpreter.buildPlayerInput(.{}, 0, 1, &player, &cfg, .{}, .{}, .{}, 0.1, &[_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{});
+
+    try expectFloatClose(100.0, out.aim_x);
+    try expectFloatClose(40.0, out.aim_y);
+}
+
+test "keyboard aim with non relative move mode keeps world aim" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 100.0, .y = 100.0 }, .{ .x = 180.0, .y = 130.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.aim_scheme_p1 = @bitCast(@as(i32, aim_scheme_keyboard));
+    cfg.player_mode_flag_p1 = @intCast(movement_control_dual_action_pad);
+
+    const out = interpreter.buildPlayerInput(.{}, 0, 1, &player, &cfg, .{}, .{}, .{}, 0.1, &[_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{});
+
+    try expectFloatClose(180.0, out.aim_x);
+    try expectFloatClose(130.0, out.aim_y);
+}
+
+test "relative mouse aim centered keeps world aim" {
+    var interpreter: LocalInputInterpreter = .{};
+    const player = makePlayer(0, .{ .x = 100.0, .y = 100.0 }, .{ .x = 180.0, .y = 130.0 }, 0.0);
+    var cfg = formats.crimson_cfg.defaultConfig();
+    cfg.aim_scheme_p1 = @bitCast(@as(i32, aim_scheme_mouse_relative));
+    const center: state_mod.Vec2 = .{ .x = 320.0, .y = 200.0 };
+
+    const out = interpreter.buildPlayerInput(.{}, 0, 1, &player, &cfg, center, .{}, center, 0.1, &[_]struct { active: bool, hp: f32, pos: state_mod.Vec2 }{});
+
+    try expectFloatClose(180.0, out.aim_x);
+    try expectFloatClose(130.0, out.aim_y);
+}

--- a/crimson-zig/src/replay_info_native.zig
+++ b/crimson-zig/src/replay_info_native.zig
@@ -335,11 +335,9 @@ fn buildInfoFailedOutputForReplayInfoError(
         error.UnsupportedEventPlayerIndex => "replay info collector encountered an out-of-range player_index event",
         error.InvalidPerkPickEvent => "replay perk_pick event could not be applied in current perk state",
         error.InvalidCaptureEnumValue => "replay capture payload contains an invalid enum value",
-        error.UnsupportedPerkApplyHandler => "replay selected a perk with apply/effect behavior not yet ported",
         error.UnsupportedSpawnTemplate => "replay triggered survival template spawns not yet ported in native creature runtime",
         error.UnsupportedQuestSpawnTable => "quest replay requires a quest spawn table variant not yet ported in native runtime",
         error.UnsupportedWeaponFirePath => "replay triggered weapon fire path not yet ported in native projectile runtime",
-        error.UnsupportedBonusApplyPath => "replay triggered bonus apply path not yet ported in native bonus runtime",
     };
     return buildInfoFailedOutput(allocator, detail);
 }

--- a/crimson-zig/src/root.zig
+++ b/crimson-zig/src/root.zig
@@ -25,6 +25,7 @@ pub const session_builders = @import("runtime/session_builders.zig");
 pub const live_runner = @import("runtime/live_runner.zig");
 
 pub const formats = @import("formats/mod.zig");
+pub const local_input = @import("local_input.zig");
 pub const window_atlas = @import("window_atlas.zig");
 
 pub const version = "0.1.0-dev";

--- a/crimson-zig/src/runtime/bonuses.zig
+++ b/crimson-zig/src/runtime/bonuses.zig
@@ -16,9 +16,7 @@ const PerkId = perks.PerkId;
 const BonusId = game_ids.BonusId;
 const GameModeId = game_ids.GameModeId;
 
-pub const BonusRuntimeError = error{
-    UnsupportedBonusApplyPath,
-};
+pub const BonusRuntimeError = error{};
 
 pub const bonus_pool_size: usize = 16;
 pub const BonusPickupRecord = struct {

--- a/crimson-zig/src/runtime/perks.zig
+++ b/crimson-zig/src/runtime/perks.zig
@@ -13,9 +13,7 @@ const state_mod = @import("state.zig");
 
 const narrowF32 = native_math.roundF32;
 
-pub const PerkApplyError = error{
-    UnsupportedPerkApplyHandler,
-};
+pub const PerkApplyError = error{};
 
 pub const PerkId = game_ids.PerkId;
 pub const GameModeId = game_ids.GameModeId;

--- a/crimson-zig/src/runtime/player.zig
+++ b/crimson-zig/src/runtime/player.zig
@@ -18,6 +18,8 @@ pub const GameInputFlags = struct {
     fire_down: bool,
     fire_pressed: bool,
     reload_pressed: bool,
+    reload_down: bool = false,
+    move_to_cursor_pressed: bool = false,
     move_mode: ?i32 = null,
     aim_scheme: ?i32 = null,
     move_forward_pressed: ?bool = null,

--- a/crimson-zig/src/runtime/replay/events.zig
+++ b/crimson-zig/src/runtime/replay/events.zig
@@ -23,7 +23,6 @@ pub const EventError = error{
     UnsupportedEventKind,
     UnsupportedEventPlayerIndex,
     InvalidPerkPickEvent,
-    UnsupportedPerkApplyHandler,
     UnsupportedSpawnTemplate,
 };
 
@@ -111,9 +110,7 @@ pub fn applyReplayEvent(
                     .creatures = creatures,
                     .dt_frame = dt_frame,
                 },
-            ) catch |err| switch (err) {
-                error.UnsupportedPerkApplyHandler => return error.UnsupportedPerkApplyHandler,
-            };
+            ) catch unreachable;
             if (applied == null) {
                 if (!options.strict_events) {
                     return outcome;
@@ -162,9 +159,7 @@ pub fn applyReplayEvent(
                     .creatures = creatures,
                     .dt_frame = dt_frame,
                 },
-            ) catch |err| switch (err) {
-                error.UnsupportedPerkApplyHandler => return error.UnsupportedPerkApplyHandler,
-            };
+            ) catch unreachable;
             if (capture_perk_apply.outside_before) {
                 if (capture_perk_apply.pending_after) |pending_after| {
                     state.perk_selection.pending_count = pending_after;

--- a/crimson-zig/src/runtime/replay_runner.zig
+++ b/crimson-zig/src/runtime/replay_runner.zig
@@ -71,11 +71,9 @@ pub const ReplayRunnerError = error{
     UnsupportedEventKind,
     UnsupportedEventPlayerIndex,
     InvalidPerkPickEvent,
-    UnsupportedPerkApplyHandler,
     UnsupportedSpawnTemplate,
     UnsupportedQuestSpawnTable,
     UnsupportedWeaponFirePath,
-    UnsupportedBonusApplyPath,
 };
 
 fn parseCaptureCreatureAiMode(value: i32) ReplayRunnerError!spawn_mod.CreatureAiMode {

--- a/crimson-zig/src/test_root.zig
+++ b/crimson-zig/src/test_root.zig
@@ -10,6 +10,7 @@ test {
     _ = cz.formats;
     _ = cz.helpers;
     _ = @import("input_codes.zig");
+    _ = cz.local_input;
     _ = cz.lifecycle;
     _ = cz.live_runner;
     _ = cz.perks;

--- a/crimson-zig/src/verify_native.zig
+++ b/crimson-zig/src/verify_native.zig
@@ -730,11 +730,9 @@ fn buildNotPortedOutputForReplayRunnerError(
         error.UnsupportedEventPlayerIndex => "replay simulation scaffold encountered an out-of-range player_index event",
         error.InvalidPerkPickEvent => "replay perk_pick event could not be applied in current perk state",
         error.InvalidCaptureEnumValue => "replay capture payload contains an invalid enum value",
-        error.UnsupportedPerkApplyHandler => "replay selected a perk with apply/effect behavior not yet ported",
         error.UnsupportedSpawnTemplate => "replay triggered survival template spawns not yet ported in native creature runtime",
         error.UnsupportedQuestSpawnTable => "quest replay requires a quest spawn table variant not yet ported in native runtime",
         error.UnsupportedWeaponFirePath => "replay triggered weapon fire path not yet ported in native projectile runtime",
-        error.UnsupportedBonusApplyPath => "replay triggered bonus apply path not yet ported in native bonus runtime",
     };
 
     var stderr_buf: std.ArrayList(u8) = .empty;
@@ -1342,20 +1340,6 @@ test "survival sim not ported output maps unsupported demo mode path" {
 
     try std.testing.expectEqual(@as(i32, 1), output.exit_code);
     try std.testing.expect(std.mem.indexOf(u8, output.stderr, "does not support demo_mode_active=true") != null);
-}
-
-test "survival sim not ported output maps unsupported bonus apply path" {
-    const allocator = std.testing.allocator;
-    const output = try buildNotPortedOutputForReplayRunnerError(
-        allocator,
-        error.UnsupportedBonusApplyPath,
-        .{},
-    );
-    defer allocator.free(output.stdout);
-    defer allocator.free(output.stderr);
-
-    try std.testing.expectEqual(@as(i32, 1), output.exit_code);
-    try std.testing.expect(std.mem.indexOf(u8, output.stderr, "bonus apply path not yet ported") != null);
 }
 
 test "survival sim not ported output includes replay progress hints" {

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -873,7 +873,8 @@ fn collectGameplayInput(
 }
 
 fn boolAxis(negative: bool, positive: bool) f32 {
-    return @floatFromInt(@intFromBool(positive) - @intFromBool(negative));
+    if (negative == positive) return 0.0;
+    return if (positive) 1.0 else -1.0;
 }
 
 fn inputCodeIsDownWithAlt(primary_code: i32, alt_code: i32) bool {
@@ -886,6 +887,13 @@ fn statusWeaponUsageCounts(status: formats.game_cfg.Status) [state_mod.weapon_co
         counts[idx] = status.weapon_usage_counts[idx];
     }
     return counts;
+}
+
+test "boolAxis returns signed unit values without overflow" {
+    try std.testing.expectEqual(@as(f32, -1.0), boolAxis(true, false));
+    try std.testing.expectEqual(@as(f32, 0.0), boolAxis(false, false));
+    try std.testing.expectEqual(@as(f32, 0.0), boolAxis(true, true));
+    try std.testing.expectEqual(@as(f32, 1.0), boolAxis(false, true));
 }
 
 fn drawWorld(

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -8,6 +8,7 @@ const weapon_data = cz.weapon_data;
 const app_runtime = @import("app_runtime.zig");
 const audio_mod = @import("audio/audio.zig");
 const input_codes = @import("input_codes.zig");
+const local_input = cz.local_input;
 const live_audio = @import("audio/live_audio.zig");
 const window_assets = @import("window_assets.zig");
 const window_atlas = cz.window_atlas;
@@ -77,6 +78,7 @@ const GameplayScreen = struct {
     runner: live_runner.LiveRunner,
     run_config: live_runner.LiveModeConfig,
     last_update: live_runner.FrameUpdate,
+    input_interpreter: local_input.LocalInputInterpreter = .{},
     ground: ?window_ground.GroundRenderer = null,
     terrain_fx: window_terrain_fx.TerrainFxTracker = .{},
 
@@ -220,7 +222,7 @@ const App = struct {
                 gameplay.runner.session.state.camera_shake_offset,
             );
             self.runtime.recordGameplayFrame(frame_dt);
-            const input = collectGameplayInput(&gameplay.runner, camera, &self.runtime);
+            const input = collectGameplayInput(&gameplay.input_interpreter, &gameplay.runner, camera, &self.runtime, frame_dt);
             if (input.perk_choice_index != null) {
                 self.audio.playUiButtonClick();
             }
@@ -311,6 +313,8 @@ const App = struct {
             .last_update = last_update,
             .terrain_fx = window_terrain_fx.TerrainFxTracker.init(runner.seed),
         };
+        gameplay.input_interpreter.setPreserveBugs(gameplay.runner.session.state.preserve_bugs);
+        gameplay.input_interpreter.reset(gameplay.runner.session.playersConst());
         if (self.runtime_assets) |*runtime_assets| {
             gameplay.ground = window_ground.GroundRenderer.initForTerrainSetup(
                 runtime_assets,
@@ -489,6 +493,7 @@ pub fn main() !void {
 
     while (!rl.windowShouldClose() and !app.quit_requested) {
         const frame_dt = rl.getFrameTime();
+        input_codes.inputBeginFrame();
         app.update(frame_dt);
 
         rl.beginDrawing();
@@ -828,35 +833,38 @@ fn buildWorldCamera(world_size: f32, shake_offset: state_mod.Vec2) rl.Camera2D {
 }
 
 fn collectGameplayInput(
+    interpreter: *local_input.LocalInputInterpreter,
     runner: *live_runner.LiveRunner,
     camera: rl.Camera2D,
     runtime: *const app_runtime.DesktopRuntime,
+    frame_dt: f32,
 ) live_runner.FrameInput {
-    const binds = runtime.primaryBindBlock();
-    const move_up_pressed = inputCodeIsDownWithAlt(binds.move_forward, 0xC8);
-    const move_down_pressed = inputCodeIsDownWithAlt(binds.move_backward, 0xD0);
-    const move_left_pressed = inputCodeIsDownWithAlt(binds.turn_left, 0xCB);
-    const move_right_pressed = inputCodeIsDownWithAlt(binds.turn_right, 0xCD);
     const mouse_world = rl.getScreenToWorld2D(rl.getMousePosition(), camera);
+    const player = runner.player0Const() orelse return .{};
+    const screen_center: state_mod.Vec2 = .{
+        .x = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5,
+        .y = @as(f32, @floatFromInt(rl.getScreenHeight())) * 0.5,
+    };
 
     var frame_input: live_runner.FrameInput = .{
-        .player = .{
-            .move_x = boolAxis(move_left_pressed, move_right_pressed),
-            .move_y = boolAxis(move_up_pressed, move_down_pressed),
-            .aim_x = mouse_world.x,
-            .aim_y = mouse_world.y,
-            .flags = .{
-                .fire_down = input_codes.inputCodeIsDown(binds.fire),
-                .fire_pressed = input_codes.inputCodeIsPressed(binds.fire),
-                .reload_pressed = input_codes.inputCodeIsPressed(@intCast(runtime.config.keybind_reload)),
-                .move_mode = @intCast(runtime.config.player_mode_flag_p1),
-                .aim_scheme = 0,
-                .move_forward_pressed = move_up_pressed,
-                .move_backward_pressed = move_down_pressed,
-                .turn_left_pressed = move_left_pressed,
-                .turn_right_pressed = move_right_pressed,
+        .player = interpreter.buildPlayerInput(
+            input_codes.RaylibInputSampler{},
+            0,
+            runner.session.playersConst().len,
+            player,
+            &runtime.config,
+            .{
+                .x = rl.getMousePosition().x,
+                .y = rl.getMousePosition().y,
             },
-        },
+            .{
+                .x = mouse_world.x,
+                .y = mouse_world.y,
+            },
+            screen_center,
+            frame_dt,
+            runner.session.creatures.entries[0..],
+        ),
     };
 
     if (runner.perkPendingCount() > 0) {
@@ -875,10 +883,6 @@ fn collectGameplayInput(
 fn boolAxis(negative: bool, positive: bool) f32 {
     if (negative == positive) return 0.0;
     return if (positive) 1.0 else -1.0;
-}
-
-fn inputCodeIsDownWithAlt(primary_code: i32, alt_code: i32) bool {
-    return input_codes.inputCodeIsDown(primary_code) or input_codes.inputCodeIsDown(alt_code);
 }
 
 fn statusWeaponUsageCounts(status: formats.game_cfg.Status) [state_mod.weapon_count_size]u32 {


### PR DESCRIPTION
## Summary
- port the Python local input interpreter into Zig as a persistent desktop input layer
- route the window gameplay loop through the new interpreter instead of ad hoc player-1 sampling
- expand the Zig input-code layer to support the config-driven keyboard/mouse/gamepad behaviors the interpreter needs

## Testing
- zig build test
- zig build window
- zig build wasm
