### PR TITLE
feat(zig): split boot and advance main menu

### DIFF
--- a/crimson-zig/src/window_boot.zig
+++ b/crimson-zig/src/window_boot.zig
@@ -1,0 +1,159 @@
+const std = @import("std");
+const rl = @import("raylib");
+
+const window_assets = @import("window_assets.zig");
+const window_ui = @import("window_ui.zig");
+
+pub const splash_alpha_scale: f32 = 2.0;
+pub const logo_time_scale: f32 = 1.1;
+pub const logo_time_offset: f32 = 2.0;
+pub const logo_skip_accel: f32 = 4.0;
+pub const logo_skip_jump: f32 = 16.0;
+pub const logo_theme_trigger: f32 = 14.0;
+pub const logo_10_in_start: f32 = 1.0;
+pub const logo_10_in_end: f32 = 2.0;
+pub const logo_10_hold_end: f32 = 4.0;
+pub const logo_10_out_end: f32 = 5.0;
+pub const logo_ref_in_start: f32 = 7.0;
+pub const logo_ref_in_end: f32 = 8.0;
+pub const logo_ref_hold_end: f32 = 10.0;
+pub const logo_ref_out_end: f32 = 11.0;
+
+pub const State = struct {
+    boot_time: f32 = 0.5,
+    fade_out_ready: bool = true,
+    fade_out_done: bool = false,
+    logo_delay_ticks: i32 = 0,
+    logo_skip: bool = false,
+    logo_active: bool = false,
+
+    pub fn reset(self: *State) void {
+        self.* = .{};
+    }
+};
+
+pub const UpdateResult = struct {
+    finished: bool = false,
+};
+
+pub fn update(state: *State, frame_dt: f32) UpdateResult {
+    const dt = @min(frame_dt, 0.1);
+    if (!state.fade_out_done) {
+        state.boot_time -= dt;
+        if (state.boot_time <= 0.0) {
+            state.boot_time = 0.0;
+            state.fade_out_done = true;
+        }
+        return .{};
+    }
+
+    if (state.logo_delay_ticks < 5) {
+        state.logo_delay_ticks += 1;
+        return .{};
+    }
+
+    state.logo_active = true;
+    if (state.boot_time > logo_theme_trigger) {
+        return .{ .finished = true };
+    }
+    if (!state.logo_skip and skipTriggered()) {
+        state.logo_skip = true;
+    }
+    state.boot_time += dt * logo_time_scale;
+    var t = state.boot_time - logo_time_offset;
+    if (state.logo_skip) {
+        if (t < logo_10_in_start or (t >= logo_10_out_end and (t < logo_ref_in_start or t >= logo_ref_out_end))) {
+            t = logo_skip_jump;
+        } else {
+            t += dt * logo_skip_accel;
+        }
+        state.boot_time = t + logo_time_offset;
+    }
+    return .{};
+}
+
+pub fn draw(state: *const State, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+    rl.clearBackground(rl.Color.black);
+    if (runtime_assets) |assets| {
+        if (!state.fade_out_done) {
+            drawSplash(assets, clamp01(state.boot_time * splash_alpha_scale));
+        } else if (state.logo_active) {
+            drawCompanyLogo(assets, state.boot_time - logo_time_offset);
+        }
+    } else {
+        drawCenteredText("CRIMSON-ZIG", 144, 72, rl.Color.init(218, 80, 46, 255));
+        drawCenteredText("Desktop gameplay slice booting", 232, 24, rl.Color.init(245, 236, 225, 255));
+        drawCenteredText("raylib shell + live Zig runtime + archive-backed assets", 270, 18, rl.Color.init(171, 150, 132, 255));
+    }
+}
+
+fn clamp01(value: f32) f32 {
+    return std.math.clamp(value, @as(f32, 0.0), @as(f32, 1.0));
+}
+
+fn skipTriggered() bool {
+    if (rl.getKeyPressed() != .null) return true;
+    if (rl.isMouseButtonPressed(.left)) return true;
+    if (rl.isMouseButtonPressed(.right)) return true;
+    return false;
+}
+
+fn logoAlpha(t: f32, in_start: f32, in_end: f32, hold_end: f32, out_end: f32) ?f32 {
+    if (t < in_start or t >= out_end) return null;
+    if (t < in_end) return clamp01(t - in_start);
+    if (t < hold_end) return 1.0;
+    return clamp01(1.0 - (t - hold_end));
+}
+
+fn drawCompanyLogo(runtime_assets: *const window_assets.RuntimeAssets, t: f32) void {
+    const LogoState = struct {
+        texture: rl.Texture2D,
+        alpha: f32,
+    };
+    const logo_state: LogoState = blk: {
+        if (logoAlpha(t, logo_10_in_start, logo_10_in_end, logo_10_hold_end, logo_10_out_end)) |alpha| {
+            break :blk .{ .texture = runtime_assets.texture(.splash_10tons), .alpha = alpha };
+        }
+        if (logoAlpha(t, logo_ref_in_start, logo_ref_in_end, logo_ref_hold_end, logo_ref_out_end)) |alpha| {
+            break :blk .{ .texture = runtime_assets.texture(.splash_reflexive), .alpha = alpha };
+        }
+        return;
+    };
+
+    const texture = logo_state.texture;
+    const x = (@as(f32, @floatFromInt(rl.getScreenWidth())) - @as(f32, @floatFromInt(texture.width))) * 0.5;
+    const y = (@as(f32, @floatFromInt(rl.getScreenHeight())) - @as(f32, @floatFromInt(texture.height))) * 0.5;
+    window_ui.drawTextureFit(
+        texture,
+        rl.Rectangle.init(x, y, @floatFromInt(texture.width), @floatFromInt(texture.height)),
+        window_ui.colorWithAlpha(rl.Color.white, logo_state.alpha),
+    );
+}
+
+fn drawSplash(runtime_assets: *const window_assets.RuntimeAssets, alpha: f32) void {
+    if (!(alpha > 0.0)) return;
+    const screen_w = @as(f32, @floatFromInt(rl.getScreenWidth()));
+    const screen_h = @as(f32, @floatFromInt(rl.getScreenHeight()));
+    const logo = runtime_assets.texture(.cl_logo);
+    const band_height = @as(f32, @floatFromInt(logo.height)) * 2.0;
+    const band_top = (screen_h - band_height) * 0.5 - 4.0;
+    const band_bottom = band_top + band_height;
+    const line_color = window_ui.colorWithAlpha(rl.Color.init(149, 175, 198, 255), alpha * 0.7);
+    rl.drawRectangle(0, @intFromFloat(band_top), rl.getScreenWidth(), 1, line_color);
+    rl.drawRectangle(0, @intFromFloat(band_bottom), rl.getScreenWidth(), 1, line_color);
+    rl.drawRectangle(0, @intFromFloat(band_top), 1, @intFromFloat(band_height), line_color);
+    rl.drawRectangle(rl.getScreenWidth() - 1, @intFromFloat(band_top), 1, @intFromFloat(band_height), line_color);
+
+    const logo_x = (screen_w - @as(f32, @floatFromInt(logo.width))) * 0.5;
+    const logo_y = (screen_h - @as(f32, @floatFromInt(logo.height))) * 0.5;
+    window_ui.drawTextureFit(logo, rl.Rectangle.init(logo_x, logo_y, @floatFromInt(logo.width), @floatFromInt(logo.height)), window_ui.colorWithAlpha(rl.Color.white, alpha));
+    const loading = runtime_assets.texture(.loading);
+    window_ui.drawTextureFit(loading, rl.Rectangle.init(screen_w * 0.5 + 128.0, screen_h * 0.5 + 16.0, @floatFromInt(loading.width), @floatFromInt(loading.height)), window_ui.colorWithAlpha(rl.Color.white, alpha));
+    const esrb = runtime_assets.texture(.logo_esrb);
+    window_ui.drawTextureFit(esrb, rl.Rectangle.init(screen_w - @as(f32, @floatFromInt(esrb.width)) - 1.0, screen_h - @as(f32, @floatFromInt(esrb.height)) - 1.0, @floatFromInt(esrb.width), @floatFromInt(esrb.height)), window_ui.colorWithAlpha(rl.Color.white, alpha));
+}
+
+fn drawCenteredText(text: [:0]const u8, y: i32, font_size: i32, color: rl.Color) void {
+    const width = rl.measureText(text, font_size);
+    rl.drawText(text, @divTrunc(rl.getScreenWidth() - width, 2), y, font_size, color);
+}

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -26,10 +26,45 @@ const state_mod = cz.state;
 
 const window_width = 1280;
 const window_height = 720;
-const boot_duration_seconds: f32 = 0.45;
 const ui_button_width: f32 = 280.0;
 const ui_button_height: f32 = 56.0;
 const world_margin: f32 = 56.0;
+
+const splash_alpha_scale: f32 = 2.0;
+const logo_time_scale: f32 = 1.1;
+const logo_time_offset: f32 = 2.0;
+const logo_skip_accel: f32 = 4.0;
+const logo_skip_jump: f32 = 16.0;
+const logo_theme_trigger: f32 = 14.0;
+const logo_10_in_start: f32 = 1.0;
+const logo_10_in_end: f32 = 2.0;
+const logo_10_hold_end: f32 = 4.0;
+const logo_10_out_end: f32 = 5.0;
+const logo_ref_in_start: f32 = 7.0;
+const logo_ref_in_end: f32 = 8.0;
+const logo_ref_hold_end: f32 = 10.0;
+const logo_ref_out_end: f32 = 11.0;
+const menu_demo_idle_start_ms: i32 = 23_000;
+const menu_label_width: f32 = 122.0;
+const menu_label_height: f32 = 28.0;
+const menu_label_base_x: f32 = -60.0;
+const menu_label_base_y: f32 = 210.0;
+const menu_label_step: f32 = 60.0;
+const menu_item_offset_x: f32 = -71.0;
+const menu_item_offset_y: f32 = -59.0;
+const menu_sign_width: f32 = 571.44;
+const menu_sign_height: f32 = 141.36;
+const menu_sign_offset_x: f32 = -576.44;
+const menu_sign_offset_y: f32 = -61.0;
+const menu_sign_pos_y: f32 = 70.0;
+const menu_sign_pos_y_small: f32 = 60.0;
+const menu_sign_pos_x_pad: f32 = 4.0;
+const menu_scale_small_threshold: i32 = 640;
+const menu_scale_large_min: i32 = 801;
+const menu_scale_large_max: i32 = 1024;
+const menu_scale_small: f32 = 0.8;
+const menu_scale_large: f32 = 1.2;
+const menu_scale_shift: f32 = 10.0;
 
 const bg_color = rl.Color.init(16, 12, 10, 255);
 const panel_color = rl.Color.init(37, 24, 20, 255);
@@ -75,6 +110,36 @@ const AssetsState = enum {
 const UiButton = struct {
     label: [:0]const u8,
     rect: rl.Rectangle,
+};
+
+const BootSequenceState = struct {
+    boot_time: f32 = 0.5,
+    fade_out_ready: bool = true,
+    fade_out_done: bool = false,
+    logo_delay_ticks: i32 = 0,
+    logo_skip: bool = false,
+    logo_active: bool = false,
+    intro_started: bool = false,
+
+    fn reset(self: *BootSequenceState) void {
+        self.* = .{};
+    }
+};
+
+const MenuScreenState = struct {
+    timeline_ms: i32 = 0,
+    focus_timer_ms: i32 = 0,
+    hovered_index: ?usize = null,
+    panel_open_sfx_played: bool = false,
+    idle_ms: i32 = 0,
+    last_mouse_pos: rl.Vector2 = .{ .x = 0.0, .y = 0.0 },
+    hover_amounts: [6]i32 = [_]i32{0} ** 6,
+
+    fn reset(self: *MenuScreenState) void {
+        self.* = .{
+            .last_mouse_pos = rl.getMousePosition(),
+        };
+    }
 };
 
 const GameplayScreen = struct {
@@ -255,7 +320,8 @@ const App = struct {
     allocator: std.mem.Allocator,
     runtime: app_runtime.DesktopRuntime,
     screen: Screen = .boot,
-    boot_elapsed: f32 = 0.0,
+    boot: BootSequenceState = .{},
+    menu: MenuScreenState = .{},
     menu_selection: usize = 0,
     results_selection: usize = 0,
     gameplay: ?GameplayScreen = null,
@@ -275,6 +341,8 @@ const App = struct {
             .runtime = runtime,
             .audio = live_audio.Bridge.init(allocator, audio_mod.audioConfigFromCrimsonCfg(runtime.config), null),
         };
+        app.boot.reset();
+        app.menu.reset();
         app.loadAssets();
         return app;
     }
@@ -320,7 +388,7 @@ const App = struct {
     fn update(self: *App, frame_dt: f32) void {
         switch (self.screen) {
             .boot => self.updateBoot(frame_dt),
-            .main_menu => self.updateMainMenu(),
+            .main_menu => self.updateMainMenu(frame_dt),
             .gameplay => self.updateGameplay(frame_dt),
             .results => self.updateResults(),
             .high_scores => self.updateHighScores(),
@@ -341,26 +409,93 @@ const App = struct {
     }
 
     fn updateBoot(self: *App, frame_dt: f32) void {
-        self.audio.ensureIntroMusic();
-        self.boot_elapsed += frame_dt;
-        if (self.boot_elapsed >= boot_duration_seconds) {
+        const dt = @min(frame_dt, 0.1);
+        if (!self.boot.fade_out_done) {
+            self.audio.ensureIntroMusic();
+            self.boot.boot_time -= dt;
+            if (self.boot.boot_time <= 0.0) {
+                self.boot.boot_time = 0.0;
+                self.boot.fade_out_done = true;
+            }
+            return;
+        }
+
+        if (self.boot.logo_delay_ticks < 5) {
+            self.boot.logo_delay_ticks += 1;
+            return;
+        }
+
+        self.boot.logo_active = true;
+        if (self.boot.boot_time > logo_theme_trigger) {
+            self.menu.reset();
             self.screen = .main_menu;
+            return;
+        }
+        if (!self.boot.intro_started) {
+            self.audio.ensureIntroMusic();
+            self.boot.intro_started = true;
+        }
+        if (!self.boot.logo_skip and bootSkipTriggered()) {
+            self.boot.logo_skip = true;
+        }
+        self.boot.boot_time += dt * logo_time_scale;
+        var t = self.boot.boot_time - logo_time_offset;
+        if (self.boot.logo_skip) {
+            if (t < logo_10_in_start or (t >= logo_10_out_end and (t < logo_ref_in_start or t >= logo_ref_out_end))) {
+                t = logo_skip_jump;
+            } else {
+                t += dt * logo_skip_accel;
+            }
+            self.boot.boot_time = t + logo_time_offset;
         }
     }
 
-    fn updateMainMenu(self: *App) void {
+    fn updateMainMenu(self: *App, frame_dt: f32) void {
         self.audio.ensureMenuTheme();
+        const dt_ms = @as(i32, @intFromFloat(@min(frame_dt, 0.1) * 1000.0));
         const buttons = mainMenuButtons();
-        updateSelectionFromPointer(&self.menu_selection, buttons[0..]);
-        if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
-            self.menu_selection = if (self.menu_selection == 0) buttons.len - 1 else self.menu_selection - 1;
-        }
-        if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
-            self.menu_selection = (self.menu_selection + 1) % buttons.len;
+        if (dt_ms > 0) {
+            const mouse = rl.getMousePosition();
+            const mouse_moved = mouse.x != self.menu.last_mouse_pos.x or mouse.y != self.menu.last_mouse_pos.y;
+            if (mouse_moved) {
+                self.menu.last_mouse_pos = mouse;
+            }
+
+            if (rl.getKeyPressed() != .null or rl.isMouseButtonPressed(.left) or rl.isMouseButtonPressed(.right) or mouse_moved) {
+                self.menu.idle_ms = 0;
+            } else {
+                self.menu.idle_ms += dt_ms;
+            }
+
+            self.menu.timeline_ms = @min(menuMaxTimelineMs(buttons.len), self.menu.timeline_ms + dt_ms);
+            self.menu.focus_timer_ms = @max(0, self.menu.focus_timer_ms - dt_ms);
+            if (self.menu.timeline_ms >= menuMaxTimelineMs(buttons.len) and !self.menu.panel_open_sfx_played) {
+                self.audio.playUiPanelClick();
+                self.menu.panel_open_sfx_played = true;
+            }
         }
 
-        const activated = buttonActivated(buttons[0..], self.menu_selection);
-        if (!activated) return;
+        self.menu.hovered_index = hoveredMainMenuIndex(buttons[0..]);
+        if (self.menu.hovered_index) |hovered_index| {
+            if (mainMenuEntryEnabled(@intCast(hovered_index), self.menu.timeline_ms)) {
+                self.menu_selection = hovered_index;
+                self.menu.focus_timer_ms = 1000;
+            }
+        }
+        const activated = mainMenuEntryEnabled(@intCast(self.menu_selection), self.menu.timeline_ms) and buttonActivated(buttons[0..], self.menu_selection);
+        if (!activated) {
+            if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
+                self.menu_selection = previousEnabledMenuSelection(self.menu_selection, self.menu.timeline_ms, buttons.len);
+                self.menu.focus_timer_ms = 1000;
+            }
+            if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
+                self.menu_selection = nextEnabledMenuSelection(self.menu_selection, self.menu.timeline_ms, buttons.len);
+                self.menu.focus_timer_ms = 1000;
+            }
+            updateMenuHoverAmounts(&self.menu, dt_ms, buttons.len);
+            return;
+        }
+
         self.audio.playUiButtonClick();
 
         switch (self.menu_selection) {
@@ -372,6 +507,7 @@ const App = struct {
             5 => self.quit_requested = true,
             else => {},
         }
+        updateMenuHoverAmounts(&self.menu, dt_ms, buttons.len);
     }
 
     fn updateGameplay(self: *App, frame_dt: f32) void {
@@ -446,6 +582,7 @@ const App = struct {
                 }
                 self.results = null;
                 self.menu_selection = 0;
+                self.menu.reset();
                 self.screen = .main_menu;
             },
             else => {},
@@ -473,6 +610,7 @@ const App = struct {
                 2 => self.setHighScoresMode(.quests),
                 3 => {
                     self.menu_selection = 3;
+                    self.menu.reset();
                     self.screen = .main_menu;
                 },
                 else => {},
@@ -548,6 +686,7 @@ const App = struct {
             5 => {
                 self.audio.playUiButtonClick();
                 self.menu_selection = 3;
+                self.menu.reset();
                 self.screen = .main_menu;
             },
             else => {},
@@ -827,27 +966,30 @@ const App = struct {
     }
 
     fn drawBoot(self: *const App) void {
-        rl.clearBackground(bgColorLerp(bootProgress(self.boot_elapsed)));
-        drawBackdrop();
+        rl.clearBackground(rl.Color.black);
         if (self.runtime_assets) |*runtime_assets| {
-            drawBootAssets(runtime_assets, bootProgress(self.boot_elapsed));
+            if (!self.boot.fade_out_done) {
+                drawBootSplash(runtime_assets, clamp01(self.boot.boot_time * splash_alpha_scale));
+            } else if (self.boot.logo_active) {
+                drawBootCompanyLogo(runtime_assets, self.boot.boot_time - logo_time_offset);
+            }
+        } else {
+            drawCenteredText("CRIMSON-ZIG", 144, 72, accent_color);
+            drawCenteredText("Desktop gameplay slice booting", 232, 24, text_color);
+            drawCenteredText("raylib shell + live Zig runtime + archive-backed assets", 270, 18, muted_text);
         }
-        drawCenteredText("CRIMSON-ZIG", 144, 72, accent_color);
-        drawCenteredText("Desktop gameplay slice booting", 232, 24, text_color);
-        drawCenteredText("raylib shell + live Zig runtime + archive-backed assets", 270, 18, muted_text);
         drawAssetsStatus(self);
         drawAudioStatus(&self.audio);
     }
 
     fn drawMainMenu(self: *const App) void {
-        rl.clearBackground(bg_color);
-        drawBackdrop();
         if (self.runtime_assets) |*runtime_assets| {
-            drawMenuAssets(runtime_assets);
-            drawSmallTextCentered(runtime_assets, "NATIVE SURVIVAL / RUSH / QUEST GAMEPLAY SLICE", 204.0, HudTextColor.primary);
-            drawSmallTextCentered(runtime_assets, "LIVE ZIG RUNTIME NOW BOOTS MULTIPLE REAL MODES.", 234.0, HudTextColor.dim);
+            rl.clearBackground(rl.Color.black);
+            drawMenuAssets(self, runtime_assets);
         }
         if (self.runtime_assets == null) {
+            rl.clearBackground(bg_color);
+            drawBackdrop();
             drawCenteredText("CRIMSON-ZIG", 118, 68, accent_color);
             drawCenteredText("Native survival / rush / quest gameplay slice", 198, 24, text_color);
             drawCenteredText("Live Zig runtime now boots multiple real modes.", 232, 18, muted_text);
@@ -858,11 +1000,16 @@ const App = struct {
         const buttons = mainMenuButtons();
         for (buttons, 0..) |button, idx| {
             const mouse_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
-            drawButton(button, idx == self.menu_selection, mouse_hovered, if (self.runtime_assets) |*assets| assets else null);
+            if (self.runtime_assets) |*assets| {
+                drawMainMenuButton(self, assets, button, idx, idx == self.menu_selection, mouse_hovered);
+            } else {
+                drawButton(button, idx == self.menu_selection, mouse_hovered, null);
+            }
         }
 
         if (self.runtime_assets) |*runtime_assets| {
-            drawSmallTextCentered(runtime_assets, "ENTER STARTS. HIGH SCORES NOW READ REAL ZIG `.HI` TABLES. ESC CLOSES THE WINDOW.", 624.0, HudTextColor.dim);
+            drawSmallText(runtime_assets, "Enter activates selected item. Mouse works too.", 34.0, 646.0, HudTextColor.dim);
+            drawSmallText(runtime_assets, "Current menu still routes directly into the Zig gameplay shell.", 34.0, 664.0, HudTextColor.dim);
         } else {
             drawCenteredText("Enter starts. High scores now read real Zig .hi tables. Esc closes the window.", 620, 18, muted_text);
         }
@@ -1053,19 +1200,6 @@ pub fn main() !void {
     try app.saveAllIfDirty();
 }
 
-fn bootProgress(boot_elapsed: f32) f32 {
-    return std.math.clamp(boot_elapsed / boot_duration_seconds, @as(f32, 0.0), @as(f32, 1.0));
-}
-
-fn bgColorLerp(progress: f32) rl.Color {
-    return rl.Color.init(
-        @intFromFloat(8.0 + progress * 8.0),
-        @intFromFloat(5.0 + progress * 7.0),
-        @intFromFloat(5.0 + progress * 5.0),
-        255,
-    );
-}
-
 fn drawBackdrop() void {
     const width = rl.getScreenWidth();
     const height = rl.getScreenHeight();
@@ -1074,32 +1208,158 @@ fn drawBackdrop() void {
     rl.drawCircle(160, height - 80, 220.0, rl.Color.init(58, 23, 18, 90));
 }
 
-fn drawBootAssets(runtime_assets: *const window_assets.RuntimeAssets, progress: f32) void {
-    const left_rect = rl.Rectangle.init(98.0, 112.0, 320.0, 180.0);
-    const right_rect = rl.Rectangle.init(862.0, 112.0, 320.0, 180.0);
-    const alpha = @as(u8, @intFromFloat(64.0 + progress * 160.0));
-
-    drawTextureFit(runtime_assets.texture(.splash_10tons), left_rect, rl.Color.init(255, 255, 255, alpha));
-    drawTextureFit(runtime_assets.texture(.splash_reflexive), right_rect, rl.Color.init(255, 255, 255, alpha));
-    drawTextureFit(runtime_assets.texture(.loading), rl.Rectangle.init(520.0, 330.0, 240.0, 72.0), rl.Color.init(255, 255, 255, alpha));
+fn clamp01(value: f32) f32 {
+    return std.math.clamp(value, @as(f32, 0.0), @as(f32, 1.0));
 }
 
-fn drawMenuAssets(runtime_assets: *const window_assets.RuntimeAssets) void {
+fn bootSkipTriggered() bool {
+    if (rl.getKeyPressed() != .null) return true;
+    if (rl.isMouseButtonPressed(.left)) return true;
+    if (rl.isMouseButtonPressed(.right)) return true;
+    return false;
+}
+
+fn bootLogoAlpha(t: f32, in_start: f32, in_end: f32, hold_end: f32, out_end: f32) ?f32 {
+    if (t < in_start or t >= out_end) return null;
+    if (t < in_end) return clamp01(t - in_start);
+    if (t < hold_end) return 1.0;
+    return clamp01(1.0 - (t - hold_end));
+}
+
+fn drawBootCompanyLogo(runtime_assets: *const window_assets.RuntimeAssets, t: f32) void {
+    const LogoState = struct {
+        texture: rl.Texture2D,
+        alpha: f32,
+    };
+    const logo_state: LogoState = blk: {
+        if (bootLogoAlpha(t, logo_10_in_start, logo_10_in_end, logo_10_hold_end, logo_10_out_end)) |alpha| {
+            break :blk .{ .texture = runtime_assets.texture(.splash_10tons), .alpha = alpha };
+        }
+        if (bootLogoAlpha(t, logo_ref_in_start, logo_ref_in_end, logo_ref_hold_end, logo_ref_out_end)) |alpha| {
+            break :blk .{ .texture = runtime_assets.texture(.splash_reflexive), .alpha = alpha };
+        }
+        return;
+    };
+
+    const texture = logo_state.texture;
+    const x = (@as(f32, @floatFromInt(rl.getScreenWidth())) - @as(f32, @floatFromInt(texture.width))) * 0.5;
+    const y = (@as(f32, @floatFromInt(rl.getScreenHeight())) - @as(f32, @floatFromInt(texture.height))) * 0.5;
+    drawTextureFit(
+        texture,
+        rl.Rectangle.init(x, y, @floatFromInt(texture.width), @floatFromInt(texture.height)),
+        colorWithAlpha(rl.Color.white, logo_state.alpha),
+    );
+}
+
+fn drawBootSplash(runtime_assets: *const window_assets.RuntimeAssets, alpha: f32) void {
+    if (!(alpha > 0.0)) return;
+    const screen_w = @as(f32, @floatFromInt(rl.getScreenWidth()));
+    const screen_h = @as(f32, @floatFromInt(rl.getScreenHeight()));
+    const logo = runtime_assets.texture(.cl_logo);
+    const band_height = @as(f32, @floatFromInt(logo.height)) * 2.0;
+    const band_top = (screen_h - band_height) * 0.5 - 4.0;
+    const band_bottom = band_top + band_height;
+    const line_color = colorWithAlpha(rl.Color.init(149, 175, 198, 255), alpha * 0.7);
+    rl.drawRectangle(0, @intFromFloat(band_top), rl.getScreenWidth(), 1, line_color);
+    rl.drawRectangle(0, @intFromFloat(band_bottom), rl.getScreenWidth(), 1, line_color);
+    rl.drawRectangle(0, @intFromFloat(band_top), 1, @intFromFloat(band_height), line_color);
+    rl.drawRectangle(rl.getScreenWidth() - 1, @intFromFloat(band_top), 1, @intFromFloat(band_height), line_color);
+
+    const logo_x = (screen_w - @as(f32, @floatFromInt(logo.width))) * 0.5;
+    const logo_y = (screen_h - @as(f32, @floatFromInt(logo.height))) * 0.5;
+    drawTextureFit(logo, rl.Rectangle.init(logo_x, logo_y, @floatFromInt(logo.width), @floatFromInt(logo.height)), colorWithAlpha(rl.Color.white, alpha));
+    drawTextureFit(runtime_assets.texture(.loading), rl.Rectangle.init(screen_w * 0.5 + 128.0, screen_h * 0.5 + 16.0, @floatFromInt(runtime_assets.texture(.loading).width), @floatFromInt(runtime_assets.texture(.loading).height)), colorWithAlpha(rl.Color.white, alpha));
+    const esrb = runtime_assets.texture(.logo_esrb);
+    drawTextureFit(esrb, rl.Rectangle.init(screen_w - @as(f32, @floatFromInt(esrb.width)) - 1.0, screen_h - @as(f32, @floatFromInt(esrb.height)) - 1.0, @floatFromInt(esrb.width), @floatFromInt(esrb.height)), colorWithAlpha(rl.Color.white, alpha));
+}
+
+fn drawMenuAssets(app: *const App, runtime_assets: *const window_assets.RuntimeAssets) void {
     drawTextureFit(
         runtime_assets.texture(.backplasma),
         rl.Rectangle.init(0.0, 0.0, @floatFromInt(rl.getScreenWidth()), @floatFromInt(rl.getScreenHeight())),
         rl.Color.init(255, 255, 255, 92),
     );
     rl.drawRectangle(0, 0, rl.getScreenWidth(), rl.getScreenHeight(), rl.Color.init(16, 11, 9, 160));
-    drawTextureCentered(
-        runtime_assets.texture(.ui_sign_crimson),
-        rl.Vector2.init(@as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5, 120.0),
-        446.0,
-        110.0,
-        rl.Color.init(255, 255, 255, 232),
+    drawMainMenuSign(app, runtime_assets);
+}
+
+fn menuUiElementAnim(index: usize, start_ms: i32, end_ms: i32, width: f32, timeline_ms: i32) struct { angle_rad: f32, offset_x: f32 } {
+    if (start_ms <= end_ms or width <= 0.0) return .{ .angle_rad = 0.0, .offset_x = 0.0 };
+    var angle: f32 = 0.0;
+    var offset_x: f32 = 0.0;
+    if (timeline_ms < end_ms) {
+        angle = 1.5707964;
+        offset_x = -@abs(width);
+    } else if (timeline_ms < start_ms) {
+        const p = @as(f32, @floatFromInt(timeline_ms - end_ms)) / @as(f32, @floatFromInt(start_ms - end_ms));
+        angle = 1.5707964 * (1.0 - p);
+        offset_x = (1.0 - p) * -@abs(width);
+    }
+    if (index == 0) angle = -@abs(angle);
+    return .{ .angle_rad = angle, .offset_x = offset_x };
+}
+
+fn mainMenuLabelAlpha(counter_value: i32) u8 {
+    return @intCast(100 + @divTrunc(counter_value * 155, 1000));
+}
+
+fn mainMenuSignLayoutScale(screen_w: i32) struct { scale: f32, shift_x: f32 } {
+    if (screen_w <= menu_scale_small_threshold) return .{ .scale = menu_scale_small, .shift_x = menu_scale_shift };
+    if (screen_w >= menu_scale_large_min and screen_w <= menu_scale_large_max) return .{ .scale = menu_scale_large, .shift_x = menu_scale_shift };
+    return .{ .scale = 1.0, .shift_x = 0.0 };
+}
+
+fn drawMainMenuSign(app: *const App, runtime_assets: *const window_assets.RuntimeAssets) void {
+    const screen_w = rl.getScreenWidth();
+    const sign = runtime_assets.texture(.ui_sign_crimson);
+    const layout = mainMenuSignLayoutScale(screen_w);
+    const sign_pos = rl.Vector2.init(
+        @as(f32, @floatFromInt(screen_w)) + menu_sign_pos_x_pad,
+        if (screen_w > menu_scale_small_threshold) menu_sign_pos_y else menu_sign_pos_y_small,
     );
-    drawTextureFit(runtime_assets.texture(.ui_menu_panel), rl.Rectangle.init(388.0, 242.0, 504.0, 252.0), rl.Color.init(255, 255, 255, 220));
-    drawTextureFit(runtime_assets.texture(.logo_esrb), rl.Rectangle.init(42.0, 44.0, 112.0, 150.0), rl.Color.init(255, 255, 255, 190));
+    const sign_w = menu_sign_width * layout.scale;
+    const sign_h = menu_sign_height * layout.scale;
+    const offset_x = menu_sign_offset_x * layout.scale + layout.shift_x;
+    const offset_y = menu_sign_offset_y * layout.scale;
+    const anim = menuUiElementAnim(0, 300, 0, sign_w, app.menu.timeline_ms);
+    const rotation_deg = radiansToDegrees(anim.angle_rad);
+
+    rl.drawTexturePro(
+        sign,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(sign.width), @floatFromInt(sign.height)),
+        rl.Rectangle.init(sign_pos.x, sign_pos.y, sign_w, sign_h),
+        rl.Vector2.init(-offset_x, -offset_y),
+        rotation_deg,
+        rl.Color.white,
+    );
+}
+
+fn drawMainMenuButton(app: *const App, runtime_assets: *const window_assets.RuntimeAssets, button: UiButton, idx: usize, selected: bool, hovered: bool) void {
+    const item = runtime_assets.texture(.ui_menu_item);
+    const scale_info = menuItemScale(idx);
+    const pos_x = menuSlotPosX(idx);
+    const pos_y = menu_label_base_y + @as(f32, @floatFromInt(idx)) * menu_label_step + menuWidescreenYShift(@floatFromInt(rl.getScreenWidth()));
+    const anim = menuUiElementAnim(idx + 2, menuSlotStartMs(idx), menuSlotEndMs(idx), @as(f32, @floatFromInt(item.width)) * scale_info.scale, app.menu.timeline_ms);
+    const dst = rl.Rectangle.init(pos_x, pos_y, @as(f32, @floatFromInt(item.width)) * scale_info.scale, @as(f32, @floatFromInt(item.height)) * scale_info.scale);
+    const origin = rl.Vector2.init(-(menu_item_offset_x * scale_info.scale), -(menu_item_offset_y * scale_info.scale - scale_info.local_y_shift));
+    const rotation_deg = radiansToDegrees(anim.angle_rad);
+
+    rl.drawTexturePro(
+        item,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(item.width), @floatFromInt(item.height)),
+        dst,
+        origin,
+        rotation_deg,
+        rl.Color.white,
+    );
+
+    const hover_counter = if (selected and app.menu.focus_timer_ms > 0) app.menu.focus_timer_ms else app.menu.hover_amounts[idx];
+    const label_alpha = if (mainMenuEntryEnabled(@intCast(idx), app.menu.timeline_ms)) mainMenuLabelAlpha(hover_counter) else @as(u8, 100);
+    const text_alpha: f32 = if (selected or hovered) 1.0 else 0.7;
+    const label_width = measureSmallText(runtime_assets, button.label);
+    const label_x = button.rect.x + (button.rect.width - label_width) * 0.5 + 1.0;
+    const label_y = button.rect.y + 11.0;
+    drawSmallText(runtime_assets, button.label, label_x, label_y, rl.Color.init(255, 255, 255, @intFromFloat(@as(f32, @floatFromInt(label_alpha)) * text_alpha)));
 }
 
 fn drawAssetsStatus(app: *const App) void {
@@ -1259,15 +1519,57 @@ fn drawTextureTiled(texture: rl.Texture2D, area: rl.Rectangle, tint: rl.Color) v
     }
 }
 
+fn menuWidescreenYShift(screen_w: f32) f32 {
+    return (screen_w / 640.0) * 150.0 - 150.0;
+}
+
+fn menuSlotPosX(slot: usize) f32 {
+    return menu_label_base_x - @as(f32, @floatFromInt(slot)) * 20.0;
+}
+
+fn menuSlotStartMs(slot: usize) i32 {
+    return @intCast((slot + 2) * 100 + 300);
+}
+
+fn menuSlotEndMs(slot: usize) i32 {
+    return @intCast((slot + 2) * 100);
+}
+
+fn menuMaxTimelineMs(slot_count: usize) i32 {
+    var max_ms: i32 = 300;
+    for (0..slot_count) |slot| {
+        max_ms = @max(max_ms, menuSlotStartMs(slot));
+    }
+    return max_ms;
+}
+
+fn menuItemScale(slot: usize) struct { scale: f32, local_y_shift: f32 } {
+    if (rl.getScreenWidth() < 641) {
+        return .{ .scale = 0.9, .local_y_shift = @as(f32, @floatFromInt(slot)) * 11.0 };
+    }
+    return .{ .scale = 1.0, .local_y_shift = 0.0 };
+}
+
+fn mainMenuItemRect(slot: usize, item_texture: ?rl.Texture2D) rl.Rectangle {
+    const y_shift = menuWidescreenYShift(@floatFromInt(rl.getScreenWidth()));
+    const item_width: f32 = if (item_texture) |item| @floatFromInt(item.width) else 325.0;
+    const item_height: f32 = if (item_texture) |item| @floatFromInt(item.height) else 54.0;
+    const scale = menuItemScale(slot);
+    const width = item_width * scale.scale;
+    const height = item_height * scale.scale;
+    const x = menuSlotPosX(slot) + menu_item_offset_x * scale.scale;
+    const y = menu_label_base_y + @as(f32, @floatFromInt(slot)) * menu_label_step + y_shift + menu_item_offset_y * scale.scale - scale.local_y_shift;
+    return rl.Rectangle.init(x, y, width, height);
+}
+
 fn mainMenuButtons() [6]UiButton {
-    const center_x: f32 = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
     return .{
-        .{ .label = "START SURVIVAL", .rect = centeredRect(center_x, 214.0, ui_button_width, 48.0) },
-        .{ .label = "START RUSH", .rect = centeredRect(center_x, 272.0, ui_button_width, 48.0) },
-        .{ .label = "START QUEST 1.1", .rect = centeredRect(center_x, 330.0, ui_button_width, 48.0) },
-        .{ .label = "OPTIONS", .rect = centeredRect(center_x, 388.0, ui_button_width, 48.0) },
-        .{ .label = "HIGH SCORES", .rect = centeredRect(center_x, 446.0, ui_button_width, 48.0) },
-        .{ .label = "QUIT", .rect = centeredRect(center_x, 504.0, ui_button_width, 48.0) },
+        .{ .label = "START SURVIVAL", .rect = mainMenuItemRect(0, null) },
+        .{ .label = "START RUSH", .rect = mainMenuItemRect(1, null) },
+        .{ .label = "START QUEST 1.1", .rect = mainMenuItemRect(2, null) },
+        .{ .label = "OPTIONS", .rect = mainMenuItemRect(3, null) },
+        .{ .label = "HIGH SCORES", .rect = mainMenuItemRect(4, null) },
+        .{ .label = "QUIT", .rect = mainMenuItemRect(5, null) },
     };
 }
 
@@ -1323,6 +1625,49 @@ fn updateSelectionFromPointer(selection: *usize, buttons: []const UiButton) void
         if (rl.checkCollisionPointRec(mouse, button.rect)) {
             selection.* = idx;
             return;
+        }
+    }
+}
+
+fn hoveredMainMenuIndex(buttons: []const UiButton) ?usize {
+    const mouse = rl.getMousePosition();
+    for (buttons, 0..) |button, idx| {
+        if (rl.checkCollisionPointRec(mouse, button.rect)) return idx;
+    }
+    return null;
+}
+
+fn mainMenuEntryEnabled(slot: i32, timeline_ms: i32) bool {
+    return timeline_ms >= menuSlotStartMs(@intCast(slot));
+}
+
+fn previousEnabledMenuSelection(selection: usize, timeline_ms: i32, count: usize) usize {
+    var idx = selection;
+    var attempts: usize = 0;
+    while (attempts < count) : (attempts += 1) {
+        idx = if (idx == 0) count - 1 else idx - 1;
+        if (mainMenuEntryEnabled(@intCast(idx), timeline_ms)) return idx;
+    }
+    return selection;
+}
+
+fn nextEnabledMenuSelection(selection: usize, timeline_ms: i32, count: usize) usize {
+    var idx = selection;
+    var attempts: usize = 0;
+    while (attempts < count) : (attempts += 1) {
+        idx = (idx + 1) % count;
+        if (mainMenuEntryEnabled(@intCast(idx), timeline_ms)) return idx;
+    }
+    return selection;
+}
+
+fn updateMenuHoverAmounts(menu: *MenuScreenState, dt_ms: i32, count: usize) void {
+    for (0..count) |idx| {
+        const hovered = menu.hovered_index != null and menu.hovered_index.? == idx;
+        if (hovered) {
+            menu.hover_amounts[idx] = std.math.clamp(menu.hover_amounts[idx] + dt_ms * 6, 0, 1000);
+        } else {
+            menu.hover_amounts[idx] = std.math.clamp(menu.hover_amounts[idx] - dt_ms * 2, 0, 1000);
         }
     }
 }

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -82,6 +82,7 @@ const GameplayScreen = struct {
     run_config: live_runner.LiveModeConfig,
     last_update: live_runner.FrameUpdate,
     input_interpreter: local_input.LocalInputInterpreter = .{},
+    hud_state: HudRuntimeState = .{},
     ground: ?window_ground.GroundRenderer = null,
     terrain_fx: window_terrain_fx.TerrainFxTracker = .{},
 
@@ -91,6 +92,97 @@ const GameplayScreen = struct {
             self.ground = null;
         }
         self.* = undefined;
+    }
+};
+
+const BonusHudSlotState = struct {
+    active: bool = false,
+    bonus_id: game_ids.BonusId = .unused,
+    icon_id: i32 = -1,
+    slide_x: f32 = -184.0,
+    timer_value: f32 = 0.0,
+    timer_value_alt: f32 = 0.0,
+};
+
+const HudBonusSpec = struct {
+    bonus_id: game_ids.BonusId,
+    icon_id: i32,
+    timer_value: f32,
+    timer_value_alt: f32 = 0.0,
+};
+
+const HudRuntimeState = struct {
+    survival_xp_smoothed: i32 = 0,
+    bonus_slots: [16]BonusHudSlotState = [_]BonusHudSlotState{.{}} ** 16,
+
+    fn smoothXp(self: *HudRuntimeState, target_raw: i32, frame_dt_ms_raw: f32) i32 {
+        const target = @max(target_raw, 0);
+        if (target == 0) {
+            self.survival_xp_smoothed = 0;
+            return 0;
+        }
+
+        var smoothed = self.survival_xp_smoothed;
+        if (smoothed == target) return smoothed;
+
+        const frame_dt_ms = @max(frame_dt_ms_raw, 0.0);
+        var step = @max(@as(i32, 1), @as(i32, @intFromFloat(frame_dt_ms)) / 2);
+        const diff = @abs(smoothed - target);
+        if (diff > 1000) {
+            step *= @divTrunc(diff, 100);
+        }
+
+        if (smoothed < target) {
+            smoothed += step;
+            if (smoothed > target) smoothed = target;
+        } else {
+            smoothed -= step;
+            if (smoothed < target) smoothed = target;
+        }
+
+        self.survival_xp_smoothed = smoothed;
+        return smoothed;
+    }
+
+    fn update(self: *HudRuntimeState, frame_dt: f32, session: *const runtime_session.DeterministicSession) void {
+        var desired_specs: [16]HudBonusSpec = undefined;
+        var desired_count: usize = 0;
+        collectHudBonusSpecs(session, desired_specs[0..], &desired_count);
+
+        var matched = [_]bool{false} ** 16;
+        for (desired_specs[0..desired_count]) |spec| {
+            var existing_index: ?usize = null;
+            for (self.bonus_slots, 0..) |slot, idx| {
+                if (slot.active and slot.bonus_id == spec.bonus_id) {
+                    existing_index = idx;
+                    break;
+                }
+            }
+            const slot_index = existing_index orelse blk: {
+                for (self.bonus_slots, 0..) |slot, idx| {
+                    if (!slot.active) break :blk idx;
+                }
+                break :blk self.bonus_slots.len - 1;
+            };
+            var slot = &self.bonus_slots[slot_index];
+            slot.active = true;
+            slot.bonus_id = spec.bonus_id;
+            slot.icon_id = spec.icon_id;
+            slot.timer_value = spec.timer_value;
+            slot.timer_value_alt = spec.timer_value_alt;
+            slot.slide_x = @min(-2.0, slot.slide_x + @max(frame_dt, 0.0) * 350.0);
+            matched[slot_index] = true;
+        }
+
+        for (&self.bonus_slots, 0..) |*slot, idx| {
+            if (!slot.active or matched[idx]) continue;
+            slot.timer_value = 0.0;
+            slot.timer_value_alt = 0.0;
+            slot.slide_x -= @max(frame_dt, 0.0) * 320.0;
+            if (slot.slide_x < -184.0) {
+                slot.* = .{};
+            }
+        }
     }
 };
 
@@ -302,6 +394,7 @@ const App = struct {
                 self.finishRun(gameplay, .runtime_error, @errorName(err));
                 return;
             };
+            gameplay.hud_state.update(frame_dt, &gameplay.runner.session);
             self.audio.handleFrameAudio(gameplay.last_update.audio, gameplay.runner.session.state.bonuses.reflex_boost);
             if (self.runtime_assets) |*runtime_assets| {
                 if (gameplay.ground) |*ground| {
@@ -404,13 +497,33 @@ const App = struct {
 
         switch (self.options.selection) {
             0 => {
-                self.runtime.config.sound_disable = if (self.runtime.config.sound_disable == 0) 1 else 0;
+                var value = if (self.runtime.config.sound_disable != 0)
+                    @as(i32, 0)
+                else
+                    @as(i32, @intFromFloat(std.math.clamp(self.runtime.config.sfx_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5));
+                if (adjust_left or adjust_right) {
+                    value = std.math.clamp(value + (if (adjust_left and !adjust_right) @as(i32, -1) else @as(i32, 1)), @as(i32, 0), @as(i32, 10));
+                } else {
+                    value = if (value == 0) 10 else 0;
+                }
+                self.runtime.config.sfx_volume = @as(f32, @floatFromInt(value)) * 0.1;
+                self.runtime.config.sound_disable = if (value == 0) 1 else 0;
                 self.runtime.config_dirty = true;
                 self.reloadAudioConfig();
                 self.audio.playUiButtonClick();
             },
             1 => {
-                self.runtime.config.music_disable = if (self.runtime.config.music_disable == 0) 1 else 0;
+                var value = if (self.runtime.config.music_disable != 0)
+                    @as(i32, 0)
+                else
+                    @as(i32, @intFromFloat(std.math.clamp(self.runtime.config.music_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5));
+                if (adjust_left or adjust_right) {
+                    value = std.math.clamp(value + (if (adjust_left and !adjust_right) @as(i32, -1) else @as(i32, 1)), @as(i32, 0), @as(i32, 10));
+                } else {
+                    value = if (value == 0) 10 else 0;
+                }
+                self.runtime.config.music_volume = @as(f32, @floatFromInt(value)) * 0.1;
+                self.runtime.config.music_disable = if (value == 0) 1 else 0;
                 self.runtime.config_dirty = true;
                 self.reloadAudioConfig();
                 self.audio.playUiButtonClick();
@@ -558,6 +671,7 @@ const App = struct {
             .last_update = last_update,
             .terrain_fx = window_terrain_fx.TerrainFxTracker.init(runner.seed),
         };
+        gameplay.hud_state.update(0.0, &gameplay.runner.session);
         gameplay.input_interpreter.setPreserveBugs(gameplay.runner.session.state.preserve_bugs);
         gameplay.input_interpreter.reset(gameplay.runner.session.playersConst());
         if (self.runtime_assets) |*runtime_assets| {
@@ -774,9 +888,9 @@ const App = struct {
             drawBonuses(runner, runtime_assets);
             camera.end();
 
-            drawGameplayHud(runner, gameplay.last_update, runtime_assets);
+            drawGameplayHud(gameplay, runtime_assets);
             if (gameplay.last_update.paused_for_perk_pick) {
-                drawPerkOverlay(runner, runtime_assets);
+                drawPerkOverlay(gameplay, runtime_assets);
             }
         }
     }
@@ -790,18 +904,23 @@ const App = struct {
                 drawTextureFit(runtime_assets.texture(.ui_menu_panel), rl.Rectangle.init(262.0, 116.0, 756.0, 392.0), colorWithAlpha(rl.Color.white, 0.96));
                 switch (results.reason) {
                     .dead => drawTextureFit(runtime_assets.texture(.ui_text_reaper), rl.Rectangle.init(464.0, 136.0, 354.0, 48.0), colorWithAlpha(rl.Color.white, 0.96)),
-                    .completed, .abandoned, .runtime_error => drawSmallTextCentered(runtime_assets, resultsTitle(results.reason), 152.0, HudTextColor.accent),
+                    .completed => drawTextureFit(runtime_assets.texture(.ui_text_level_complete), rl.Rectangle.init(406.0, 136.0, 468.0, 48.0), colorWithAlpha(rl.Color.white, 0.96)),
+                    .abandoned, .runtime_error => drawSmallTextCentered(runtime_assets, resultsTitle(results.reason), 152.0, HudTextColor.accent),
                 }
                 drawSmallTextCentered(runtime_assets, resultsSubtitle(results.reason), 196.0, HudTextColor.primary);
-                drawSmallTextFmt("ELAPSED_MS {d}", runtime_assets, .{results.summary.elapsed_ms_sim}, 330.0, 258.0, HudTextColor.primary);
-                drawSmallTextFmt("XP {d}", runtime_assets, .{results.summary.player_experience}, 330.0, 286.0, HudTextColor.primary);
-                drawSmallTextFmt("LEVEL {d}", runtime_assets, .{results.summary.player_level}, 330.0, 314.0, HudTextColor.primary);
-                drawSmallTextFmt("FIRE {d}  RELOAD {d}", runtime_assets, .{ results.summary.fire_pressed_count, results.summary.reload_pressed_count }, 330.0, 342.0, HudTextColor.primary);
-                drawSmallTextFmt("SPAWNS STAGE {d}  WAVE {d}", runtime_assets, .{ results.summary.stage_spawn_count, results.summary.wave_spawn_count }, 330.0, 370.0, HudTextColor.primary);
-                drawSmallTextFmt("WEAPON {s}  HP {d:.1}", runtime_assets, .{ weaponName(results.summary.player_weapon_id), results.player_health }, 330.0, 398.0, HudTextColor.primary);
+                drawSmallText(runtime_assets, "TIME", 370.0, 258.0, HudTextColor.dim);
+                drawSmallText(runtime_assets, "XP", 370.0, 286.0, HudTextColor.dim);
+                drawSmallText(runtime_assets, "LEVEL", 370.0, 314.0, HudTextColor.dim);
+                drawSmallText(runtime_assets, "WEAPON", 370.0, 342.0, HudTextColor.dim);
+                drawSmallText(runtime_assets, "HP", 370.0, 370.0, HudTextColor.dim);
+                drawSmallTextFmt("{d} ms", runtime_assets, .{results.summary.elapsed_ms_sim}, 510.0, 258.0, HudTextColor.primary);
+                drawSmallTextFmt("{d}", runtime_assets, .{results.summary.player_experience}, 510.0, 286.0, HudTextColor.primary);
+                drawSmallTextFmt("{d}", runtime_assets, .{results.summary.player_level}, 510.0, 314.0, HudTextColor.primary);
+                drawSmallText(runtime_assets, weaponName(results.summary.player_weapon_id), 510.0, 342.0, HudTextColor.primary);
+                drawSmallTextFmt("{d:.1}", runtime_assets, .{results.player_health}, 510.0, 370.0, HudTextColor.primary);
 
                 if (results.runtime_error) |runtime_error| {
-                    drawSmallText(runtime_assets, runtime_error, 330.0, 438.0, rl.Color.orange);
+                    drawSmallText(runtime_assets, runtime_error, 330.0, 430.0, rl.Color.orange);
                 }
                 if (results.highscore) |highscore| {
                     drawResultsHighscore(runtime_assets, &highscore);
@@ -1851,19 +1970,19 @@ fn drawHighScoreTable(runtime_assets: *const window_assets.RuntimeAssets, high_s
         return;
     }
 
-    drawSmallText(runtime_assets, "RANK", 286.0, 194.0, HudTextColor.dim);
-    drawSmallText(runtime_assets, "NAME", 356.0, 194.0, HudTextColor.dim);
-    drawSmallText(runtime_assets, "VALUE", 660.0, 194.0, HudTextColor.dim);
-    drawSmallText(runtime_assets, "WEAPON", 810.0, 194.0, HudTextColor.dim);
+    rl.drawRectangle(438, 189, 322, 166, rl.Color.white);
+    rl.drawRectangle(439, 190, 320, 164, rl.Color.black);
+    drawSmallText(runtime_assets, "RANK", 452.0, 194.0, HudTextColor.dim);
+    drawSmallText(runtime_assets, "VALUE", 492.0, 194.0, HudTextColor.dim);
+    drawSmallText(runtime_assets, "PLAYER", 556.0, 194.0, HudTextColor.dim);
 
     const row_count = @min(high_scores.records.len, 10);
     for (high_scores.records[0..row_count], 0..) |record, idx| {
-        const row_y = 224.0 + @as(f32, @floatFromInt(idx)) * 28.0;
+        const row_y = 208.0 + @as(f32, @floatFromInt(idx)) * 16.0;
         var value_buf: [32]u8 = undefined;
-        drawSmallTextFmt("#{d}", runtime_assets, .{idx + 1}, 286.0, row_y, HudTextColor.primary);
-        drawSmallText(runtime_assets, record.name(), 356.0, row_y, rl.Color.white);
-        drawSmallText(runtime_assets, formatHighScoreValue(&value_buf, record), 660.0, row_y, HudTextColor.primary);
-        drawSmallText(runtime_assets, weaponName(@intFromEnum(record.mostUsedWeaponId())), 810.0, row_y, HudTextColor.dim);
+        drawSmallTextFmt("{d}", runtime_assets, .{idx + 1}, 458.0, row_y, HudTextColor.primary);
+        drawSmallText(runtime_assets, formatHighScoreValue(&value_buf, record), 492.0, row_y, HudTextColor.primary);
+        drawSmallText(runtime_assets, record.name(), 556.0, row_y, rl.Color.white);
     }
 }
 
@@ -1900,17 +2019,38 @@ fn formatHighScoreValue(buf: []u8, record: persistence.highscores.HighScoreRecor
 
 fn drawOptionsTable(runtime_assets: *const window_assets.RuntimeAssets, app: *const App) void {
     const labels = [_][]const u8{
-        "SFX",
-        "MUSIC",
-        "DETAIL",
-        "GORE",
+        "SOUND VOLUME",
+        "MUSIC VOLUME",
+        "GRAPHICS DETAIL",
+        "VIOLENCE",
         "HARDCORE",
     };
     for (labels, 0..) |label, idx| {
         const row_y = 230.0 + @as(f32, @floatFromInt(idx)) * 54.0;
         var value_buf: [32]u8 = undefined;
         drawSmallText(runtime_assets, label, 330.0, row_y, HudTextColor.dim);
-        drawSmallText(runtime_assets, optionValueText(&value_buf, app, idx), 604.0, row_y, rl.Color.white);
+        switch (idx) {
+            0, 1, 2 => {
+                const slider_value: i32 = switch (idx) {
+                    0 => if (app.runtime.config.sound_disable != 0) 0 else @intFromFloat(std.math.clamp(app.runtime.config.sfx_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5),
+                    1 => if (app.runtime.config.music_disable != 0) 0 else @intFromFloat(std.math.clamp(app.runtime.config.music_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5),
+                    else => @intCast(std.math.clamp(app.runtime.config.detail_preset, @as(u32, 1), @as(u32, 5))),
+                };
+                drawSliderRow(runtime_assets, rl.Vector2.init(620.0, row_y - 2.0), if (idx == 2) 5 else 10, slider_value);
+                drawSmallText(runtime_assets, optionValueText(&value_buf, app, idx), 708.0, row_y, rl.Color.white);
+            },
+            3, 4 => {
+                const checked = switch (idx) {
+                    3 => app.runtime.config.gore_disabled == 0,
+                    4 => app.runtime.config.hardcore_flag != 0,
+                    else => false,
+                };
+                const texture_id: window_assets.TextureId = if (checked) .ui_check_on else .ui_check_off;
+                drawTextureFit(runtime_assets.texture(texture_id), rl.Rectangle.init(620.0, row_y - 1.0, 16.0, 16.0), rl.Color.white);
+                drawSmallText(runtime_assets, optionValueText(&value_buf, app, idx), 646.0, row_y, rl.Color.white);
+            },
+            else => {},
+        }
     }
 }
 
@@ -1937,8 +2077,8 @@ fn drawOptionsTableFallback(app: *const App) void {
 
 fn optionValueText(buf: []u8, app: *const App, idx: usize) []const u8 {
     return switch (idx) {
-        0 => if (app.runtime.config.sound_disable == 0) "ON" else "OFF",
-        1 => if (app.runtime.config.music_disable == 0) "ON" else "OFF",
+        0 => std.fmt.bufPrint(buf, "{d}", .{if (app.runtime.config.sound_disable != 0) @as(i32, 0) else @as(i32, @intFromFloat(std.math.clamp(app.runtime.config.sfx_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5))}) catch "0",
+        1 => std.fmt.bufPrint(buf, "{d}", .{if (app.runtime.config.music_disable != 0) @as(i32, 0) else @as(i32, @intFromFloat(std.math.clamp(app.runtime.config.music_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5))}) catch "0",
         2 => std.fmt.bufPrint(buf, "{d}", .{std.math.clamp(app.runtime.config.detail_preset, @as(u32, 1), @as(u32, 5))}) catch "5",
         3 => if (app.runtime.config.gore_disabled == 0) "ON" else "OFF",
         4 => if (app.runtime.config.hardcore_flag == 0) "OFF" else "ON",
@@ -1952,17 +2092,255 @@ const HudTextColor = struct {
     const accent = rl.Color.init(240, 200, 80, 255);
 };
 
-fn drawAmmoIndicators(assets: *const window_assets.RuntimeAssets, texture_id: window_assets.TextureId, ammo: f32) void {
-    const texture = assets.texture(texture_id);
-    const count = @max(0, @min(30, @as(i32, @intFromFloat(ammo + 0.999))));
+const HudFlags = struct {
+    show_health: bool,
+    show_weapon: bool,
+    show_xp: bool,
+    show_time: bool,
+    show_quest_hud: bool,
+};
+
+fn hudFlagsForGameMode(game_mode: game_ids.GameModeId) HudFlags {
+    return switch (game_mode) {
+        .quests => .{
+            .show_health = true,
+            .show_weapon = true,
+            .show_xp = true,
+            .show_time = false,
+            .show_quest_hud = true,
+        },
+        .survival => .{
+            .show_health = true,
+            .show_weapon = true,
+            .show_xp = true,
+            .show_time = false,
+            .show_quest_hud = false,
+        },
+        .rush => .{
+            .show_health = true,
+            .show_weapon = false,
+            .show_xp = false,
+            .show_time = true,
+            .show_quest_hud = false,
+        },
+        .typo => .{
+            .show_health = true,
+            .show_weapon = false,
+            .show_xp = true,
+            .show_time = true,
+            .show_quest_hud = false,
+        },
+        .tutorial => .{
+            .show_health = false,
+            .show_weapon = false,
+            .show_xp = false,
+            .show_time = false,
+            .show_quest_hud = false,
+        },
+    };
+}
+
+fn hudBonusIconId(bonus_id: game_ids.BonusId) ?i32 {
+    return switch (bonus_id) {
+        .energizer => 10,
+        .weapon_power_up => 7,
+        .double_experience => 4,
+        .reflex_boost => 5,
+        .shield => 6,
+        .freeze => 8,
+        .speed => 9,
+        .fire_bullets => 11,
+        else => null,
+    };
+}
+
+fn collectHudBonusSpecs(session: *const runtime_session.DeterministicSession, dest: []HudBonusSpec, count: *usize) void {
+    count.* = 0;
+    const state = &session.state;
+    const players = session.playersConst();
+
+    appendHudBonusSpec(dest, count, .weapon_power_up, state.bonuses.weapon_power_up, 0.0);
+    appendHudBonusSpec(dest, count, .reflex_boost, state.bonuses.reflex_boost, 0.0);
+    appendHudBonusSpec(dest, count, .energizer, state.bonuses.energizer, 0.0);
+    appendHudBonusSpec(dest, count, .double_experience, state.bonuses.double_experience, 0.0);
+    appendHudBonusSpec(dest, count, .freeze, state.bonuses.freeze, 0.0);
+
+    const player0 = if (players.len > 0) players[0] else null;
+    const player1 = if (players.len > 1) players[1] else null;
+    appendHudBonusSpec(
+        dest,
+        count,
+        .fire_bullets,
+        if (player0) |player| player.fire_bullets_timer else 0.0,
+        if (player1) |player| player.fire_bullets_timer else 0.0,
+    );
+    appendHudBonusSpec(
+        dest,
+        count,
+        .shield,
+        if (player0) |player| player.shield_timer else 0.0,
+        if (player1) |player| player.shield_timer else 0.0,
+    );
+    appendHudBonusSpec(
+        dest,
+        count,
+        .speed,
+        if (player0) |player| player.speed_bonus_timer else 0.0,
+        if (player1) |player| player.speed_bonus_timer else 0.0,
+    );
+}
+
+fn appendHudBonusSpec(dest: []HudBonusSpec, count: *usize, bonus_id: game_ids.BonusId, timer_value: f32, timer_value_alt: f32) void {
+    if (!(timer_value > 0.0 or timer_value_alt > 0.0)) return;
+    if (count.* >= dest.len) return;
+    dest[count.*] = .{
+        .bonus_id = bonus_id,
+        .icon_id = hudBonusIconId(bonus_id) orelse -1,
+        .timer_value = @max(timer_value, 0.0),
+        .timer_value_alt = @max(timer_value_alt, 0.0),
+    };
+    count.* += 1;
+}
+
+fn drawProgressBar(pos: rl.Vector2, width: f32, ratio_raw: f32, fg_color: rl.Color) void {
+    const ratio = std.math.clamp(ratio_raw, @as(f32, 0.0), @as(f32, 1.0));
+    rl.drawRectangle(@intFromFloat(pos.x), @intFromFloat(pos.y), @intFromFloat(width), 4, rl.Color.init(
+        @intFromFloat(@as(f32, @floatFromInt(fg_color.r)) * 0.6),
+        @intFromFloat(@as(f32, @floatFromInt(fg_color.g)) * 0.6),
+        @intFromFloat(@as(f32, @floatFromInt(fg_color.b)) * 0.6),
+        102,
+    ));
+    rl.drawRectangle(@intFromFloat(pos.x + 1.0), @intFromFloat(pos.y + 1.0), @intFromFloat((width - 2.0) * ratio), 2, fg_color);
+}
+
+fn drawSliderRow(assets: *const window_assets.RuntimeAssets, pos: rl.Vector2, count: i32, value: i32) void {
+    const rect_on = assets.texture(.ui_rect_on);
+    const rect_off = assets.texture(.ui_rect_off);
     var idx: i32 = 0;
     while (idx < count) : (idx += 1) {
-        const alpha: f32 = if (idx < 20) 0.8 else 0.45;
+        const tex = if (idx < value) rect_on else rect_off;
+        const tint = if (idx < value) rl.Color.white else colorWithAlpha(rl.Color.white, 0.5);
+        rl.drawTexturePro(
+            tex,
+            rl.Rectangle.init(0.0, 0.0, @floatFromInt(tex.width), @floatFromInt(tex.height)),
+            rl.Rectangle.init(pos.x + @as(f32, @floatFromInt(idx * tex.width)), pos.y, @floatFromInt(tex.width), @floatFromInt(tex.height)),
+            rl.Vector2.zero(),
+            0.0,
+            tint,
+        );
+    }
+}
+
+fn questProgressRatio(session: *const runtime_session.DeterministicSession) ?f32 {
+    if (session.game_mode != .quests) return null;
+    if (session.quest_completed or session.quest_completion_transition_ms >= 0.0) return 1.0;
+    if (session.reset_quest_spawn_entries_len == 0) return null;
+    const last_trigger_ms = session.quest_spawn_entries_storage[session.reset_quest_spawn_entries_len - 1].trigger_ms;
+    if (last_trigger_ms <= 0) return null;
+    return std.math.clamp(session.quest_spawn_timeline_ms / @as(f32, @floatFromInt(last_trigger_ms)), @as(f32, 0.0), @as(f32, 1.0));
+}
+
+fn drawModeClock(assets: *const window_assets.RuntimeAssets, elapsed_ms: f32, x: f32, y: f32) void {
+    drawTextureFit(assets.texture(.ui_clock_table), rl.Rectangle.init(x, y, 32.0, 32.0), colorWithAlpha(rl.Color.white, 0.9));
+    rl.drawTexturePro(
+        assets.texture(.ui_clock_pointer),
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(assets.texture(.ui_clock_pointer).width), @floatFromInt(assets.texture(.ui_clock_pointer).height)),
+        rl.Rectangle.init(x + 16.0, y + 16.0, 32.0, 32.0),
+        rl.Vector2.init(16.0, 16.0),
+        elapsed_ms * 0.006,
+        colorWithAlpha(rl.Color.white, 0.9),
+    );
+}
+
+fn drawQuestHud(gameplay: *const GameplayScreen, assets: *const window_assets.RuntimeAssets) void {
+    const elapsed_ms = @as(f32, @floatFromInt(gameplay.last_update.elapsed_ms_sim));
+    const slide_x = if (elapsed_ms < 1000.0) (1000.0 - elapsed_ms) * -0.128 else 0.0;
+
+    drawTextureFit(assets.texture(.ui_ind_panel), rl.Rectangle.init(slide_x - 90.0, 67.0, 182.0, 53.0), colorWithAlpha(rl.Color.white, 0.7));
+    drawTextureFit(assets.texture(.ui_ind_panel), rl.Rectangle.init(-80.0, 107.0, 182.0, 53.0), colorWithAlpha(rl.Color.white, 0.7));
+    drawModeClock(assets, elapsed_ms, slide_x + 2.0, 78.0);
+    drawSmallTextFmt("{d}:{d:0>2}", assets, .{ @divTrunc(gameplay.last_update.elapsed_ms_sim, 60_000), @mod(@divTrunc(gameplay.last_update.elapsed_ms_sim, 1000), 60) }, slide_x + 32.0, 86.0, HudTextColor.primary);
+    drawSmallText(assets, "Progress", 18.0, 122.0, HudTextColor.primary);
+    if (questProgressRatio(&gameplay.runner.session)) |ratio| {
+        drawProgressBar(rl.Vector2.init(10.0, 139.0), 70.0, ratio, rl.Color.init(51, 204, 77, 204));
+    }
+}
+
+fn drawBonusHud(gameplay: *const GameplayScreen, assets: *const window_assets.RuntimeAssets) void {
+    var bonus_y: f32 = if (gameplay.runner.session.game_mode == .quests) 201.0 else 121.0;
+    const bonuses_texture = assets.texture(.bonuses);
+    for (gameplay.hud_state.bonus_slots) |slot| {
+        if (!slot.active) continue;
+        if (slot.slide_x < -184.0) {
+            bonus_y += 52.0;
+            continue;
+        }
+        drawTextureFit(assets.texture(.ui_ind_panel), rl.Rectangle.init(slot.slide_x, bonus_y - 11.0, 182.0, 53.0), colorWithAlpha(rl.Color.white, 0.7));
+        if (slot.icon_id >= 0) {
+            drawTextureRegionCenteredRotated(
+                bonuses_texture,
+                window_atlas.bonusIconRect(bonuses_texture.width, bonuses_texture.height, slot.icon_id),
+                rl.Vector2.init(slot.slide_x + 15.0, bonus_y + 16.0),
+                32.0,
+                32.0,
+                0.0,
+                rl.Color.white,
+            );
+        }
+        drawSmallText(assets, game_ids.bonusDisplayName(slot.bonus_id, gameplay.runner.session.state.preserve_bugs), slot.slide_x + 36.0, bonus_y + 6.0, HudTextColor.primary);
+        drawProgressBar(rl.Vector2.init(slot.slide_x + 36.0, bonus_y + 21.0), 100.0, slot.timer_value * 0.05, rl.Color.init(26, 77, 153, 179));
+        if (slot.timer_value_alt > 0.0) {
+            drawProgressBar(rl.Vector2.init(slot.slide_x + 36.0, bonus_y + 27.0), 100.0, slot.timer_value_alt * 0.05, rl.Color.init(26, 77, 153, 179));
+        }
+        bonus_y += 52.0;
+    }
+}
+
+fn drawWeaponAuxHud(gameplay: *const GameplayScreen, assets: *const window_assets.RuntimeAssets) void {
+    const players = gameplay.runner.session.playersConst();
+    var bonus_bottom_y: f32 = if (gameplay.runner.session.game_mode == .quests) 201.0 else 121.0;
+    for (gameplay.hud_state.bonus_slots) |slot| {
+        if (slot.active) bonus_bottom_y += 52.0;
+    }
+    for (players, 0..) |player, idx| {
+        if (!(player.aux_timer > 0.0)) continue;
+        const fade_raw = if (player.aux_timer > 1.0) 2.0 - player.aux_timer else player.aux_timer;
+        const fade = std.math.clamp(fade_raw, @as(f32, 0.0), @as(f32, 1.0));
+        if (fade <= 1e-3) continue;
+        const y = bonus_bottom_y - 17.0 + @as(f32, @floatFromInt(idx)) * 32.0;
+        drawTextureFit(assets.texture(.ui_ind_panel), rl.Rectangle.init(-12.0, y, 182.0, 53.0), colorWithAlpha(rl.Color.white, fade * 0.8));
+        const icon_index = weapon_data.weaponIconIndex(player.weapon.weapon_id);
+        if (icon_index >= 0) {
+            drawTextureRegionCenteredRotated(
+                assets.texture(.ui_wicons),
+                window_atlas.weaponIconRect(assets.texture(.ui_wicons).width, assets.texture(.ui_wicons).height, icon_index),
+                rl.Vector2.init(135.0, y + 20.0),
+                60.0,
+                30.0,
+                0.0,
+                colorWithAlpha(rl.Color.white, fade * 0.8),
+            );
+        }
+        drawSmallText(assets, game_ids.weaponDisplayName(player.weapon.weapon_id, gameplay.runner.session.state.preserve_bugs), 8.0, y + 18.0, colorWithAlpha(HudTextColor.primary, fade));
+    }
+}
+
+fn drawAmmoIndicators(assets: *const window_assets.RuntimeAssets, texture_id: window_assets.TextureId, ammo: f32, clip_size: i32) void {
+    const texture = assets.texture(texture_id);
+    const ammo_count = @max(0, @as(i32, @intFromFloat(ammo)));
+    var bars = @max(0, clip_size);
+    if (bars > 30) bars = 20;
+    var idx: i32 = 0;
+    while (idx < bars) : (idx += 1) {
+        const alpha: f32 = if (idx < ammo_count) 0.8 else 0.24;
         drawTextureFit(
             texture,
             rl.Rectangle.init(300.0 + @as(f32, @floatFromInt(idx)) * 6.0, 10.0, 6.0, 16.0),
             colorWithAlpha(rl.Color.white, alpha),
         );
+    }
+    if (ammo_count > bars) {
+        drawSmallTextFmt("+ {d}", assets, .{ammo_count - bars}, 300.0 + @as(f32, @floatFromInt(bars)) * 6.0 + 8.0, 11.0, HudTextColor.primary);
     }
 }
 
@@ -2072,70 +2450,90 @@ fn drawSmallTextCentered(
     drawSmallText(runtime_assets, text, x, y, color);
 }
 
-fn drawGameplayHud(
-    runner: *live_runner.LiveRunner,
-    update: live_runner.FrameUpdate,
-    runtime_assets: ?*const window_assets.RuntimeAssets,
-) void {
+fn drawGameplayHud(gameplay: *const GameplayScreen, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+    const runner = &gameplay.runner;
+    const update = gameplay.last_update;
     const player = runner.player0Const() orelse return;
     if (runtime_assets) |assets| {
+        const flags = hudFlagsForGameMode(runner.session.game_mode);
+        const elapsed_ms = @as(f32, @floatFromInt(update.elapsed_ms_sim));
+        const top_alpha = 0.7;
+
         drawTextureFit(
             assets.texture(.ui_game_top),
             rl.Rectangle.init(0.0, 0.0, 512.0, 64.0),
-            colorWithAlpha(rl.Color.white, 0.9),
-        );
-        drawTextureCentered(assets.texture(.ui_life_heart), rl.Vector2.init(27.0, 21.0), 32.0, 32.0, colorWithAlpha(rl.Color.white, 0.9));
-
-        rl.drawRectangleRounded(
-            .{
-                .x = 64.0,
-                .y = 16.0,
-                .width = 120.0,
-                .height = 9.0,
-            },
-            0.22,
-            4,
-            rl.Color.init(72, 20, 20, 128),
-        );
-        rl.drawRectangleRounded(
-            .{
-                .x = 64.0,
-                .y = 16.0,
-                .width = 120.0 * std.math.clamp(player.health / 100.0, @as(f32, 0.0), @as(f32, 1.0)),
-                .height = 9.0,
-            },
-            0.22,
-            4,
-            rl.Color.init(208, 58, 58, 220),
+            colorWithAlpha(rl.Color.white, top_alpha),
         );
 
-        const weapon_id = std.meta.intToEnum(game_ids.WeaponId, update.player_weapon_id) catch .pistol;
-        const icon_index = weapon_data.weaponIconIndex(weapon_id);
-        if (icon_index >= 0) {
-            drawTextureRegionCenteredRotated(
-                assets.texture(.ui_wicons),
-                window_atlas.weaponIconRect(assets.texture(.ui_wicons).width, assets.texture(.ui_wicons).height, icon_index),
-                rl.Vector2.init(252.0, 18.0),
-                64.0,
-                32.0,
-                0.0,
-                colorWithAlpha(rl.Color.white, 0.9),
+        if (flags.show_health) {
+            const pulse_speed: f32 = if (player.health < 30.0) 5.0 else 2.0;
+            const t = elapsed_ms * 0.001;
+            const pulse = std.math.pow(f32, std.math.sin(t * pulse_speed), 4) * 4.0 + 14.0;
+            drawTextureCentered(
+                assets.texture(.ui_life_heart),
+                rl.Vector2.init(27.0, 21.0),
+                pulse * 2.0,
+                pulse * 2.0,
+                colorWithAlpha(rl.Color.white, 0.8),
             );
+
+            const ind_life = assets.texture(.ui_ind_life);
+            const health_ratio = std.math.clamp(player.health / 100.0, @as(f32, 0.0), @as(f32, 1.0));
+            drawTextureFit(ind_life, rl.Rectangle.init(64.0, 16.0, 120.0, 9.0), colorWithAlpha(rl.Color.white, 0.5));
+            if (health_ratio > 0.0) {
+                rl.drawTexturePro(
+                    ind_life,
+                    rl.Rectangle.init(0.0, 0.0, @as(f32, @floatFromInt(ind_life.width)) * health_ratio, @floatFromInt(ind_life.height)),
+                    rl.Rectangle.init(64.0, 16.0, 120.0 * health_ratio, 9.0),
+                    rl.Vector2.zero(),
+                    0.0,
+                    colorWithAlpha(rl.Color.white, 0.8),
+                );
+            }
         }
 
-        drawAmmoIndicators(assets, weaponIndicatorTextureId(weapon_id), player.weapon.ammo);
-        drawTextureFit(assets.texture(.ui_ind_panel), rl.Rectangle.init(0.0, 60.0, 182.0, 53.0), colorWithAlpha(rl.Color.white, 0.9));
+        if (flags.show_weapon) {
+            const weapon_id = std.meta.intToEnum(game_ids.WeaponId, update.player_weapon_id) catch .pistol;
+            const icon_index = weapon_data.weaponIconIndex(weapon_id);
+            if (icon_index >= 0) {
+                drawTextureRegionCenteredRotated(
+                    assets.texture(.ui_wicons),
+                    window_atlas.weaponIconRect(assets.texture(.ui_wicons).width, assets.texture(.ui_wicons).height, icon_index),
+                    rl.Vector2.init(252.0, 18.0),
+                    64.0,
+                    32.0,
+                    0.0,
+                    colorWithAlpha(rl.Color.white, 0.8),
+                );
+            }
+            drawAmmoIndicators(assets, weaponIndicatorTextureId(weapon_id), player.weapon.ammo, player.weapon.clip_size);
+        }
 
-        drawSmallTextFmt("HP {d:.0}", assets, .{player.health}, 30.0, 38.0, HudTextColor.primary);
-        drawSmallTextFmt("XP", assets, .{}, 6.0, 78.0, HudTextColor.dim);
-        drawSmallTextFmt("{d}", assets, .{update.player_experience}, 26.0, 74.0, HudTextColor.primary);
-        drawSmallTextFmt("LV {d}", assets, .{update.player_level}, 86.0, 79.0, HudTextColor.accent);
+        if (flags.show_quest_hud) {
+            drawQuestHud(gameplay, assets);
+        }
 
-        rl.drawRectangle(26, 91, 54, 4, rl.Color.init(16, 26, 54, 140));
-        rl.drawRectangle(27, 92, @intFromFloat(52.0 * xpProgressRatio(update.player_experience, update.player_level)), 2, rl.Color.init(26, 77, 153, 255));
-        drawSmallTextFmt("{d}ms", assets, .{update.elapsed_ms_sim}, 92.0, 74.0, HudTextColor.dim);
-        drawSmallTextFmt("{d}/{d}", assets, .{ @as(i32, @intFromFloat(player.weapon.ammo)), weapon_data.weapon_stats.get(weapon_id).clip_size }, 308.0, 28.0, HudTextColor.primary);
-        drawSmallTextFmt("shots {d} hits {d}", assets, .{ update.shots_fired, update.shots_hit }, 24.0, @floatFromInt(rl.getScreenHeight() - 34), HudTextColor.dim);
+        if (flags.show_xp) {
+            const hud_y_shift: f32 = if (flags.show_quest_hud) 80.0 else 0.0;
+            drawTextureFit(
+                assets.texture(.ui_ind_panel),
+                rl.Rectangle.init(-68.0, 60.0 + hud_y_shift, 182.0, 53.0),
+                colorWithAlpha(rl.Color.white, 0.9),
+            );
+            const xp_display = gameplay.hud_state.survival_xp_smoothed;
+            drawSmallText(assets, "Xp", 4.0, 78.0 + hud_y_shift, HudTextColor.dim);
+            drawSmallTextFmt("{d}", assets, .{xp_display}, 26.0, 74.0 + hud_y_shift, HudTextColor.primary);
+            drawSmallTextFmt("{d}", assets, .{update.player_level}, 85.0, 79.0 + hud_y_shift, HudTextColor.primary);
+            drawProgressBar(rl.Vector2.init(26.0, 91.0 + hud_y_shift), 54.0, xpProgressRatio(update.player_experience, update.player_level), rl.Color.init(26, 77, 153, 255));
+        }
+
+        if (flags.show_time) {
+            drawModeClock(assets, elapsed_ms, 220.0, 2.0);
+            drawSmallTextFmt("{d} seconds", assets, .{@divTrunc(update.elapsed_ms_sim, 1000)}, 255.0, 10.0, HudTextColor.primary);
+        }
+
+        drawBonusHud(gameplay, assets);
+        drawWeaponAuxHud(gameplay, assets);
         return;
     }
 
@@ -2154,30 +2552,24 @@ fn drawGameplayHud(
     drawTextFmt("weapon {s}  ammo {d:.1}", .{ weaponName(update.player_weapon_id), player.weapon.ammo }, 36, 62, 22, text_color);
     drawTextFmt("shots {d}  hits {d}  creatures {d}", .{ update.shots_fired, update.shots_hit, update.creature_active_count }, 36, 90, 20, muted_text);
     drawTextFmt("elapsed {d}ms  pickups {d}  pending perks {d}", .{ update.elapsed_ms_sim, update.bonus_active_count, runner.perkPendingCount() }, 36, 116, 20, muted_text);
-
-    drawTextSlice("WASD move  mouse aim/fire  R reload  Esc end run", 24, rl.getScreenHeight() - 34, 18, muted_text);
 }
 
-fn drawPerkOverlay(runner: *live_runner.LiveRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+fn drawPerkOverlay(gameplay: *GameplayScreen, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     rl.drawRectangle(0, 0, rl.getScreenWidth(), rl.getScreenHeight(), overlay_color);
+    const runner = &gameplay.runner;
     if (runtime_assets) |assets| {
-        drawTextureFit(assets.texture(.ui_menu_panel), rl.Rectangle.init(262.0, 152.0, 756.0, 360.0), colorWithAlpha(rl.Color.white, 0.96));
-        drawTextureFit(assets.texture(.ui_text_pick_a_perk), rl.Rectangle.init(432.0, 176.0, 410.0, 40.0), colorWithAlpha(rl.Color.white, 0.96));
+        drawTextureFit(assets.texture(.ui_menu_panel), rl.Rectangle.init(258.0, 140.0, 764.0, 378.0), colorWithAlpha(rl.Color.white, 0.96));
+        drawTextureFit(assets.texture(.ui_text_level_up), rl.Rectangle.init(456.0, 152.0, 364.0, 40.0), colorWithAlpha(rl.Color.white, 0.96));
+        drawTextureFit(assets.texture(.ui_text_pick_a_perk), rl.Rectangle.init(424.0, 190.0, 430.0, 40.0), colorWithAlpha(rl.Color.white, 0.96));
 
         const choices = runner.currentPerkChoices();
         for (choices, 0..) |perk_id, idx| {
-            const row_y = 240.0 + @as(f32, @floatFromInt(idx)) * 28.0;
-            rl.drawTexturePro(
-                assets.texture(.ui_menu_item),
-                rl.Rectangle.init(0.0, 0.0, @floatFromInt(assets.texture(.ui_menu_item).width), @floatFromInt(assets.texture(.ui_menu_item).height)),
-                rl.Rectangle.init(332.0, row_y - 6.0, 612.0, 32.0),
-                rl.Vector2.zero(),
-                0.0,
-                colorWithAlpha(rl.Color.white, if (idx == 0) 0.95 else 0.72),
-            );
-            drawSmallTextFmt("{d}. {s}", assets, .{ idx + 1, @tagName(perk_id) }, 360.0, row_y, if (idx == 0) HudTextColor.accent else HudTextColor.primary);
+            const row_y = 246.0 + @as(f32, @floatFromInt(idx)) * 19.0;
+            drawSmallTextFmt("{d}.", assets, .{idx + 1}, 346.0, row_y, if (idx == 0) HudTextColor.accent else HudTextColor.primary);
+            drawSmallText(assets, game_ids.perkDisplayName(perk_id, gameplay.run_config.gore_disabled, gameplay.runner.session.state.preserve_bugs), 374.0, row_y, if (idx == 0) HudTextColor.accent else HudTextColor.primary);
         }
-        drawSmallText(assets, "Press 1-7 to select. Gameplay is paused.", 334.0, 458.0, HudTextColor.dim);
+        drawSmallText(assets, "Press 1-7 to select", 352.0, 438.0, HudTextColor.dim);
+        drawSmallText(assets, "Gameplay is paused", 352.0, 456.0, HudTextColor.dim);
         return;
     }
 

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -13,9 +13,12 @@ const local_input = cz.local_input;
 const live_audio = @import("audio/live_audio.zig");
 const window_assets = @import("window_assets.zig");
 const window_atlas = cz.window_atlas;
+const window_boot = @import("window_boot.zig");
 const window_ground = @import("window_ground.zig");
+const window_menu = @import("window_menu.zig");
 const window_projectiles = @import("window_projectiles.zig");
 const window_terrain_fx = @import("window_terrain_fx.zig");
+const window_ui = @import("window_ui.zig");
 
 const bonuses_runtime = cz.bonuses;
 const game_ids = cz.game_ids;
@@ -29,42 +32,6 @@ const window_height = 720;
 const ui_button_width: f32 = 280.0;
 const ui_button_height: f32 = 56.0;
 const world_margin: f32 = 56.0;
-
-const splash_alpha_scale: f32 = 2.0;
-const logo_time_scale: f32 = 1.1;
-const logo_time_offset: f32 = 2.0;
-const logo_skip_accel: f32 = 4.0;
-const logo_skip_jump: f32 = 16.0;
-const logo_theme_trigger: f32 = 14.0;
-const logo_10_in_start: f32 = 1.0;
-const logo_10_in_end: f32 = 2.0;
-const logo_10_hold_end: f32 = 4.0;
-const logo_10_out_end: f32 = 5.0;
-const logo_ref_in_start: f32 = 7.0;
-const logo_ref_in_end: f32 = 8.0;
-const logo_ref_hold_end: f32 = 10.0;
-const logo_ref_out_end: f32 = 11.0;
-const menu_demo_idle_start_ms: i32 = 23_000;
-const menu_label_width: f32 = 122.0;
-const menu_label_height: f32 = 28.0;
-const menu_label_base_x: f32 = -60.0;
-const menu_label_base_y: f32 = 210.0;
-const menu_label_step: f32 = 60.0;
-const menu_item_offset_x: f32 = -71.0;
-const menu_item_offset_y: f32 = -59.0;
-const menu_sign_width: f32 = 571.44;
-const menu_sign_height: f32 = 141.36;
-const menu_sign_offset_x: f32 = -576.44;
-const menu_sign_offset_y: f32 = -61.0;
-const menu_sign_pos_y: f32 = 70.0;
-const menu_sign_pos_y_small: f32 = 60.0;
-const menu_sign_pos_x_pad: f32 = 4.0;
-const menu_scale_small_threshold: i32 = 640;
-const menu_scale_large_min: i32 = 801;
-const menu_scale_large_max: i32 = 1024;
-const menu_scale_small: f32 = 0.8;
-const menu_scale_large: f32 = 1.2;
-const menu_scale_shift: f32 = 10.0;
 
 const bg_color = rl.Color.init(16, 12, 10, 255);
 const panel_color = rl.Color.init(37, 24, 20, 255);
@@ -107,40 +74,9 @@ const AssetsState = enum {
     failed,
 };
 
-const UiButton = struct {
-    label: [:0]const u8,
-    rect: rl.Rectangle,
-};
-
-const BootSequenceState = struct {
-    boot_time: f32 = 0.5,
-    fade_out_ready: bool = true,
-    fade_out_done: bool = false,
-    logo_delay_ticks: i32 = 0,
-    logo_skip: bool = false,
-    logo_active: bool = false,
-    intro_started: bool = false,
-
-    fn reset(self: *BootSequenceState) void {
-        self.* = .{};
-    }
-};
-
-const MenuScreenState = struct {
-    timeline_ms: i32 = 0,
-    focus_timer_ms: i32 = 0,
-    hovered_index: ?usize = null,
-    panel_open_sfx_played: bool = false,
-    idle_ms: i32 = 0,
-    last_mouse_pos: rl.Vector2 = .{ .x = 0.0, .y = 0.0 },
-    hover_amounts: [6]i32 = [_]i32{0} ** 6,
-
-    fn reset(self: *MenuScreenState) void {
-        self.* = .{
-            .last_mouse_pos = rl.getMousePosition(),
-        };
-    }
-};
+const UiButton = window_ui.UiButton;
+const BootSequenceState = window_boot.State;
+const MenuScreenState = window_menu.State;
 
 const GameplayScreen = struct {
     runner: live_runner.LiveRunner,
@@ -322,7 +258,6 @@ const App = struct {
     screen: Screen = .boot,
     boot: BootSequenceState = .{},
     menu: MenuScreenState = .{},
-    menu_selection: usize = 0,
     results_selection: usize = 0,
     gameplay: ?GameplayScreen = null,
     results: ?ResultsScreen = null,
@@ -409,105 +344,39 @@ const App = struct {
     }
 
     fn updateBoot(self: *App, frame_dt: f32) void {
-        const dt = @min(frame_dt, 0.1);
-        if (!self.boot.fade_out_done) {
-            self.audio.ensureIntroMusic();
-            self.boot.boot_time -= dt;
-            if (self.boot.boot_time <= 0.0) {
-                self.boot.boot_time = 0.0;
-                self.boot.fade_out_done = true;
-            }
-            return;
-        }
-
-        if (self.boot.logo_delay_ticks < 5) {
-            self.boot.logo_delay_ticks += 1;
-            return;
-        }
-
-        self.boot.logo_active = true;
-        if (self.boot.boot_time > logo_theme_trigger) {
-            self.menu.reset();
+        const result = window_boot.update(&self.boot, frame_dt);
+        if (result.finished) {
+            self.menu.openRoot();
             self.screen = .main_menu;
             return;
         }
-        if (!self.boot.intro_started) {
-            self.audio.ensureIntroMusic();
-            self.boot.intro_started = true;
-        }
-        if (!self.boot.logo_skip and bootSkipTriggered()) {
-            self.boot.logo_skip = true;
-        }
-        self.boot.boot_time += dt * logo_time_scale;
-        var t = self.boot.boot_time - logo_time_offset;
-        if (self.boot.logo_skip) {
-            if (t < logo_10_in_start or (t >= logo_10_out_end and (t < logo_ref_in_start or t >= logo_ref_out_end))) {
-                t = logo_skip_jump;
-            } else {
-                t += dt * logo_skip_accel;
-            }
-            self.boot.boot_time = t + logo_time_offset;
-        }
+        self.audio.ensureIntroMusic();
     }
 
     fn updateMainMenu(self: *App, frame_dt: f32) void {
         self.audio.ensureMenuTheme();
-        const dt_ms = @as(i32, @intFromFloat(@min(frame_dt, 0.1) * 1000.0));
-        const buttons = mainMenuButtons();
-        if (dt_ms > 0) {
-            const mouse = rl.getMousePosition();
-            const mouse_moved = mouse.x != self.menu.last_mouse_pos.x or mouse.y != self.menu.last_mouse_pos.y;
-            if (mouse_moved) {
-                self.menu.last_mouse_pos = mouse;
-            }
-
-            if (rl.getKeyPressed() != .null or rl.isMouseButtonPressed(.left) or rl.isMouseButtonPressed(.right) or mouse_moved) {
-                self.menu.idle_ms = 0;
-            } else {
-                self.menu.idle_ms += dt_ms;
-            }
-
-            self.menu.timeline_ms = @min(menuMaxTimelineMs(buttons.len), self.menu.timeline_ms + dt_ms);
-            self.menu.focus_timer_ms = @max(0, self.menu.focus_timer_ms - dt_ms);
-            if (self.menu.timeline_ms >= menuMaxTimelineMs(buttons.len) and !self.menu.panel_open_sfx_played) {
-                self.audio.playUiPanelClick();
-                self.menu.panel_open_sfx_played = true;
+        const menu_update = window_menu.update(
+            &self.menu,
+            frame_dt,
+            if (self.runtime_assets) |*assets| assets else null,
+        );
+        if (menu_update.play_panel_click and !self.menu.panel_open_sfx_played) {
+            self.audio.playUiPanelClick();
+            self.menu.panel_open_sfx_played = true;
+        }
+        if (menu_update.play_button_click) {
+            self.audio.playUiButtonClick();
+        }
+        if (menu_update.action) |action| {
+            switch (action) {
+                .start_survival => self.startNewRun(runConfigForMenuSelection(0, &self.next_seed_state)),
+                .start_rush => self.startNewRun(runConfigForMenuSelection(1, &self.next_seed_state)),
+                .start_quest_11 => self.startNewRun(runConfigForMenuSelection(2, &self.next_seed_state)),
+                .open_options => self.screen = .options,
+                .open_high_scores => self.openHighScores(),
+                .quit => self.quit_requested = true,
             }
         }
-
-        self.menu.hovered_index = hoveredMainMenuIndex(buttons[0..]);
-        if (self.menu.hovered_index) |hovered_index| {
-            if (mainMenuEntryEnabled(@intCast(hovered_index), self.menu.timeline_ms)) {
-                self.menu_selection = hovered_index;
-                self.menu.focus_timer_ms = 1000;
-            }
-        }
-        const activated = mainMenuEntryEnabled(@intCast(self.menu_selection), self.menu.timeline_ms) and buttonActivated(buttons[0..], self.menu_selection);
-        if (!activated) {
-            if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
-                self.menu_selection = previousEnabledMenuSelection(self.menu_selection, self.menu.timeline_ms, buttons.len);
-                self.menu.focus_timer_ms = 1000;
-            }
-            if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
-                self.menu_selection = nextEnabledMenuSelection(self.menu_selection, self.menu.timeline_ms, buttons.len);
-                self.menu.focus_timer_ms = 1000;
-            }
-            updateMenuHoverAmounts(&self.menu, dt_ms, buttons.len);
-            return;
-        }
-
-        self.audio.playUiButtonClick();
-
-        switch (self.menu_selection) {
-            0 => self.startNewRun(runConfigForMenuSelection(0, &self.next_seed_state)),
-            1 => self.startNewRun(runConfigForMenuSelection(1, &self.next_seed_state)),
-            2 => self.startNewRun(runConfigForMenuSelection(2, &self.next_seed_state)),
-            3 => self.screen = .options,
-            4 => self.openHighScores(),
-            5 => self.quit_requested = true,
-            else => {},
-        }
-        updateMenuHoverAmounts(&self.menu, dt_ms, buttons.len);
     }
 
     fn updateGameplay(self: *App, frame_dt: f32) void {
@@ -559,7 +428,7 @@ const App = struct {
         }
 
         const buttons = resultsButtons();
-        updateSelectionFromPointer(&self.results_selection, buttons[0..]);
+        window_ui.updateSelectionFromPointer(&self.results_selection, buttons[0..]);
         if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
             self.results_selection = if (self.results_selection == 0) buttons.len - 1 else self.results_selection - 1;
         }
@@ -567,7 +436,7 @@ const App = struct {
             self.results_selection = (self.results_selection + 1) % buttons.len;
         }
 
-        const activated = buttonActivated(buttons[0..], self.results_selection);
+        const activated = window_ui.buttonActivated(buttons[0..], self.results_selection);
         if (!activated) return;
         self.audio.playUiButtonClick();
 
@@ -581,8 +450,7 @@ const App = struct {
                     self.gameplay = null;
                 }
                 self.results = null;
-                self.menu_selection = 0;
-                self.menu.reset();
+                self.menu.openRoot();
                 self.screen = .main_menu;
             },
             else => {},
@@ -592,7 +460,7 @@ const App = struct {
     fn updateHighScores(self: *App) void {
         if (self.high_scores) |*high_scores| {
             const buttons = highScoresButtons();
-            updateSelectionFromPointer(&high_scores.selection, buttons[0..]);
+            window_ui.updateSelectionFromPointer(&high_scores.selection, buttons[0..]);
             if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
                 high_scores.selection = if (high_scores.selection == 0) buttons.len - 1 else high_scores.selection - 1;
             }
@@ -600,7 +468,7 @@ const App = struct {
                 high_scores.selection = (high_scores.selection + 1) % buttons.len;
             }
 
-            const activated = buttonActivated(buttons[0..], high_scores.selection);
+            const activated = window_ui.buttonActivated(buttons[0..], high_scores.selection);
             if (!activated) return;
             self.audio.playUiButtonClick();
 
@@ -609,8 +477,7 @@ const App = struct {
                 1 => self.setHighScoresMode(.rush),
                 2 => self.setHighScoresMode(.quests),
                 3 => {
-                    self.menu_selection = 3;
-                    self.menu.reset();
+                    self.menu.openRoot();
                     self.screen = .main_menu;
                 },
                 else => {},
@@ -620,7 +487,7 @@ const App = struct {
 
     fn updateOptions(self: *App) void {
         const buttons = optionsButtons();
-        updateSelectionFromPointer(&self.options.selection, buttons[0..]);
+        window_ui.updateSelectionFromPointer(&self.options.selection, buttons[0..]);
         if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
             self.options.selection = if (self.options.selection == 0) buttons.len - 1 else self.options.selection - 1;
         }
@@ -628,7 +495,7 @@ const App = struct {
             self.options.selection = (self.options.selection + 1) % buttons.len;
         }
 
-        const activate = buttonActivated(buttons[0..], self.options.selection);
+        const activate = window_ui.buttonActivated(buttons[0..], self.options.selection);
         const adjust_left = rl.isKeyPressed(.left) or rl.isKeyPressed(.a);
         const adjust_right = rl.isKeyPressed(.right) or rl.isKeyPressed(.d);
         if (!(activate or adjust_left or adjust_right)) return;
@@ -685,8 +552,7 @@ const App = struct {
             },
             5 => {
                 self.audio.playUiButtonClick();
-                self.menu_selection = 3;
-                self.menu.reset();
+                self.menu.openRoot();
                 self.screen = .main_menu;
             },
             else => {},
@@ -701,7 +567,7 @@ const App = struct {
         collectNameInput(highscore);
 
         const buttons = resultsHighscoreButtons();
-        updateSelectionFromPointer(&highscore.selection, buttons[0..]);
+        window_ui.updateSelectionFromPointer(&highscore.selection, buttons[0..]);
         if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
             highscore.selection = if (highscore.selection == 0) buttons.len - 1 else highscore.selection - 1;
         }
@@ -709,7 +575,7 @@ const App = struct {
             highscore.selection = (highscore.selection + 1) % buttons.len;
         }
 
-        if (!buttonActivated(buttons[0..], highscore.selection)) return;
+        if (!window_ui.buttonActivated(buttons[0..], highscore.selection)) return;
         self.audio.playUiButtonClick();
 
         switch (highscore.selection) {
@@ -966,53 +832,13 @@ const App = struct {
     }
 
     fn drawBoot(self: *const App) void {
-        rl.clearBackground(rl.Color.black);
-        if (self.runtime_assets) |*runtime_assets| {
-            if (!self.boot.fade_out_done) {
-                drawBootSplash(runtime_assets, clamp01(self.boot.boot_time * splash_alpha_scale));
-            } else if (self.boot.logo_active) {
-                drawBootCompanyLogo(runtime_assets, self.boot.boot_time - logo_time_offset);
-            }
-        } else {
-            drawCenteredText("CRIMSON-ZIG", 144, 72, accent_color);
-            drawCenteredText("Desktop gameplay slice booting", 232, 24, text_color);
-            drawCenteredText("raylib shell + live Zig runtime + archive-backed assets", 270, 18, muted_text);
-        }
-        drawAssetsStatus(self);
-        drawAudioStatus(&self.audio);
+        window_boot.draw(&self.boot, if (self.runtime_assets) |*assets| assets else null);
+        drawStartupDiagnostics(self);
     }
 
     fn drawMainMenu(self: *const App) void {
-        if (self.runtime_assets) |*runtime_assets| {
-            rl.clearBackground(rl.Color.black);
-            drawMenuAssets(self, runtime_assets);
-        }
-        if (self.runtime_assets == null) {
-            rl.clearBackground(bg_color);
-            drawBackdrop();
-            drawCenteredText("CRIMSON-ZIG", 118, 68, accent_color);
-            drawCenteredText("Native survival / rush / quest gameplay slice", 198, 24, text_color);
-            drawCenteredText("Live Zig runtime now boots multiple real modes.", 232, 18, muted_text);
-        }
-        drawAssetsStatus(self);
-        drawAudioStatus(&self.audio);
-
-        const buttons = mainMenuButtons();
-        for (buttons, 0..) |button, idx| {
-            const mouse_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
-            if (self.runtime_assets) |*assets| {
-                drawMainMenuButton(self, assets, button, idx, idx == self.menu_selection, mouse_hovered);
-            } else {
-                drawButton(button, idx == self.menu_selection, mouse_hovered, null);
-            }
-        }
-
-        if (self.runtime_assets) |*runtime_assets| {
-            drawSmallText(runtime_assets, "Enter activates selected item. Mouse works too.", 34.0, 646.0, HudTextColor.dim);
-            drawSmallText(runtime_assets, "Current menu still routes directly into the Zig gameplay shell.", 34.0, 664.0, HudTextColor.dim);
-        } else {
-            drawCenteredText("Enter starts. High scores now read real Zig .hi tables. Esc closes the window.", 620, 18, muted_text);
-        }
+        window_menu.draw(&self.menu, if (self.runtime_assets) |*assets| assets else null);
+        drawStartupDiagnostics(self);
     }
 
     fn drawGameplay(self: *App) void {
@@ -1106,7 +932,7 @@ const App = struct {
                     false
             else
                 idx == self.results_selection;
-            drawButton(button, selected, mouse_hovered, if (self.runtime_assets) |*assets| assets else null);
+            window_ui.drawButton(button, selected, mouse_hovered, if (self.runtime_assets) |*assets| assets else null);
         }
         drawAudioStatus(&self.audio);
     }
@@ -1141,7 +967,7 @@ const App = struct {
         const selected_idx = if (self.high_scores) |high_scores| high_scores.selection else 0;
         for (buttons, 0..) |button, idx| {
             const mouse_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
-            drawButton(button, idx == selected_idx, mouse_hovered, if (self.runtime_assets) |*assets| assets else null);
+            window_ui.drawButton(button, idx == selected_idx, mouse_hovered, if (self.runtime_assets) |*assets| assets else null);
         }
         drawAudioStatus(&self.audio);
     }
@@ -1164,7 +990,7 @@ const App = struct {
         const buttons = optionsButtons();
         for (buttons, 0..) |button, idx| {
             const mouse_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
-            drawButton(button, idx == self.options.selection, mouse_hovered, if (self.runtime_assets) |*assets| assets else null);
+            window_ui.drawButton(button, idx == self.options.selection, mouse_hovered, if (self.runtime_assets) |*assets| assets else null);
         }
         drawAudioStatus(&self.audio);
     }
@@ -1208,183 +1034,6 @@ fn drawBackdrop() void {
     rl.drawCircle(160, height - 80, 220.0, rl.Color.init(58, 23, 18, 90));
 }
 
-fn clamp01(value: f32) f32 {
-    return std.math.clamp(value, @as(f32, 0.0), @as(f32, 1.0));
-}
-
-fn bootSkipTriggered() bool {
-    if (rl.getKeyPressed() != .null) return true;
-    if (rl.isMouseButtonPressed(.left)) return true;
-    if (rl.isMouseButtonPressed(.right)) return true;
-    return false;
-}
-
-fn bootLogoAlpha(t: f32, in_start: f32, in_end: f32, hold_end: f32, out_end: f32) ?f32 {
-    if (t < in_start or t >= out_end) return null;
-    if (t < in_end) return clamp01(t - in_start);
-    if (t < hold_end) return 1.0;
-    return clamp01(1.0 - (t - hold_end));
-}
-
-fn drawBootCompanyLogo(runtime_assets: *const window_assets.RuntimeAssets, t: f32) void {
-    const LogoState = struct {
-        texture: rl.Texture2D,
-        alpha: f32,
-    };
-    const logo_state: LogoState = blk: {
-        if (bootLogoAlpha(t, logo_10_in_start, logo_10_in_end, logo_10_hold_end, logo_10_out_end)) |alpha| {
-            break :blk .{ .texture = runtime_assets.texture(.splash_10tons), .alpha = alpha };
-        }
-        if (bootLogoAlpha(t, logo_ref_in_start, logo_ref_in_end, logo_ref_hold_end, logo_ref_out_end)) |alpha| {
-            break :blk .{ .texture = runtime_assets.texture(.splash_reflexive), .alpha = alpha };
-        }
-        return;
-    };
-
-    const texture = logo_state.texture;
-    const x = (@as(f32, @floatFromInt(rl.getScreenWidth())) - @as(f32, @floatFromInt(texture.width))) * 0.5;
-    const y = (@as(f32, @floatFromInt(rl.getScreenHeight())) - @as(f32, @floatFromInt(texture.height))) * 0.5;
-    drawTextureFit(
-        texture,
-        rl.Rectangle.init(x, y, @floatFromInt(texture.width), @floatFromInt(texture.height)),
-        colorWithAlpha(rl.Color.white, logo_state.alpha),
-    );
-}
-
-fn drawBootSplash(runtime_assets: *const window_assets.RuntimeAssets, alpha: f32) void {
-    if (!(alpha > 0.0)) return;
-    const screen_w = @as(f32, @floatFromInt(rl.getScreenWidth()));
-    const screen_h = @as(f32, @floatFromInt(rl.getScreenHeight()));
-    const logo = runtime_assets.texture(.cl_logo);
-    const band_height = @as(f32, @floatFromInt(logo.height)) * 2.0;
-    const band_top = (screen_h - band_height) * 0.5 - 4.0;
-    const band_bottom = band_top + band_height;
-    const line_color = colorWithAlpha(rl.Color.init(149, 175, 198, 255), alpha * 0.7);
-    rl.drawRectangle(0, @intFromFloat(band_top), rl.getScreenWidth(), 1, line_color);
-    rl.drawRectangle(0, @intFromFloat(band_bottom), rl.getScreenWidth(), 1, line_color);
-    rl.drawRectangle(0, @intFromFloat(band_top), 1, @intFromFloat(band_height), line_color);
-    rl.drawRectangle(rl.getScreenWidth() - 1, @intFromFloat(band_top), 1, @intFromFloat(band_height), line_color);
-
-    const logo_x = (screen_w - @as(f32, @floatFromInt(logo.width))) * 0.5;
-    const logo_y = (screen_h - @as(f32, @floatFromInt(logo.height))) * 0.5;
-    drawTextureFit(logo, rl.Rectangle.init(logo_x, logo_y, @floatFromInt(logo.width), @floatFromInt(logo.height)), colorWithAlpha(rl.Color.white, alpha));
-    drawTextureFit(runtime_assets.texture(.loading), rl.Rectangle.init(screen_w * 0.5 + 128.0, screen_h * 0.5 + 16.0, @floatFromInt(runtime_assets.texture(.loading).width), @floatFromInt(runtime_assets.texture(.loading).height)), colorWithAlpha(rl.Color.white, alpha));
-    const esrb = runtime_assets.texture(.logo_esrb);
-    drawTextureFit(esrb, rl.Rectangle.init(screen_w - @as(f32, @floatFromInt(esrb.width)) - 1.0, screen_h - @as(f32, @floatFromInt(esrb.height)) - 1.0, @floatFromInt(esrb.width), @floatFromInt(esrb.height)), colorWithAlpha(rl.Color.white, alpha));
-}
-
-fn drawMenuAssets(app: *const App, runtime_assets: *const window_assets.RuntimeAssets) void {
-    drawTextureFit(
-        runtime_assets.texture(.backplasma),
-        rl.Rectangle.init(0.0, 0.0, @floatFromInt(rl.getScreenWidth()), @floatFromInt(rl.getScreenHeight())),
-        rl.Color.init(255, 255, 255, 92),
-    );
-    rl.drawRectangle(0, 0, rl.getScreenWidth(), rl.getScreenHeight(), rl.Color.init(16, 11, 9, 160));
-    drawMainMenuSign(app, runtime_assets);
-}
-
-fn menuUiElementAnim(index: usize, start_ms: i32, end_ms: i32, width: f32, timeline_ms: i32) struct { angle_rad: f32, offset_x: f32 } {
-    if (start_ms <= end_ms or width <= 0.0) return .{ .angle_rad = 0.0, .offset_x = 0.0 };
-    var angle: f32 = 0.0;
-    var offset_x: f32 = 0.0;
-    if (timeline_ms < end_ms) {
-        angle = 1.5707964;
-        offset_x = -@abs(width);
-    } else if (timeline_ms < start_ms) {
-        const p = @as(f32, @floatFromInt(timeline_ms - end_ms)) / @as(f32, @floatFromInt(start_ms - end_ms));
-        angle = 1.5707964 * (1.0 - p);
-        offset_x = (1.0 - p) * -@abs(width);
-    }
-    if (index == 0) angle = -@abs(angle);
-    return .{ .angle_rad = angle, .offset_x = offset_x };
-}
-
-fn mainMenuLabelAlpha(counter_value: i32) u8 {
-    return @intCast(100 + @divTrunc(counter_value * 155, 1000));
-}
-
-fn mainMenuSignLayoutScale(screen_w: i32) struct { scale: f32, shift_x: f32 } {
-    if (screen_w <= menu_scale_small_threshold) return .{ .scale = menu_scale_small, .shift_x = menu_scale_shift };
-    if (screen_w >= menu_scale_large_min and screen_w <= menu_scale_large_max) return .{ .scale = menu_scale_large, .shift_x = menu_scale_shift };
-    return .{ .scale = 1.0, .shift_x = 0.0 };
-}
-
-fn drawMainMenuSign(app: *const App, runtime_assets: *const window_assets.RuntimeAssets) void {
-    const screen_w = rl.getScreenWidth();
-    const sign = runtime_assets.texture(.ui_sign_crimson);
-    const layout = mainMenuSignLayoutScale(screen_w);
-    const sign_pos = rl.Vector2.init(
-        @as(f32, @floatFromInt(screen_w)) + menu_sign_pos_x_pad,
-        if (screen_w > menu_scale_small_threshold) menu_sign_pos_y else menu_sign_pos_y_small,
-    );
-    const sign_w = menu_sign_width * layout.scale;
-    const sign_h = menu_sign_height * layout.scale;
-    const offset_x = menu_sign_offset_x * layout.scale + layout.shift_x;
-    const offset_y = menu_sign_offset_y * layout.scale;
-    const anim = menuUiElementAnim(0, 300, 0, sign_w, app.menu.timeline_ms);
-    const rotation_deg = radiansToDegrees(anim.angle_rad);
-
-    rl.drawTexturePro(
-        sign,
-        rl.Rectangle.init(0.0, 0.0, @floatFromInt(sign.width), @floatFromInt(sign.height)),
-        rl.Rectangle.init(sign_pos.x, sign_pos.y, sign_w, sign_h),
-        rl.Vector2.init(-offset_x, -offset_y),
-        rotation_deg,
-        rl.Color.white,
-    );
-}
-
-fn drawMainMenuButton(app: *const App, runtime_assets: *const window_assets.RuntimeAssets, button: UiButton, idx: usize, selected: bool, hovered: bool) void {
-    const item = runtime_assets.texture(.ui_menu_item);
-    const scale_info = menuItemScale(idx);
-    const pos_x = menuSlotPosX(idx);
-    const pos_y = menu_label_base_y + @as(f32, @floatFromInt(idx)) * menu_label_step + menuWidescreenYShift(@floatFromInt(rl.getScreenWidth()));
-    const anim = menuUiElementAnim(idx + 2, menuSlotStartMs(idx), menuSlotEndMs(idx), @as(f32, @floatFromInt(item.width)) * scale_info.scale, app.menu.timeline_ms);
-    const dst = rl.Rectangle.init(pos_x, pos_y, @as(f32, @floatFromInt(item.width)) * scale_info.scale, @as(f32, @floatFromInt(item.height)) * scale_info.scale);
-    const origin = rl.Vector2.init(-(menu_item_offset_x * scale_info.scale), -(menu_item_offset_y * scale_info.scale - scale_info.local_y_shift));
-    const rotation_deg = radiansToDegrees(anim.angle_rad);
-
-    rl.drawTexturePro(
-        item,
-        rl.Rectangle.init(0.0, 0.0, @floatFromInt(item.width), @floatFromInt(item.height)),
-        dst,
-        origin,
-        rotation_deg,
-        rl.Color.white,
-    );
-
-    const hover_counter = if (selected and app.menu.focus_timer_ms > 0) app.menu.focus_timer_ms else app.menu.hover_amounts[idx];
-    const label_alpha = if (mainMenuEntryEnabled(@intCast(idx), app.menu.timeline_ms)) mainMenuLabelAlpha(hover_counter) else @as(u8, 100);
-    const text_alpha: f32 = if (selected or hovered) 1.0 else 0.7;
-    const label_width = measureSmallText(runtime_assets, button.label);
-    const label_x = button.rect.x + (button.rect.width - label_width) * 0.5 + 1.0;
-    const label_y = button.rect.y + 11.0;
-    drawSmallText(runtime_assets, button.label, label_x, label_y, rl.Color.init(255, 255, 255, @intFromFloat(@as(f32, @floatFromInt(label_alpha)) * text_alpha)));
-}
-
-fn drawAssetsStatus(app: *const App) void {
-    switch (app.assets_state) {
-        .loaded => {
-            const runtime_assets = &(app.runtime_assets orelse return);
-            drawTextFmt(
-                "assets: {d} textures / {d} archive entries from {s}",
-                .{ runtime_assets.textureCount(), runtime_assets.archive_entry_count, runtime_assets.assets_dir },
-                28,
-                688,
-                18,
-                muted_text,
-            );
-        },
-        .unavailable => drawTextSlice("assets: no crimson.paq found; using primitive fallback", 28, 688, 18, muted_text),
-        .failed => {
-            drawTextSlice("assets: load failed; using primitive fallback", 28, 668, 18, muted_text);
-            if (app.assets_message) |message| {
-                drawTextSlice(message, 28, 688, 18, rl.Color.orange);
-            }
-        },
-    }
-}
-
 fn drawAudioStatus(audio: *const live_audio.Bridge) void {
     switch (audio.load_state) {
         .loaded => {
@@ -1406,6 +1055,24 @@ fn drawAudioStatus(audio: *const live_audio.Bridge) void {
                 drawTextSlice(message, 420, 708, 18, rl.Color.orange);
             }
         },
+    }
+}
+
+fn drawStartupDiagnostics(app: *const App) void {
+    switch (app.assets_state) {
+        .loaded => {},
+        .unavailable => drawTextSlice("assets: no crimson.paq found; using primitive fallback", 28, 688, 18, muted_text),
+        .failed => {
+            drawTextSlice("assets: load failed; using primitive fallback", 28, 668, 18, muted_text);
+            if (app.assets_message) |message| {
+                drawTextSlice(message, 28, 688, 18, rl.Color.orange);
+            }
+        },
+    }
+
+    switch (app.audio.load_state) {
+        .loaded => {},
+        .unavailable, .disabled, .failed => drawAudioStatus(&app.audio),
     }
 }
 
@@ -1519,83 +1186,29 @@ fn drawTextureTiled(texture: rl.Texture2D, area: rl.Rectangle, tint: rl.Color) v
     }
 }
 
-fn menuWidescreenYShift(screen_w: f32) f32 {
-    return (screen_w / 640.0) * 150.0 - 150.0;
-}
-
-fn menuSlotPosX(slot: usize) f32 {
-    return menu_label_base_x - @as(f32, @floatFromInt(slot)) * 20.0;
-}
-
-fn menuSlotStartMs(slot: usize) i32 {
-    return @intCast((slot + 2) * 100 + 300);
-}
-
-fn menuSlotEndMs(slot: usize) i32 {
-    return @intCast((slot + 2) * 100);
-}
-
-fn menuMaxTimelineMs(slot_count: usize) i32 {
-    var max_ms: i32 = 300;
-    for (0..slot_count) |slot| {
-        max_ms = @max(max_ms, menuSlotStartMs(slot));
-    }
-    return max_ms;
-}
-
-fn menuItemScale(slot: usize) struct { scale: f32, local_y_shift: f32 } {
-    if (rl.getScreenWidth() < 641) {
-        return .{ .scale = 0.9, .local_y_shift = @as(f32, @floatFromInt(slot)) * 11.0 };
-    }
-    return .{ .scale = 1.0, .local_y_shift = 0.0 };
-}
-
-fn mainMenuItemRect(slot: usize, item_texture: ?rl.Texture2D) rl.Rectangle {
-    const y_shift = menuWidescreenYShift(@floatFromInt(rl.getScreenWidth()));
-    const item_width: f32 = if (item_texture) |item| @floatFromInt(item.width) else 325.0;
-    const item_height: f32 = if (item_texture) |item| @floatFromInt(item.height) else 54.0;
-    const scale = menuItemScale(slot);
-    const width = item_width * scale.scale;
-    const height = item_height * scale.scale;
-    const x = menuSlotPosX(slot) + menu_item_offset_x * scale.scale;
-    const y = menu_label_base_y + @as(f32, @floatFromInt(slot)) * menu_label_step + y_shift + menu_item_offset_y * scale.scale - scale.local_y_shift;
-    return rl.Rectangle.init(x, y, width, height);
-}
-
-fn mainMenuButtons() [6]UiButton {
-    return .{
-        .{ .label = "START SURVIVAL", .rect = mainMenuItemRect(0, null) },
-        .{ .label = "START RUSH", .rect = mainMenuItemRect(1, null) },
-        .{ .label = "START QUEST 1.1", .rect = mainMenuItemRect(2, null) },
-        .{ .label = "OPTIONS", .rect = mainMenuItemRect(3, null) },
-        .{ .label = "HIGH SCORES", .rect = mainMenuItemRect(4, null) },
-        .{ .label = "QUIT", .rect = mainMenuItemRect(5, null) },
-    };
-}
-
 fn resultsButtons() [2]UiButton {
     const center_x: f32 = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
     return .{
-        .{ .label = "RESTART", .rect = centeredRect(center_x, 586.0, ui_button_width, ui_button_height) },
-        .{ .label = "MAIN MENU", .rect = centeredRect(center_x, 658.0, ui_button_width, ui_button_height) },
+        .{ .label = "RESTART", .rect = window_ui.centeredRect(center_x, 586.0, ui_button_width, ui_button_height) },
+        .{ .label = "MAIN MENU", .rect = window_ui.centeredRect(center_x, 658.0, ui_button_width, ui_button_height) },
     };
 }
 
 fn resultsHighscoreButtons() [2]UiButton {
     const center_x: f32 = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
     return .{
-        .{ .label = "SAVE SCORE", .rect = centeredRect(center_x, 586.0, ui_button_width, ui_button_height) },
-        .{ .label = "SKIP", .rect = centeredRect(center_x, 658.0, ui_button_width, ui_button_height) },
+        .{ .label = "SAVE SCORE", .rect = window_ui.centeredRect(center_x, 586.0, ui_button_width, ui_button_height) },
+        .{ .label = "SKIP", .rect = window_ui.centeredRect(center_x, 658.0, ui_button_width, ui_button_height) },
     };
 }
 
 fn highScoresButtons() [4]UiButton {
     const center_x: f32 = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
     return .{
-        .{ .label = "SURVIVAL", .rect = centeredRect(center_x, 560.0, 220.0, 48.0) },
-        .{ .label = "RUSH", .rect = centeredRect(center_x, 616.0, 220.0, 48.0) },
-        .{ .label = "QUEST 1.1", .rect = centeredRect(center_x, 672.0, 220.0, 48.0) },
-        .{ .label = "BACK", .rect = centeredRect(center_x + 262.0, 672.0, 150.0, 48.0) },
+        .{ .label = "SURVIVAL", .rect = window_ui.centeredRect(center_x, 560.0, 220.0, 48.0) },
+        .{ .label = "RUSH", .rect = window_ui.centeredRect(center_x, 616.0, 220.0, 48.0) },
+        .{ .label = "QUEST 1.1", .rect = window_ui.centeredRect(center_x, 672.0, 220.0, 48.0) },
+        .{ .label = "BACK", .rect = window_ui.centeredRect(center_x + 262.0, 672.0, 150.0, 48.0) },
     };
 }
 
@@ -1608,81 +1221,6 @@ fn optionsButtons() [6]UiButton {
         .{ .label = "HARDCORE", .rect = rl.Rectangle.init(304.0, 436.0, 420.0, 44.0) },
         .{ .label = "BACK", .rect = rl.Rectangle.init(304.0, 522.0, 220.0, 48.0) },
     };
-}
-
-fn centeredRect(center_x: f32, top_y: f32, width: f32, height: f32) rl.Rectangle {
-    return .{
-        .x = center_x - width * 0.5,
-        .y = top_y,
-        .width = width,
-        .height = height,
-    };
-}
-
-fn updateSelectionFromPointer(selection: *usize, buttons: []const UiButton) void {
-    const mouse = rl.getMousePosition();
-    for (buttons, 0..) |button, idx| {
-        if (rl.checkCollisionPointRec(mouse, button.rect)) {
-            selection.* = idx;
-            return;
-        }
-    }
-}
-
-fn hoveredMainMenuIndex(buttons: []const UiButton) ?usize {
-    const mouse = rl.getMousePosition();
-    for (buttons, 0..) |button, idx| {
-        if (rl.checkCollisionPointRec(mouse, button.rect)) return idx;
-    }
-    return null;
-}
-
-fn mainMenuEntryEnabled(slot: i32, timeline_ms: i32) bool {
-    return timeline_ms >= menuSlotStartMs(@intCast(slot));
-}
-
-fn previousEnabledMenuSelection(selection: usize, timeline_ms: i32, count: usize) usize {
-    var idx = selection;
-    var attempts: usize = 0;
-    while (attempts < count) : (attempts += 1) {
-        idx = if (idx == 0) count - 1 else idx - 1;
-        if (mainMenuEntryEnabled(@intCast(idx), timeline_ms)) return idx;
-    }
-    return selection;
-}
-
-fn nextEnabledMenuSelection(selection: usize, timeline_ms: i32, count: usize) usize {
-    var idx = selection;
-    var attempts: usize = 0;
-    while (attempts < count) : (attempts += 1) {
-        idx = (idx + 1) % count;
-        if (mainMenuEntryEnabled(@intCast(idx), timeline_ms)) return idx;
-    }
-    return selection;
-}
-
-fn updateMenuHoverAmounts(menu: *MenuScreenState, dt_ms: i32, count: usize) void {
-    for (0..count) |idx| {
-        const hovered = menu.hovered_index != null and menu.hovered_index.? == idx;
-        if (hovered) {
-            menu.hover_amounts[idx] = std.math.clamp(menu.hover_amounts[idx] + dt_ms * 6, 0, 1000);
-        } else {
-            menu.hover_amounts[idx] = std.math.clamp(menu.hover_amounts[idx] - dt_ms * 2, 0, 1000);
-        }
-    }
-}
-
-fn buttonActivated(buttons: []const UiButton, selection: usize) bool {
-    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space)) return true;
-
-    if (!rl.isMouseButtonPressed(.left)) return false;
-    const mouse = rl.getMousePosition();
-    for (buttons, 0..) |button, idx| {
-        if (idx == selection and rl.checkCollisionPointRec(mouse, button.rect)) {
-            return true;
-        }
-    }
-    return false;
 }
 
 fn collectNameInput(highscore: *ResultsHighscoreState) void {
@@ -1699,61 +1237,6 @@ fn collectNameInput(highscore: *ResultsHighscoreState) void {
         highscore.input_len -= 1;
         highscore.input[highscore.input_len] = 0;
     }
-}
-
-fn drawButton(
-    button: UiButton,
-    selected: bool,
-    hovered: bool,
-    runtime_assets: ?*const window_assets.RuntimeAssets,
-) void {
-    if (runtime_assets) |assets| {
-        const scale = button.rect.height / 32.0;
-        const texture = if (button.rect.width > 120.0) assets.texture(.ui_button_md) else assets.texture(.ui_button_sm);
-        const glow_alpha: f32 = if (selected or hovered) 0.92 else 0.72;
-        if (selected or hovered) {
-            rl.drawRectangleRounded(
-                .{
-                    .x = button.rect.x + 12.0 * scale,
-                    .y = button.rect.y + 5.0 * scale,
-                    .width = button.rect.width - 24.0 * scale,
-                    .height = button.rect.height - 10.0 * scale,
-                },
-                0.18,
-                8,
-                rl.Color.init(128, 128, 178, @intFromFloat(glow_alpha * 120.0)),
-            );
-        }
-        const plate_alpha: f32 = if (selected or hovered) 255.0 else 230.0;
-        rl.drawTexturePro(
-            texture,
-            rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height)),
-            button.rect,
-            rl.Vector2.zero(),
-            0.0,
-            rl.Color.init(255, 255, 255, @intFromFloat(plate_alpha)),
-        );
-
-        const label_width = measureSmallText(assets, button.label);
-        drawSmallText(
-            assets,
-            button.label,
-            button.rect.x + (button.rect.width - label_width) * 0.5 + 1.0,
-            button.rect.y + 10.0,
-            colorWithAlpha(rl.Color.white, if (selected or hovered) 1.0 else 0.7),
-        );
-        return;
-    }
-
-    const fill = if (selected or hovered) accent_color else panel_color;
-    const outline = if (selected or hovered) rl.Color.gold else panel_outline;
-    rl.drawRectangleRounded(button.rect, 0.2, 8, fill);
-    rl.drawRectangleRoundedLinesEx(button.rect, 0.2, 8, 2.0, outline);
-
-    const label_width = rl.measureText(button.label, 24);
-    const label_x = @as(i32, @intFromFloat(button.rect.x + (button.rect.width - @as(f32, @floatFromInt(label_width))) * 0.5));
-    const label_y = @as(i32, @intFromFloat(button.rect.y + (button.rect.height - 24.0) * 0.5));
-    rl.drawText(button.label, label_x, label_y, 24, text_color);
 }
 
 fn buildWorldCamera(world_size: f32, shake_offset: state_mod.Vec2) rl.Camera2D {

--- a/crimson-zig/src/window_menu.zig
+++ b/crimson-zig/src/window_menu.zig
@@ -1,0 +1,494 @@
+const std = @import("std");
+const rl = @import("raylib");
+
+const window_assets = @import("window_assets.zig");
+const window_ui = @import("window_ui.zig");
+
+pub const menu_demo_idle_start_ms: i32 = 23_000;
+const menu_label_width: f32 = 122.0;
+const menu_label_height: f32 = 28.0;
+const menu_label_row_height: f32 = 32.0;
+const menu_label_offset_x: f32 = 271.0;
+const menu_label_offset_y: f32 = -37.0;
+const menu_label_base_x: f32 = -60.0;
+const menu_label_base_y: f32 = 210.0;
+const menu_label_step: f32 = 60.0;
+const menu_item_offset_x: f32 = -71.0;
+const menu_item_offset_y: f32 = -59.0;
+const menu_sign_width: f32 = 571.44;
+const menu_sign_height: f32 = 141.36;
+const menu_sign_offset_x: f32 = -576.44;
+const menu_sign_offset_y: f32 = -61.0;
+const menu_sign_pos_y: f32 = 70.0;
+const menu_sign_pos_y_small: f32 = 60.0;
+const menu_sign_pos_x_pad: f32 = 4.0;
+const menu_scale_small_threshold: i32 = 640;
+const menu_scale_large_min: i32 = 801;
+const menu_scale_large_max: i32 = 1024;
+const menu_scale_small: f32 = 0.8;
+const menu_scale_large: f32 = 1.2;
+const menu_scale_shift: f32 = 10.0;
+
+const label_row_play_game: i32 = 1;
+const label_row_options: i32 = 2;
+const label_row_statistics: i32 = 3;
+const label_row_quit: i32 = 6;
+const label_row_back: i32 = 7;
+
+pub const Page = enum {
+    root,
+    play_game,
+};
+
+pub const Action = enum {
+    start_survival,
+    start_rush,
+    start_quest_11,
+    open_options,
+    open_high_scores,
+    quit,
+};
+
+pub const State = struct {
+    page: Page = .root,
+    selection: usize = 0,
+    timeline_ms: i32 = 0,
+    focus_timer_ms: i32 = 0,
+    hovered_index: ?usize = null,
+    panel_open_sfx_played: bool = false,
+    idle_ms: i32 = 0,
+    last_mouse_pos: rl.Vector2 = .{ .x = 0.0, .y = 0.0 },
+    hover_amounts: [4]i32 = [_]i32{0} ** 4,
+
+    pub fn reset(self: *State) void {
+        self.* = .{
+            .last_mouse_pos = rl.getMousePosition(),
+        };
+    }
+
+    pub fn openRoot(self: *State) void {
+        self.reset();
+    }
+
+    fn openPlayGame(self: *State) void {
+        self.page = .play_game;
+        self.selection = 0;
+        self.hovered_index = null;
+        self.focus_timer_ms = 1000;
+    }
+
+    fn openMain(self: *State) void {
+        self.page = .root;
+        self.selection = 0;
+        self.hovered_index = null;
+        self.focus_timer_ms = 1000;
+    }
+};
+
+pub const UpdateResult = struct {
+    action: ?Action = null,
+    play_panel_click: bool = false,
+    play_button_click: bool = false,
+};
+
+const RootEntry = struct {
+    slot: usize,
+    row: i32,
+    action: Action,
+};
+
+const root_entries = [_]RootEntry{
+    .{ .slot = 0, .row = label_row_play_game, .action = .start_survival }, // action unused on root
+    .{ .slot = 1, .row = label_row_options, .action = .open_options },
+    .{ .slot = 2, .row = label_row_statistics, .action = .open_high_scores },
+    .{ .slot = 3, .row = label_row_quit, .action = .quit },
+};
+
+pub fn update(state: *State, frame_dt: f32, runtime_assets: ?*const window_assets.RuntimeAssets) UpdateResult {
+    const dt_ms = @as(i32, @intFromFloat(@min(frame_dt, 0.1) * 1000.0));
+    return switch (state.page) {
+        .root => updateRoot(state, dt_ms, runtime_assets),
+        .play_game => updatePlayGame(state),
+    };
+}
+
+pub fn draw(state: *const State, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+    if (runtime_assets) |assets| {
+        drawMenuBackdrop(assets);
+        switch (state.page) {
+            .root => drawRootMenu(state, assets),
+            .play_game => drawPlayGamePanel(state, assets),
+        }
+        return;
+    }
+
+    rl.clearBackground(rl.Color.init(16, 12, 10, 255));
+    drawFallbackBackdrop();
+    switch (state.page) {
+        .root => drawFallbackRoot(state),
+        .play_game => drawFallbackPlayGame(state),
+    }
+}
+
+fn updateRoot(state: *State, dt_ms: i32, runtime_assets: ?*const window_assets.RuntimeAssets) UpdateResult {
+    if (dt_ms > 0) {
+        const mouse = rl.getMousePosition();
+        const mouse_moved = mouse.x != state.last_mouse_pos.x or mouse.y != state.last_mouse_pos.y;
+        if (mouse_moved) {
+            state.last_mouse_pos = mouse;
+        }
+
+        if (rl.getKeyPressed() != .null or rl.isMouseButtonPressed(.left) or rl.isMouseButtonPressed(.right) or mouse_moved) {
+            state.idle_ms = 0;
+        } else {
+            state.idle_ms += dt_ms;
+        }
+
+        state.timeline_ms = @min(rootTimelineMaxMs(), state.timeline_ms + dt_ms);
+        state.focus_timer_ms = @max(0, state.focus_timer_ms - dt_ms);
+    }
+
+    state.hovered_index = hoveredRootIndex(runtime_assets);
+    if (state.hovered_index) |hovered_index| {
+        if (rootEntryEnabled(hovered_index, state.timeline_ms)) {
+            state.selection = hovered_index;
+            state.focus_timer_ms = 1000;
+        }
+    }
+
+    if (!activateRootSelection(state)) {
+        if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
+            state.selection = previousEnabledRootSelection(state.selection, state.timeline_ms);
+            state.focus_timer_ms = 1000;
+        }
+        if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
+            state.selection = nextEnabledRootSelection(state.selection, state.timeline_ms);
+            state.focus_timer_ms = 1000;
+        }
+        updateHoverAmounts(state, dt_ms);
+        return .{
+            .play_panel_click = dt_ms > 0 and state.timeline_ms >= rootTimelineMaxMs() and !state.panel_open_sfx_played,
+        };
+    }
+
+    var result: UpdateResult = .{ .play_button_click = true };
+    switch (state.selection) {
+        0 => state.openPlayGame(),
+        1 => result.action = .open_options,
+        2 => result.action = .open_high_scores,
+        3 => result.action = .quit,
+        else => {},
+    }
+    updateHoverAmounts(state, dt_ms);
+    if (dt_ms > 0 and state.timeline_ms >= rootTimelineMaxMs() and !state.panel_open_sfx_played) {
+        result.play_panel_click = true;
+    }
+    return result;
+}
+
+fn updatePlayGame(state: *State) UpdateResult {
+    const buttons = playGameButtons();
+    window_ui.updateSelectionFromPointer(&state.selection, buttons[0..]);
+
+    if (rl.isKeyPressed(.escape)) {
+        state.openMain();
+        return .{ .play_button_click = true };
+    }
+    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
+        state.selection = if (state.selection == 0) buttons.len - 1 else state.selection - 1;
+    }
+    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
+        state.selection = (state.selection + 1) % buttons.len;
+    }
+
+    if (!window_ui.buttonActivated(buttons[0..], state.selection)) return .{};
+
+    return switch (state.selection) {
+        0 => .{ .action = .start_survival, .play_button_click = true },
+        1 => .{ .action = .start_rush, .play_button_click = true },
+        2 => .{ .action = .start_quest_11, .play_button_click = true },
+        3 => blk: {
+            state.openMain();
+            break :blk .{ .play_button_click = true };
+        },
+        else => .{},
+    };
+}
+
+fn drawMenuBackdrop(runtime_assets: *const window_assets.RuntimeAssets) void {
+    window_ui.drawTextureFit(
+        runtime_assets.texture(.backplasma),
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(rl.getScreenWidth()), @floatFromInt(rl.getScreenHeight())),
+        rl.Color.init(255, 255, 255, 92),
+    );
+    rl.drawRectangle(0, 0, rl.getScreenWidth(), rl.getScreenHeight(), rl.Color.init(16, 11, 9, 160));
+}
+
+fn drawFallbackBackdrop() void {
+    const width = rl.getScreenWidth();
+    const height = rl.getScreenHeight();
+    rl.drawRectangleGradientV(0, 0, width, height, rl.Color.init(32, 18, 16, 255), rl.Color.init(16, 12, 10, 255));
+    rl.drawCircle(width - 180, 120, 200.0, rl.Color.init(93, 31, 22, 80));
+    rl.drawCircle(160, height - 80, 220.0, rl.Color.init(58, 23, 18, 90));
+}
+
+fn drawRootMenu(state: *const State, runtime_assets: *const window_assets.RuntimeAssets) void {
+    drawMainMenuSign(state, runtime_assets);
+    for (root_entries, 0..) |entry, idx| {
+        drawRootEntry(state, runtime_assets, entry, idx, idx == state.selection);
+    }
+}
+
+fn drawRootEntry(state: *const State, runtime_assets: *const window_assets.RuntimeAssets, entry: RootEntry, idx: usize, selected: bool) void {
+    const item = runtime_assets.texture(.ui_menu_item);
+    const labels = runtime_assets.texture(.ui_item_texts);
+    const scale_info = menuItemScale(entry.slot);
+    const pos_x = menuSlotPosX(entry.slot);
+    const pos_y = menu_label_base_y + @as(f32, @floatFromInt(entry.slot)) * menu_label_step + menuWidescreenYShift(@floatFromInt(rl.getScreenWidth()));
+    const anim = menuUiElementAnim(entry.slot + 2, menuSlotStartMs(entry.slot), menuSlotEndMs(entry.slot), @as(f32, @floatFromInt(item.width)) * scale_info.scale, state.timeline_ms);
+    const dst = rl.Rectangle.init(pos_x, pos_y, @as(f32, @floatFromInt(item.width)) * scale_info.scale, @as(f32, @floatFromInt(item.height)) * scale_info.scale);
+    const origin = rl.Vector2.init(-(menu_item_offset_x * scale_info.scale), -(menu_item_offset_y * scale_info.scale - scale_info.local_y_shift));
+    const rotation_deg = radiansToDegrees(anim.angle_rad);
+
+    rl.drawTexturePro(
+        item,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(item.width), @floatFromInt(item.height)),
+        dst,
+        origin,
+        rotation_deg,
+        rl.Color.white,
+    );
+
+    const hover_counter = if (selected and state.focus_timer_ms > 0) state.focus_timer_ms else state.hover_amounts[idx];
+    const label_alpha = if (rootEntryEnabled(idx, state.timeline_ms)) mainMenuLabelAlpha(hover_counter) else @as(u8, 100);
+    const tint = rl.Color.init(255, 255, 255, label_alpha);
+    const src = rl.Rectangle.init(0.0, @as(f32, @floatFromInt(entry.row)) * menu_label_row_height, menu_label_width, menu_label_row_height);
+    const label_dst = rl.Rectangle.init(pos_x, pos_y, menu_label_width * scale_info.scale, menu_label_height * scale_info.scale);
+    const label_origin = rl.Vector2.init(-(menu_label_offset_x * scale_info.scale), -(menu_label_offset_y * scale_info.scale - scale_info.local_y_shift));
+    rl.drawTexturePro(labels, src, label_dst, label_origin, rotation_deg, tint);
+    if (rootEntryEnabled(idx, state.timeline_ms)) {
+        rl.beginBlendMode(.additive);
+        rl.drawTexturePro(labels, src, label_dst, label_origin, rotation_deg, rl.Color.init(255, 255, 255, label_alpha));
+        rl.endBlendMode();
+    }
+}
+
+fn drawPlayGamePanel(state: *const State, runtime_assets: *const window_assets.RuntimeAssets) void {
+    drawMainMenuSign(state, runtime_assets);
+    window_ui.drawTextureFit(runtime_assets.texture(.ui_menu_panel), rl.Rectangle.init(420.0, 180.0, 430.0, 310.0), window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    drawAtlasLabelCentered(runtime_assets, label_row_play_game, 228.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+
+    const buttons = playGameButtons();
+    for (buttons, 0..) |button, idx| {
+        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
+        window_ui.drawButton(button, idx == state.selection, hovered, runtime_assets);
+    }
+}
+
+fn drawFallbackRoot(state: *const State) void {
+    drawCenteredText("CRIMSONLAND", 104, 64, rl.Color.init(218, 80, 46, 255));
+    const buttons = fallbackRootButtons();
+    for (buttons, 0..) |button, idx| {
+        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
+        window_ui.drawButton(button, idx == state.selection, hovered, null);
+    }
+}
+
+fn drawFallbackPlayGame(state: *const State) void {
+    drawCenteredText("PLAY GAME", 110, 46, rl.Color.init(218, 80, 46, 255));
+    const buttons = playGameButtons();
+    for (buttons, 0..) |button, idx| {
+        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
+        window_ui.drawButton(button, idx == state.selection, hovered, null);
+    }
+}
+
+fn hoveredRootIndex(runtime_assets: ?*const window_assets.RuntimeAssets) ?usize {
+    const mouse = rl.getMousePosition();
+    if (runtime_assets) |assets| {
+        const item = assets.texture(.ui_menu_item);
+        for (root_entries, 0..) |entry, idx| {
+            if (rl.checkCollisionPointRec(mouse, rootButtonRect(entry.slot, item))) return idx;
+        }
+        return null;
+    }
+
+    const buttons = fallbackRootButtons();
+    for (buttons, 0..) |button, idx| {
+        if (rl.checkCollisionPointRec(mouse, button.rect)) return idx;
+    }
+    return null;
+}
+
+fn activateRootSelection(state: *State) bool {
+    if (!rootEntryEnabled(state.selection, state.timeline_ms)) return false;
+    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space)) return true;
+
+    if (!rl.isMouseButtonPressed(.left)) return false;
+    const hovered = state.hovered_index orelse return false;
+    return hovered == state.selection;
+}
+
+fn rootButtonRect(slot: usize, item_texture: rl.Texture2D) rl.Rectangle {
+    const scale = menuItemScale(slot);
+    const width = @as(f32, @floatFromInt(item_texture.width)) * scale.scale;
+    const height = @as(f32, @floatFromInt(item_texture.height)) * scale.scale;
+    const x = menuSlotPosX(slot) + menu_item_offset_x * scale.scale;
+    const y = menu_label_base_y + @as(f32, @floatFromInt(slot)) * menu_label_step + menuWidescreenYShift(@floatFromInt(rl.getScreenWidth())) + menu_item_offset_y * scale.scale - scale.local_y_shift;
+    return rl.Rectangle.init(x, y, width, height);
+}
+
+fn rootEntryEnabled(slot: usize, timeline_ms: i32) bool {
+    return timeline_ms >= menuSlotStartMs(slot);
+}
+
+fn previousEnabledRootSelection(selection: usize, timeline_ms: i32) usize {
+    var idx = selection;
+    var attempts: usize = 0;
+    while (attempts < root_entries.len) : (attempts += 1) {
+        idx = if (idx == 0) root_entries.len - 1 else idx - 1;
+        if (rootEntryEnabled(idx, timeline_ms)) return idx;
+    }
+    return selection;
+}
+
+fn nextEnabledRootSelection(selection: usize, timeline_ms: i32) usize {
+    var idx = selection;
+    var attempts: usize = 0;
+    while (attempts < root_entries.len) : (attempts += 1) {
+        idx = (idx + 1) % root_entries.len;
+        if (rootEntryEnabled(idx, timeline_ms)) return idx;
+    }
+    return selection;
+}
+
+fn updateHoverAmounts(state: *State, dt_ms: i32) void {
+    for (0..root_entries.len) |idx| {
+        const hovered = state.hovered_index != null and state.hovered_index.? == idx;
+        if (hovered) {
+            state.hover_amounts[idx] = std.math.clamp(state.hover_amounts[idx] + dt_ms * 6, 0, 1000);
+        } else {
+            state.hover_amounts[idx] = std.math.clamp(state.hover_amounts[idx] - dt_ms * 2, 0, 1000);
+        }
+    }
+}
+
+fn rootTimelineMaxMs() i32 {
+    var max_ms: i32 = 300;
+    for (root_entries) |entry| {
+        max_ms = @max(max_ms, menuSlotStartMs(entry.slot));
+    }
+    return max_ms;
+}
+
+fn menuWidescreenYShift(screen_w: f32) f32 {
+    return (screen_w / 640.0) * 150.0 - 150.0;
+}
+
+fn menuSlotPosX(slot: usize) f32 {
+    return menu_label_base_x - @as(f32, @floatFromInt(slot)) * 20.0;
+}
+
+fn menuSlotStartMs(slot: usize) i32 {
+    return @intCast((slot + 2) * 100 + 300);
+}
+
+fn menuSlotEndMs(slot: usize) i32 {
+    return @intCast((slot + 2) * 100);
+}
+
+fn menuUiElementAnim(index: usize, start_ms: i32, end_ms: i32, width: f32, timeline_ms: i32) struct { angle_rad: f32, offset_x: f32 } {
+    if (start_ms <= end_ms or width <= 0.0) return .{ .angle_rad = 0.0, .offset_x = 0.0 };
+    var angle: f32 = 0.0;
+    var offset_x: f32 = 0.0;
+    if (timeline_ms < end_ms) {
+        angle = 1.5707964;
+        offset_x = -@abs(width);
+    } else if (timeline_ms < start_ms) {
+        const p = @as(f32, @floatFromInt(timeline_ms - end_ms)) / @as(f32, @floatFromInt(start_ms - end_ms));
+        angle = 1.5707964 * (1.0 - p);
+        offset_x = (1.0 - p) * -@abs(width);
+    }
+    if (index == 0) angle = -@abs(angle);
+    return .{ .angle_rad = angle, .offset_x = offset_x };
+}
+
+fn mainMenuLabelAlpha(counter_value: i32) u8 {
+    return @intCast(100 + @divTrunc(counter_value * 155, 1000));
+}
+
+fn mainMenuSignLayoutScale(screen_w: i32) struct { scale: f32, shift_x: f32 } {
+    if (screen_w <= menu_scale_small_threshold) return .{ .scale = menu_scale_small, .shift_x = menu_scale_shift };
+    if (screen_w >= menu_scale_large_min and screen_w <= menu_scale_large_max) return .{ .scale = menu_scale_large, .shift_x = menu_scale_shift };
+    return .{ .scale = 1.0, .shift_x = 0.0 };
+}
+
+fn drawMainMenuSign(state: *const State, runtime_assets: *const window_assets.RuntimeAssets) void {
+    const screen_w = rl.getScreenWidth();
+    const sign = runtime_assets.texture(.ui_sign_crimson);
+    const layout = mainMenuSignLayoutScale(screen_w);
+    const sign_pos = rl.Vector2.init(
+        @as(f32, @floatFromInt(screen_w)) + menu_sign_pos_x_pad,
+        if (screen_w > menu_scale_small_threshold) menu_sign_pos_y else menu_sign_pos_y_small,
+    );
+    const sign_w = menu_sign_width * layout.scale;
+    const sign_h = menu_sign_height * layout.scale;
+    const offset_x = menu_sign_offset_x * layout.scale + layout.shift_x;
+    const offset_y = menu_sign_offset_y * layout.scale;
+    const anim = menuUiElementAnim(0, 300, 0, sign_w, state.timeline_ms);
+    const rotation_deg = radiansToDegrees(anim.angle_rad);
+
+    rl.drawTexturePro(
+        sign,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(sign.width), @floatFromInt(sign.height)),
+        rl.Rectangle.init(sign_pos.x, sign_pos.y, sign_w, sign_h),
+        rl.Vector2.init(-offset_x, -offset_y),
+        rotation_deg,
+        rl.Color.white,
+    );
+}
+
+fn menuItemScale(slot: usize) struct { scale: f32, local_y_shift: f32 } {
+    if (rl.getScreenWidth() < 641) {
+        return .{ .scale = 0.9, .local_y_shift = @as(f32, @floatFromInt(slot)) * 11.0 };
+    }
+    return .{ .scale = 1.0, .local_y_shift = 0.0 };
+}
+
+fn drawAtlasLabelCentered(runtime_assets: *const window_assets.RuntimeAssets, row: i32, y: f32, tint: rl.Color) void {
+    const texture = runtime_assets.texture(.ui_item_texts);
+    const src = rl.Rectangle.init(0.0, @as(f32, @floatFromInt(row)) * menu_label_row_height, menu_label_width, menu_label_row_height);
+    const width = menu_label_width;
+    const height = menu_label_height;
+    const x = (@as(f32, @floatFromInt(rl.getScreenWidth())) - width) * 0.5;
+    rl.drawTexturePro(texture, src, rl.Rectangle.init(x, y, width, height), rl.Vector2.zero(), 0.0, tint);
+}
+
+fn playGameButtons() [4]window_ui.UiButton {
+    const center_x = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
+    return .{
+        .{ .label = "SURVIVAL", .rect = window_ui.centeredRect(center_x, 276.0, 280.0, 48.0) },
+        .{ .label = "RUSH", .rect = window_ui.centeredRect(center_x, 332.0, 280.0, 48.0) },
+        .{ .label = "QUEST 1.1", .rect = window_ui.centeredRect(center_x, 388.0, 280.0, 48.0) },
+        .{ .label = "BACK", .rect = window_ui.centeredRect(center_x, 452.0, 220.0, 48.0) },
+    };
+}
+
+fn fallbackRootButtons() [4]window_ui.UiButton {
+    const center_x = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
+    return .{
+        .{ .label = "PLAY GAME", .rect = window_ui.centeredRect(center_x, 280.0, 300.0, 52.0) },
+        .{ .label = "OPTIONS", .rect = window_ui.centeredRect(center_x, 344.0, 300.0, 52.0) },
+        .{ .label = "STATISTICS", .rect = window_ui.centeredRect(center_x, 408.0, 300.0, 52.0) },
+        .{ .label = "QUIT", .rect = window_ui.centeredRect(center_x, 472.0, 300.0, 52.0) },
+    };
+}
+
+fn radiansToDegrees(radians: f32) f32 {
+    return radians * (180.0 / std.math.pi);
+}
+
+fn drawCenteredText(text: [:0]const u8, y: i32, font_size: i32, color: rl.Color) void {
+    const width = rl.measureText(text, font_size);
+    rl.drawText(text, @divTrunc(rl.getScreenWidth() - width, 2), y, font_size, color);
+}

--- a/crimson-zig/src/window_ui.zig
+++ b/crimson-zig/src/window_ui.zig
@@ -1,0 +1,166 @@
+const std = @import("std");
+const rl = @import("raylib");
+
+const window_assets = @import("window_assets.zig");
+
+pub const UiButton = struct {
+    label: [:0]const u8,
+    rect: rl.Rectangle,
+};
+
+pub fn centeredRect(center_x: f32, top_y: f32, width: f32, height: f32) rl.Rectangle {
+    return .{
+        .x = center_x - width * 0.5,
+        .y = top_y,
+        .width = width,
+        .height = height,
+    };
+}
+
+pub fn updateSelectionFromPointer(selection: *usize, buttons: []const UiButton) void {
+    const mouse = rl.getMousePosition();
+    for (buttons, 0..) |button, idx| {
+        if (rl.checkCollisionPointRec(mouse, button.rect)) {
+            selection.* = idx;
+            return;
+        }
+    }
+}
+
+pub fn buttonActivated(buttons: []const UiButton, selection: usize) bool {
+    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space)) return true;
+
+    if (!rl.isMouseButtonPressed(.left)) return false;
+    const mouse = rl.getMousePosition();
+    for (buttons, 0..) |button, idx| {
+        if (idx == selection and rl.checkCollisionPointRec(mouse, button.rect)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+pub fn drawButton(
+    button: UiButton,
+    selected: bool,
+    hovered: bool,
+    runtime_assets: ?*const window_assets.RuntimeAssets,
+) void {
+    if (runtime_assets) |assets| {
+        const scale = button.rect.height / 32.0;
+        const texture = if (button.rect.width > 120.0) assets.texture(.ui_button_md) else assets.texture(.ui_button_sm);
+        const glow_alpha: f32 = if (selected or hovered) 0.92 else 0.72;
+        if (selected or hovered) {
+            rl.drawRectangleRounded(
+                .{
+                    .x = button.rect.x + 12.0 * scale,
+                    .y = button.rect.y + 5.0 * scale,
+                    .width = button.rect.width - 24.0 * scale,
+                    .height = button.rect.height - 10.0 * scale,
+                },
+                0.18,
+                8,
+                rl.Color.init(128, 128, 178, @intFromFloat(glow_alpha * 120.0)),
+            );
+        }
+        const plate_alpha: f32 = if (selected or hovered) 255.0 else 230.0;
+        rl.drawTexturePro(
+            texture,
+            rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height)),
+            button.rect,
+            rl.Vector2.zero(),
+            0.0,
+            rl.Color.init(255, 255, 255, @intFromFloat(plate_alpha)),
+        );
+
+        const label_width = measureSmallText(assets, button.label);
+        drawSmallText(
+            assets,
+            button.label,
+            button.rect.x + (button.rect.width - label_width) * 0.5 + 1.0,
+            button.rect.y + 10.0,
+            colorWithAlpha(rl.Color.white, if (selected or hovered) 1.0 else 0.7),
+        );
+        return;
+    }
+
+    const fill = if (selected or hovered) rl.Color.init(218, 80, 46, 255) else rl.Color.init(37, 24, 20, 255);
+    const outline = if (selected or hovered) rl.Color.gold else rl.Color.init(122, 78, 58, 255);
+    rl.drawRectangleRounded(button.rect, 0.2, 8, fill);
+    rl.drawRectangleRoundedLinesEx(button.rect, 0.2, 8, 2.0, outline);
+
+    const label_width = rl.measureText(button.label, 24);
+    const label_x = @as(i32, @intFromFloat(button.rect.x + (button.rect.width - @as(f32, @floatFromInt(label_width))) * 0.5));
+    const label_y = @as(i32, @intFromFloat(button.rect.y + (button.rect.height - 24.0) * 0.5));
+    rl.drawText(button.label, label_x, label_y, 24, rl.Color.init(245, 236, 225, 255));
+}
+
+pub fn colorWithAlpha(color: rl.Color, alpha: f32) rl.Color {
+    return rl.Color.init(
+        color.r,
+        color.g,
+        color.b,
+        @intFromFloat(std.math.clamp(alpha, @as(f32, 0.0), @as(f32, 1.0)) * 255.0),
+    );
+}
+
+pub fn drawTextureFit(texture: rl.Texture2D, dest: rl.Rectangle, tint: rl.Color) void {
+    const src = rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height));
+    rl.drawTexturePro(texture, src, dest, rl.Vector2.zero(), 0.0, tint);
+}
+
+pub fn drawSmallText(
+    runtime_assets: *const window_assets.RuntimeAssets,
+    text: []const u8,
+    x: f32,
+    y: f32,
+    color: rl.Color,
+) void {
+    const texture = runtime_assets.texture(.small_white);
+    var x_pos = @floor(x);
+    var y_pos = @floor(y);
+    const base_x = x_pos;
+    for (text) |value| {
+        switch (value) {
+            '\n' => {
+                x_pos = base_x;
+                y_pos += 16.0;
+                continue;
+            },
+            '\r' => continue,
+            else => {},
+        }
+
+        const width = runtime_assets.small_font_widths[value];
+        if (width == 0) continue;
+        const col = value % 16;
+        const row = value / 16;
+        rl.drawTexturePro(
+            texture,
+            rl.Rectangle.init(@as(f32, @floatFromInt(col * 16)), @as(f32, @floatFromInt(row * 16)), @floatFromInt(width), 16.0),
+            rl.Rectangle.init(x_pos, y_pos, @floatFromInt(width), 16.0),
+            rl.Vector2.zero(),
+            0.0,
+            color,
+        );
+        x_pos += @as(f32, @floatFromInt(width));
+    }
+}
+
+pub fn measureSmallText(runtime_assets: *const window_assets.RuntimeAssets, text: []const u8) f32 {
+    var width: f32 = 0.0;
+    var best: f32 = 0.0;
+    for (text) |value| {
+        switch (value) {
+            '\n' => {
+                best = @max(best, width);
+                width = 0.0;
+                continue;
+            },
+            '\r' => continue,
+            else => {},
+        }
+        width += @as(f32, @floatFromInt(runtime_assets.small_font_widths[value]));
+    }
+    return @max(best, width);
+}


### PR DESCRIPTION
## Summary
- split boot and menu out of `window_main.zig` into dedicated `window_boot`, `window_menu`, and `window_ui` modules
- remove loaded asset/audio footer text from the live boot/menu surface and keep diagnostics only for actual failure states
- replace the direct mode-launch list with a top-level menu and a dedicated `PLAY GAME` submenu

## Verification
- zig build window
- zig build test
- zig build wasm
- zig build run-window
