### PR TITLE
feat(zig): port classic menu panel flow

### DIFF
--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -16,6 +16,7 @@ const window_atlas = cz.window_atlas;
 const window_boot = @import("window_boot.zig");
 const window_ground = @import("window_ground.zig");
 const window_menu = @import("window_menu.zig");
+const window_menu_panels = @import("window_menu_panels.zig");
 const window_projectiles = @import("window_projectiles.zig");
 const window_terrain_fx = @import("window_terrain_fx.zig");
 const window_ui = @import("window_ui.zig");
@@ -55,10 +56,14 @@ const overlay_color = rl.Color.init(8, 6, 5, 208);
 const Screen = enum {
     boot,
     main_menu,
+    play_game_menu,
+    quests_menu,
+    statistics_menu,
     gameplay,
     results,
     high_scores,
     options,
+    info_view,
 };
 
 const ResultsReason = enum {
@@ -203,6 +208,7 @@ const HighScoresScreen = struct {
     records: []persistence.highscores.HighScoreRecord = &.{},
     records_owned: bool = false,
     load_error: ?[]const u8 = null,
+    return_to_statistics: bool = false,
 
     fn clear(self: *HighScoresScreen, allocator: std.mem.Allocator) void {
         if (self.records_owned) {
@@ -259,6 +265,10 @@ const App = struct {
     boot: BootSequenceState = .{},
     menu: MenuScreenState = .{},
     results_selection: usize = 0,
+    play_game_menu: window_menu_panels.PlayGameState = .{},
+    quests_menu: window_menu_panels.QuestState = .{},
+    statistics_menu: window_menu_panels.StatisticsState = .{},
+    info_view: window_menu_panels.InfoViewState = .{},
     gameplay: ?GameplayScreen = null,
     results: ?ResultsScreen = null,
     high_scores: ?HighScoresScreen = null,
@@ -324,10 +334,14 @@ const App = struct {
         switch (self.screen) {
             .boot => self.updateBoot(frame_dt),
             .main_menu => self.updateMainMenu(frame_dt),
+            .play_game_menu => self.updatePlayGameMenu(frame_dt),
+            .quests_menu => self.updateQuestsMenu(frame_dt),
+            .statistics_menu => self.updateStatisticsMenu(frame_dt),
             .gameplay => self.updateGameplay(frame_dt),
             .results => self.updateResults(),
             .high_scores => self.updateHighScores(),
             .options => self.updateOptions(),
+            .info_view => self.updateInfoView(),
         }
         self.audio.update(frame_dt);
     }
@@ -336,10 +350,14 @@ const App = struct {
         switch (self.screen) {
             .boot => self.drawBoot(),
             .main_menu => self.drawMainMenu(),
+            .play_game_menu => self.drawPlayGameMenu(),
+            .quests_menu => self.drawQuestsMenu(),
+            .statistics_menu => self.drawStatisticsMenu(),
             .gameplay => self.drawGameplay(),
             .results => self.drawResults(),
             .high_scores => self.drawHighScores(),
             .options => self.drawOptions(),
+            .info_view => self.drawInfoView(),
         }
     }
 
@@ -369,13 +387,96 @@ const App = struct {
         }
         if (menu_update.action) |action| {
             switch (action) {
-                .start_survival => self.startNewRun(runConfigForMenuSelection(0, &self.next_seed_state)),
-                .start_rush => self.startNewRun(runConfigForMenuSelection(1, &self.next_seed_state)),
-                .start_quest_11 => self.startNewRun(runConfigForMenuSelection(2, &self.next_seed_state)),
+                .open_play_game => {
+                    self.play_game_menu.reset();
+                    self.screen = .play_game_menu;
+                },
                 .open_options => self.screen = .options,
-                .open_high_scores => self.openHighScores(),
+                .open_statistics => {
+                    self.statistics_menu.reset();
+                    self.screen = .statistics_menu;
+                },
                 .quit => self.quit_requested = true,
             }
+        }
+    }
+
+    fn updatePlayGameMenu(self: *App, frame_dt: f32) void {
+        self.audio.ensureMenuTheme();
+        const play_game_update = window_menu_panels.updatePlayGame(&self.play_game_menu, frame_dt, &self.runtime.config);
+        if (play_game_update.config_dirty) self.runtime.config_dirty = true;
+        if (play_game_update.play_panel_click and !self.play_game_menu.panel.panel_open_sfx_played) {
+            self.audio.playUiPanelClick();
+            self.play_game_menu.panel.panel_open_sfx_played = true;
+        }
+        if (play_game_update.play_button_click) self.audio.playUiButtonClick();
+        if (play_game_update.action) |action| switch (action) {
+            .start_survival => self.startNewRun(runConfigForLiveMode(.survival, null, &self.next_seed_state)),
+            .start_rush => self.startNewRun(runConfigForLiveMode(.rush, null, &self.next_seed_state)),
+            .open_quests => {
+                self.quests_menu.reset();
+                self.screen = .quests_menu;
+            },
+            .back_to_menu => {
+                self.menu.openRoot();
+                self.screen = .main_menu;
+            },
+        };
+    }
+
+    fn updateQuestsMenu(self: *App, frame_dt: f32) void {
+        self.audio.ensureMenuTheme();
+        const quest_update = window_menu_panels.updateQuests(&self.quests_menu, frame_dt, &self.runtime.config, self.runtime.status);
+        if (quest_update.config_dirty) self.runtime.config_dirty = true;
+        if (quest_update.play_panel_click and !self.quests_menu.panel.panel_open_sfx_played) {
+            self.audio.playUiPanelClick();
+            self.quests_menu.panel.panel_open_sfx_played = true;
+        }
+        if (quest_update.play_button_click) self.audio.playUiButtonClick();
+        if (quest_update.back_to_play_game) {
+            self.play_game_menu.reset();
+            self.screen = .play_game_menu;
+            return;
+        }
+        if (quest_update.start_level_key) |level_key| {
+            self.startNewRun(runConfigForLiveMode(.quests, level_key, &self.next_seed_state));
+        }
+    }
+
+    fn updateStatisticsMenu(self: *App, frame_dt: f32) void {
+        self.audio.ensureMenuTheme();
+        const statistics_update = window_menu_panels.updateStatistics(&self.statistics_menu, frame_dt);
+        if (statistics_update.play_panel_click and !self.statistics_menu.panel.panel_open_sfx_played) {
+            self.audio.playUiPanelClick();
+            self.statistics_menu.panel.panel_open_sfx_played = true;
+        }
+        if (statistics_update.play_button_click) self.audio.playUiButtonClick();
+        if (statistics_update.action) |action| switch (action) {
+            .open_high_scores => self.openHighScores(true),
+            .open_weapons => {
+                self.info_view.open(.weapons);
+                self.screen = .info_view;
+            },
+            .open_perks => {
+                self.info_view.open(.perks);
+                self.screen = .info_view;
+            },
+            .open_credits => {
+                self.info_view.open(.credits);
+                self.screen = .info_view;
+            },
+            .back_to_menu => {
+                self.menu.openRoot();
+                self.screen = .main_menu;
+            },
+        };
+    }
+
+    fn updateInfoView(self: *App) void {
+        const info_update = window_menu_panels.updateInfoView(&self.info_view);
+        if (info_update.back_to_statistics) {
+            self.statistics_menu.reset();
+            self.screen = .statistics_menu;
         }
     }
 
@@ -477,8 +578,13 @@ const App = struct {
                 1 => self.setHighScoresMode(.rush),
                 2 => self.setHighScoresMode(.quests),
                 3 => {
-                    self.menu.openRoot();
-                    self.screen = .main_menu;
+                    if (high_scores.return_to_statistics) {
+                        self.statistics_menu.reset();
+                        self.screen = .statistics_menu;
+                    } else {
+                        self.menu.openRoot();
+                        self.screen = .main_menu;
+                    }
                 },
                 else => {},
             }
@@ -644,6 +750,7 @@ const App = struct {
     fn startNewRun(self: *App, run_config: live_runner.LiveModeConfig) void {
         self.audio.stopGameplayMusic();
         var configured_run = run_config;
+        configured_run.player_count = @intCast(std.math.clamp(self.runtime.config.player_count, @as(u32, 1), @as(u32, 4)));
         configured_run.detail_preset = @intCast(std.math.clamp(self.runtime.config.detail_preset, @as(u32, 1), @as(u32, 5)));
         configured_run.gore_disabled = @intCast(self.runtime.config.gore_disabled);
         configured_run.hardcore = self.runtime.config.hardcore_flag != 0;
@@ -699,9 +806,12 @@ const App = struct {
         self.screen = .gameplay;
     }
 
-    fn openHighScores(self: *App) void {
+    fn openHighScores(self: *App, return_to_statistics: bool) void {
         if (self.high_scores == null) {
             self.high_scores = .{};
+        }
+        if (self.high_scores) |*high_scores| {
+            high_scores.return_to_statistics = return_to_statistics;
         }
         self.setHighScoresMode(.survival);
         self.screen = .high_scores;
@@ -839,6 +949,28 @@ const App = struct {
     fn drawMainMenu(self: *const App) void {
         window_menu.draw(&self.menu, if (self.runtime_assets) |*assets| assets else null);
         drawStartupDiagnostics(self);
+    }
+
+    fn drawPlayGameMenu(self: *const App) void {
+        window_menu_panels.drawPlayGame(
+            &self.play_game_menu,
+            if (self.runtime_assets) |*assets| assets else null,
+            self.runtime.status,
+            self.runtime.config.player_count,
+        );
+    }
+
+    fn drawQuestsMenu(self: *const App) void {
+        window_menu_panels.drawQuests(
+            &self.quests_menu,
+            if (self.runtime_assets) |*assets| assets else null,
+            self.runtime.config,
+            self.runtime.status,
+        );
+    }
+
+    fn drawStatisticsMenu(self: *const App) void {
+        window_menu_panels.drawStatistics(&self.statistics_menu, if (self.runtime_assets) |*assets| assets else null);
     }
 
     fn drawGameplay(self: *App) void {
@@ -993,6 +1125,14 @@ const App = struct {
             window_ui.drawButton(button, idx == self.options.selection, mouse_hovered, if (self.runtime_assets) |*assets| assets else null);
         }
         drawAudioStatus(&self.audio);
+    }
+
+    fn drawInfoView(self: *const App) void {
+        window_menu_panels.drawInfoView(
+            &self.info_view,
+            if (self.runtime_assets) |*assets| assets else null,
+            self.runtime.status,
+        );
     }
 };
 
@@ -2458,17 +2598,25 @@ fn nextRunSeed(seed_state: *u32) u32 {
     return if (seed_state.* == 0) 1 else seed_state.*;
 }
 
-fn runConfigForMenuSelection(selection: usize, seed_state: *u32) live_runner.LiveModeConfig {
+fn runConfigForLiveMode(mode: game_ids.GameModeId, quest_level_key: ?i32, seed_state: *u32) live_runner.LiveModeConfig {
     const seed = nextRunSeed(seed_state);
-    return switch (selection) {
-        1 => .{
+    return switch (mode) {
+        .rush => .{
             .seed = seed,
             .game_mode = .rush,
         },
-        2 => .{
+        .quests => .{
             .seed = seed,
             .game_mode = .quests,
-            .quest_level_key = 101,
+            .quest_level_key = quest_level_key orelse 101,
+        },
+        .typo => .{
+            .seed = seed,
+            .game_mode = .typo,
+        },
+        .tutorial => .{
+            .seed = seed,
+            .game_mode = .tutorial,
         },
         else => .{
             .seed = seed,

--- a/crimson-zig/src/window_menu.zig
+++ b/crimson-zig/src/window_menu.zig
@@ -4,7 +4,6 @@ const rl = @import("raylib");
 const window_assets = @import("window_assets.zig");
 const window_ui = @import("window_ui.zig");
 
-pub const menu_demo_idle_start_ms: i32 = 23_000;
 const menu_label_width: f32 = 122.0;
 const menu_label_height: f32 = 28.0;
 const menu_label_row_height: f32 = 32.0;
@@ -29,28 +28,20 @@ const menu_scale_small: f32 = 0.8;
 const menu_scale_large: f32 = 1.2;
 const menu_scale_shift: f32 = 10.0;
 
-const label_row_play_game: i32 = 1;
-const label_row_options: i32 = 2;
-const label_row_statistics: i32 = 3;
-const label_row_quit: i32 = 6;
-const label_row_back: i32 = 7;
-
-pub const Page = enum {
-    root,
-    play_game,
-};
+pub const label_row_play_game: i32 = 1;
+pub const label_row_options: i32 = 2;
+pub const label_row_statistics: i32 = 3;
+pub const label_row_quit: i32 = 6;
+pub const label_row_back: i32 = 7;
 
 pub const Action = enum {
-    start_survival,
-    start_rush,
-    start_quest_11,
+    open_play_game,
     open_options,
-    open_high_scores,
+    open_statistics,
     quit,
 };
 
 pub const State = struct {
-    page: Page = .root,
     selection: usize = 0,
     timeline_ms: i32 = 0,
     focus_timer_ms: i32 = 0,
@@ -69,20 +60,6 @@ pub const State = struct {
     pub fn openRoot(self: *State) void {
         self.reset();
     }
-
-    fn openPlayGame(self: *State) void {
-        self.page = .play_game;
-        self.selection = 0;
-        self.hovered_index = null;
-        self.focus_timer_ms = 1000;
-    }
-
-    fn openMain(self: *State) void {
-        self.page = .root;
-        self.selection = 0;
-        self.hovered_index = null;
-        self.focus_timer_ms = 1000;
-    }
 };
 
 pub const UpdateResult = struct {
@@ -94,49 +71,21 @@ pub const UpdateResult = struct {
 const RootEntry = struct {
     slot: usize,
     row: i32,
-    action: Action,
 };
 
 const root_entries = [_]RootEntry{
-    .{ .slot = 0, .row = label_row_play_game, .action = .start_survival }, // action unused on root
-    .{ .slot = 1, .row = label_row_options, .action = .open_options },
-    .{ .slot = 2, .row = label_row_statistics, .action = .open_high_scores },
-    .{ .slot = 3, .row = label_row_quit, .action = .quit },
+    .{ .slot = 0, .row = label_row_play_game },
+    .{ .slot = 1, .row = label_row_options },
+    .{ .slot = 2, .row = label_row_statistics },
+    .{ .slot = 3, .row = label_row_quit },
 };
 
 pub fn update(state: *State, frame_dt: f32, runtime_assets: ?*const window_assets.RuntimeAssets) UpdateResult {
     const dt_ms = @as(i32, @intFromFloat(@min(frame_dt, 0.1) * 1000.0));
-    return switch (state.page) {
-        .root => updateRoot(state, dt_ms, runtime_assets),
-        .play_game => updatePlayGame(state),
-    };
-}
-
-pub fn draw(state: *const State, runtime_assets: ?*const window_assets.RuntimeAssets) void {
-    if (runtime_assets) |assets| {
-        drawMenuBackdrop(assets);
-        switch (state.page) {
-            .root => drawRootMenu(state, assets),
-            .play_game => drawPlayGamePanel(state, assets),
-        }
-        return;
-    }
-
-    rl.clearBackground(rl.Color.init(16, 12, 10, 255));
-    drawFallbackBackdrop();
-    switch (state.page) {
-        .root => drawFallbackRoot(state),
-        .play_game => drawFallbackPlayGame(state),
-    }
-}
-
-fn updateRoot(state: *State, dt_ms: i32, runtime_assets: ?*const window_assets.RuntimeAssets) UpdateResult {
     if (dt_ms > 0) {
         const mouse = rl.getMousePosition();
         const mouse_moved = mouse.x != state.last_mouse_pos.x or mouse.y != state.last_mouse_pos.y;
-        if (mouse_moved) {
-            state.last_mouse_pos = mouse;
-        }
+        if (mouse_moved) state.last_mouse_pos = mouse;
 
         if (rl.getKeyPressed() != .null or rl.isMouseButtonPressed(.left) or rl.isMouseButtonPressed(.right) or mouse_moved) {
             state.idle_ms = 0;
@@ -172,13 +121,13 @@ fn updateRoot(state: *State, dt_ms: i32, runtime_assets: ?*const window_assets.R
     }
 
     var result: UpdateResult = .{ .play_button_click = true };
-    switch (state.selection) {
-        0 => state.openPlayGame(),
-        1 => result.action = .open_options,
-        2 => result.action = .open_high_scores,
-        3 => result.action = .quit,
-        else => {},
-    }
+    result.action = switch (state.selection) {
+        0 => .open_play_game,
+        1 => .open_options,
+        2 => .open_statistics,
+        3 => .quit,
+        else => null,
+    };
     updateHoverAmounts(state, dt_ms);
     if (dt_ms > 0 and state.timeline_ms >= rootTimelineMaxMs() and !state.panel_open_sfx_played) {
         result.play_panel_click = true;
@@ -186,42 +135,96 @@ fn updateRoot(state: *State, dt_ms: i32, runtime_assets: ?*const window_assets.R
     return result;
 }
 
-fn updatePlayGame(state: *State) UpdateResult {
-    const buttons = playGameButtons();
-    window_ui.updateSelectionFromPointer(&state.selection, buttons[0..]);
-
-    if (rl.isKeyPressed(.escape)) {
-        state.openMain();
-        return .{ .play_button_click = true };
-    }
-    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
-        state.selection = if (state.selection == 0) buttons.len - 1 else state.selection - 1;
-    }
-    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
-        state.selection = (state.selection + 1) % buttons.len;
+pub fn draw(state: *const State, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+    if (runtime_assets) |assets| {
+        drawMenuBackdrop(assets);
+        drawSign(state.timeline_ms, assets);
+        for (root_entries, 0..) |entry, idx| {
+            drawRootEntry(state, assets, entry, idx, idx == state.selection);
+        }
+        return;
     }
 
-    if (!window_ui.buttonActivated(buttons[0..], state.selection)) return .{};
-
-    return switch (state.selection) {
-        0 => .{ .action = .start_survival, .play_button_click = true },
-        1 => .{ .action = .start_rush, .play_button_click = true },
-        2 => .{ .action = .start_quest_11, .play_button_click = true },
-        3 => blk: {
-            state.openMain();
-            break :blk .{ .play_button_click = true };
-        },
-        else => .{},
-    };
+    rl.clearBackground(rl.Color.init(16, 12, 10, 255));
+    drawFallbackBackdrop();
+    drawCenteredText("CRIMSONLAND", 104, 64, rl.Color.init(218, 80, 46, 255));
+    const buttons = fallbackRootButtons();
+    for (buttons, 0..) |button, idx| {
+        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
+        window_ui.drawButton(button, idx == state.selection, hovered, null);
+    }
 }
 
-fn drawMenuBackdrop(runtime_assets: *const window_assets.RuntimeAssets) void {
+pub fn drawMenuBackdrop(runtime_assets: *const window_assets.RuntimeAssets) void {
     window_ui.drawTextureFit(
         runtime_assets.texture(.backplasma),
         rl.Rectangle.init(0.0, 0.0, @floatFromInt(rl.getScreenWidth()), @floatFromInt(rl.getScreenHeight())),
         rl.Color.init(255, 255, 255, 92),
     );
     rl.drawRectangle(0, 0, rl.getScreenWidth(), rl.getScreenHeight(), rl.Color.init(16, 11, 9, 160));
+}
+
+pub fn drawSign(timeline_ms: i32, runtime_assets: *const window_assets.RuntimeAssets) void {
+    const screen_w = rl.getScreenWidth();
+    const sign = runtime_assets.texture(.ui_sign_crimson);
+    const layout = mainMenuSignLayoutScale(screen_w);
+    const sign_pos = rl.Vector2.init(
+        @as(f32, @floatFromInt(screen_w)) + menu_sign_pos_x_pad,
+        if (screen_w > menu_scale_small_threshold) menu_sign_pos_y else menu_sign_pos_y_small,
+    );
+    const sign_w = menu_sign_width * layout.scale;
+    const sign_h = menu_sign_height * layout.scale;
+    const offset_x = menu_sign_offset_x * layout.scale + layout.shift_x;
+    const offset_y = menu_sign_offset_y * layout.scale;
+    const anim = uiElementAnim(0, 300, 0, sign_w, timeline_ms);
+    const rotation_deg = radiansToDegrees(anim.angle_rad);
+
+    rl.drawTexturePro(
+        sign,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(sign.width), @floatFromInt(sign.height)),
+        rl.Rectangle.init(sign_pos.x, sign_pos.y, sign_w, sign_h),
+        rl.Vector2.init(-offset_x, -offset_y),
+        rotation_deg,
+        rl.Color.white,
+    );
+}
+
+pub fn drawAtlasLabelCentered(runtime_assets: *const window_assets.RuntimeAssets, row: i32, y: f32, tint: rl.Color) void {
+    const texture = runtime_assets.texture(.ui_item_texts);
+    const src = rl.Rectangle.init(0.0, @as(f32, @floatFromInt(row)) * menu_label_row_height, menu_label_width, menu_label_row_height);
+    const x = (@as(f32, @floatFromInt(rl.getScreenWidth())) - menu_label_width) * 0.5;
+    rl.drawTexturePro(
+        texture,
+        src,
+        rl.Rectangle.init(x, y, menu_label_width, menu_label_height),
+        rl.Vector2.zero(),
+        0.0,
+        tint,
+    );
+}
+
+pub fn uiElementAnim(index: usize, start_ms: i32, end_ms: i32, width: f32, timeline_ms: i32) struct { angle_rad: f32, offset_x: f32 } {
+    if (start_ms <= end_ms or width <= 0.0) return .{ .angle_rad = 0.0, .offset_x = 0.0 };
+    var angle: f32 = 0.0;
+    var offset_x: f32 = 0.0;
+    if (timeline_ms < end_ms) {
+        angle = 1.5707964;
+        offset_x = -@abs(width);
+    } else if (timeline_ms < start_ms) {
+        const p = @as(f32, @floatFromInt(timeline_ms - end_ms)) / @as(f32, @floatFromInt(start_ms - end_ms));
+        angle = 1.5707964 * (1.0 - p);
+        offset_x = (1.0 - p) * -@abs(width);
+    }
+    if (index == 0) angle = -@abs(angle);
+    return .{ .angle_rad = angle, .offset_x = offset_x };
+}
+
+pub fn menuWidescreenYShift(screen_w: f32) f32 {
+    return (screen_w / 640.0) * 150.0 - 150.0;
+}
+
+pub fn menuScale(screen_w: i32) struct { scale: f32, shift_x: f32 } {
+    return mainMenuSignLayoutScale(screen_w);
 }
 
 fn drawFallbackBackdrop() void {
@@ -232,20 +235,13 @@ fn drawFallbackBackdrop() void {
     rl.drawCircle(160, height - 80, 220.0, rl.Color.init(58, 23, 18, 90));
 }
 
-fn drawRootMenu(state: *const State, runtime_assets: *const window_assets.RuntimeAssets) void {
-    drawMainMenuSign(state, runtime_assets);
-    for (root_entries, 0..) |entry, idx| {
-        drawRootEntry(state, runtime_assets, entry, idx, idx == state.selection);
-    }
-}
-
 fn drawRootEntry(state: *const State, runtime_assets: *const window_assets.RuntimeAssets, entry: RootEntry, idx: usize, selected: bool) void {
     const item = runtime_assets.texture(.ui_menu_item);
     const labels = runtime_assets.texture(.ui_item_texts);
     const scale_info = menuItemScale(entry.slot);
     const pos_x = menuSlotPosX(entry.slot);
     const pos_y = menu_label_base_y + @as(f32, @floatFromInt(entry.slot)) * menu_label_step + menuWidescreenYShift(@floatFromInt(rl.getScreenWidth()));
-    const anim = menuUiElementAnim(entry.slot + 2, menuSlotStartMs(entry.slot), menuSlotEndMs(entry.slot), @as(f32, @floatFromInt(item.width)) * scale_info.scale, state.timeline_ms);
+    const anim = uiElementAnim(entry.slot + 2, menuSlotStartMs(entry.slot), menuSlotEndMs(entry.slot), @as(f32, @floatFromInt(item.width)) * scale_info.scale, state.timeline_ms);
     const dst = rl.Rectangle.init(pos_x, pos_y, @as(f32, @floatFromInt(item.width)) * scale_info.scale, @as(f32, @floatFromInt(item.height)) * scale_info.scale);
     const origin = rl.Vector2.init(-(menu_item_offset_x * scale_info.scale), -(menu_item_offset_y * scale_info.scale - scale_info.local_y_shift));
     const rotation_deg = radiansToDegrees(anim.angle_rad);
@@ -270,36 +266,6 @@ fn drawRootEntry(state: *const State, runtime_assets: *const window_assets.Runti
         rl.beginBlendMode(.additive);
         rl.drawTexturePro(labels, src, label_dst, label_origin, rotation_deg, rl.Color.init(255, 255, 255, label_alpha));
         rl.endBlendMode();
-    }
-}
-
-fn drawPlayGamePanel(state: *const State, runtime_assets: *const window_assets.RuntimeAssets) void {
-    drawMainMenuSign(state, runtime_assets);
-    window_ui.drawTextureFit(runtime_assets.texture(.ui_menu_panel), rl.Rectangle.init(420.0, 180.0, 430.0, 310.0), window_ui.colorWithAlpha(rl.Color.white, 0.96));
-    drawAtlasLabelCentered(runtime_assets, label_row_play_game, 228.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
-
-    const buttons = playGameButtons();
-    for (buttons, 0..) |button, idx| {
-        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
-        window_ui.drawButton(button, idx == state.selection, hovered, runtime_assets);
-    }
-}
-
-fn drawFallbackRoot(state: *const State) void {
-    drawCenteredText("CRIMSONLAND", 104, 64, rl.Color.init(218, 80, 46, 255));
-    const buttons = fallbackRootButtons();
-    for (buttons, 0..) |button, idx| {
-        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
-        window_ui.drawButton(button, idx == state.selection, hovered, null);
-    }
-}
-
-fn drawFallbackPlayGame(state: *const State) void {
-    drawCenteredText("PLAY GAME", 110, 46, rl.Color.init(218, 80, 46, 255));
-    const buttons = playGameButtons();
-    for (buttons, 0..) |button, idx| {
-        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
-        window_ui.drawButton(button, idx == state.selection, hovered, null);
     }
 }
 
@@ -381,10 +347,6 @@ fn rootTimelineMaxMs() i32 {
     return max_ms;
 }
 
-fn menuWidescreenYShift(screen_w: f32) f32 {
-    return (screen_w / 640.0) * 150.0 - 150.0;
-}
-
 fn menuSlotPosX(slot: usize) f32 {
     return menu_label_base_x - @as(f32, @floatFromInt(slot)) * 20.0;
 }
@@ -397,22 +359,6 @@ fn menuSlotEndMs(slot: usize) i32 {
     return @intCast((slot + 2) * 100);
 }
 
-fn menuUiElementAnim(index: usize, start_ms: i32, end_ms: i32, width: f32, timeline_ms: i32) struct { angle_rad: f32, offset_x: f32 } {
-    if (start_ms <= end_ms or width <= 0.0) return .{ .angle_rad = 0.0, .offset_x = 0.0 };
-    var angle: f32 = 0.0;
-    var offset_x: f32 = 0.0;
-    if (timeline_ms < end_ms) {
-        angle = 1.5707964;
-        offset_x = -@abs(width);
-    } else if (timeline_ms < start_ms) {
-        const p = @as(f32, @floatFromInt(timeline_ms - end_ms)) / @as(f32, @floatFromInt(start_ms - end_ms));
-        angle = 1.5707964 * (1.0 - p);
-        offset_x = (1.0 - p) * -@abs(width);
-    }
-    if (index == 0) angle = -@abs(angle);
-    return .{ .angle_rad = angle, .offset_x = offset_x };
-}
-
 fn mainMenuLabelAlpha(counter_value: i32) u8 {
     return @intCast(100 + @divTrunc(counter_value * 155, 1000));
 }
@@ -423,55 +369,11 @@ fn mainMenuSignLayoutScale(screen_w: i32) struct { scale: f32, shift_x: f32 } {
     return .{ .scale = 1.0, .shift_x = 0.0 };
 }
 
-fn drawMainMenuSign(state: *const State, runtime_assets: *const window_assets.RuntimeAssets) void {
-    const screen_w = rl.getScreenWidth();
-    const sign = runtime_assets.texture(.ui_sign_crimson);
-    const layout = mainMenuSignLayoutScale(screen_w);
-    const sign_pos = rl.Vector2.init(
-        @as(f32, @floatFromInt(screen_w)) + menu_sign_pos_x_pad,
-        if (screen_w > menu_scale_small_threshold) menu_sign_pos_y else menu_sign_pos_y_small,
-    );
-    const sign_w = menu_sign_width * layout.scale;
-    const sign_h = menu_sign_height * layout.scale;
-    const offset_x = menu_sign_offset_x * layout.scale + layout.shift_x;
-    const offset_y = menu_sign_offset_y * layout.scale;
-    const anim = menuUiElementAnim(0, 300, 0, sign_w, state.timeline_ms);
-    const rotation_deg = radiansToDegrees(anim.angle_rad);
-
-    rl.drawTexturePro(
-        sign,
-        rl.Rectangle.init(0.0, 0.0, @floatFromInt(sign.width), @floatFromInt(sign.height)),
-        rl.Rectangle.init(sign_pos.x, sign_pos.y, sign_w, sign_h),
-        rl.Vector2.init(-offset_x, -offset_y),
-        rotation_deg,
-        rl.Color.white,
-    );
-}
-
 fn menuItemScale(slot: usize) struct { scale: f32, local_y_shift: f32 } {
     if (rl.getScreenWidth() < 641) {
         return .{ .scale = 0.9, .local_y_shift = @as(f32, @floatFromInt(slot)) * 11.0 };
     }
     return .{ .scale = 1.0, .local_y_shift = 0.0 };
-}
-
-fn drawAtlasLabelCentered(runtime_assets: *const window_assets.RuntimeAssets, row: i32, y: f32, tint: rl.Color) void {
-    const texture = runtime_assets.texture(.ui_item_texts);
-    const src = rl.Rectangle.init(0.0, @as(f32, @floatFromInt(row)) * menu_label_row_height, menu_label_width, menu_label_row_height);
-    const width = menu_label_width;
-    const height = menu_label_height;
-    const x = (@as(f32, @floatFromInt(rl.getScreenWidth())) - width) * 0.5;
-    rl.drawTexturePro(texture, src, rl.Rectangle.init(x, y, width, height), rl.Vector2.zero(), 0.0, tint);
-}
-
-fn playGameButtons() [4]window_ui.UiButton {
-    const center_x = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
-    return .{
-        .{ .label = "SURVIVAL", .rect = window_ui.centeredRect(center_x, 276.0, 280.0, 48.0) },
-        .{ .label = "RUSH", .rect = window_ui.centeredRect(center_x, 332.0, 280.0, 48.0) },
-        .{ .label = "QUEST 1.1", .rect = window_ui.centeredRect(center_x, 388.0, 280.0, 48.0) },
-        .{ .label = "BACK", .rect = window_ui.centeredRect(center_x, 452.0, 220.0, 48.0) },
-    };
 }
 
 fn fallbackRootButtons() [4]window_ui.UiButton {

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -1,0 +1,703 @@
+const std = @import("std");
+const rl = @import("raylib");
+
+const cz = @import("crimson_zig");
+const formats = cz.formats;
+const game_ids = cz.game_ids;
+
+const window_assets = @import("window_assets.zig");
+const window_menu = @import("window_menu.zig");
+const window_ui = @import("window_ui.zig");
+
+const panel_color = rl.Color.init(37, 24, 20, 255);
+const panel_outline = rl.Color.init(122, 78, 58, 255);
+const text_color = rl.Color.init(245, 236, 225, 255);
+const muted_text = rl.Color.init(171, 150, 132, 255);
+const accent_color = rl.Color.init(218, 80, 46, 255);
+
+const player_count_labels = [_][:0]const u8{
+    "1 player",
+    "2 players",
+    "3 players",
+    "4 players",
+};
+
+const quest_titles = [_][]const u8{
+    "Land Hostile",             "Minor Alien Breach",      "Target Practice",        "Frontline Assault",      "Alien Dens",
+    "The Random Factor",        "Spider Wave Syndrome",    "Alien Squads",           "Nesting Grounds",        "8-legged Terror",
+    "Everred Pastures",         "Spider Spawns",           "Arachnoid Farm",         "Two Fronts",             "Sweep Stakes",
+    "Evil Zombies At Large",    "Survival Of The Fastest", "Land Of Lizards",        "Ghost Patrols",          "Spideroids",
+    "The Blighting",            "Lizard Kings",            "The Killing",            "Hidden Evil",            "Surrounded By Reptiles",
+    "The Lizquidation",         "Spiders Inc.",            "Lizard Raze",            "Deja vu",                "Zombie Masters",
+    "Major Alien Breach",       "Zombie Time",             "Lizard Zombie Pact",     "The Collaboration",      "The Massacre",
+    "The Unblitzkrieg",         "Gauntlet",                "Syntax Terror",          "The Annihilation",       "The End of All",
+    "The Beating",              "The Spanking Of The Dead","The Fortress",           "The Gang Wars",          "Knee-deep in the Dead",
+    "Cross Fire",               "Army of Three",           "Monster Blues",          "Nagolipoli",             "The Gathering",
+};
+
+const credits_lines = [_][]const u8{
+    "2026 Remake:",
+    "banteg",
+    "",
+    "Crimsonland",
+    "Game Design:",
+    "Tero Alatalo",
+    "",
+    "Programming:",
+    "Tero Alatalo",
+    "",
+    "Producer:",
+    "Zach Young",
+    "",
+    "2D Art:",
+    "Tero Alatalo",
+    "",
+    "3D Modelling:",
+    "Tero Alatalo",
+    "Timo Palonen",
+    "",
+    "Music:",
+    "Valtteri Pihlajam",
+    "Ville Eriksson",
+    "",
+    "Sound Effects:",
+    "Ion Hardie",
+    "Tero Alatalo",
+    "Valtteri Pihlajam",
+    "Ville Eriksson",
+    "",
+    "Manual:",
+    "Miikka Kulmala",
+    "Zach Young",
+    "",
+    "Special thanks to:",
+    "Petri J",
+    "Peter Hajba / Remedy",
+    "",
+    "Play testers:",
+    "Avraham Petrosyan",
+    "Bryce Baker",
+    "Dan Ruskin",
+    "Dirk Bunk",
+    "Eric Dallaire",
+    "Erik Van Pelt",
+    "Ernie Ramirez",
+    "Ion Hardie",
+    "James C. Smith",
+    "Jarkko Forsbacka",
+    "Jeff McAteer",
+    "Juha Alatalo",
+    "Kalle Hahl",
+    "Lars Brubaker",
+    "Lee Cooper",
+    "Markus Lassila",
+    "Matti Alanen",
+    "Miikka Kulmala",
+    "Mika Alatalo",
+    "Mike Colonnese",
+    "Simon Hallam",
+    "Toni Nurminen",
+    "Valtteri Pihlajam",
+    "Ville Eriksson",
+    "Ville M",
+    "Zach Young",
+    "",
+    "2003 (c) 10tons entertainment",
+    "10tons logo by Pasi Heinonen",
+    "",
+    "Uses Vorbis Audio Decompression",
+    "2003 (c) Xiph.Org Foundation",
+    "(see vorbis.txt)",
+};
+
+pub const PlayGameAction = enum {
+    start_survival,
+    start_rush,
+    open_quests,
+    back_to_menu,
+};
+
+pub const StatisticsAction = enum {
+    open_high_scores,
+    open_weapons,
+    open_perks,
+    open_credits,
+    back_to_menu,
+};
+
+pub const InfoKind = enum {
+    weapons,
+    perks,
+    credits,
+};
+
+const PanelState = struct {
+    selection: usize = 0,
+    timeline_ms: i32 = 0,
+    panel_open_sfx_played: bool = false,
+
+    fn reset(self: *PanelState) void {
+        self.* = .{};
+    }
+};
+
+pub const PlayGameState = struct {
+    panel: PanelState = .{},
+    player_list_open: bool = false,
+    player_count_selection: usize = 0,
+
+    pub fn reset(self: *PlayGameState) void {
+        self.* = .{};
+    }
+};
+
+pub const PlayGameResult = struct {
+    action: ?PlayGameAction = null,
+    play_panel_click: bool = false,
+    play_button_click: bool = false,
+    config_dirty: bool = false,
+};
+
+pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg) PlayGameResult {
+    const dt_ms = panelAdvance(&state.panel, frame_dt);
+    const player_count = @as(usize, @intCast(std.math.clamp(config.player_count, @as(u32, 1), @as(u32, 4))));
+    if (state.player_count_selection >= player_count_labels.len) state.player_count_selection = player_count - 1;
+
+    if (rl.isKeyPressed(.escape)) {
+        state.player_list_open = false;
+        return .{ .action = .back_to_menu, .play_button_click = true };
+    }
+
+    if (state.player_list_open) {
+        return updatePlayGamePlayerList(state, config, dt_ms);
+    }
+
+    const buttons = playGameButtons();
+    window_ui.updateSelectionFromPointer(&state.panel.selection, buttons[0..]);
+    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
+        state.panel.selection = if (state.panel.selection == 0) buttons.len - 1 else state.panel.selection - 1;
+    }
+    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
+        state.panel.selection = (state.panel.selection + 1) % buttons.len;
+    }
+
+    const selector = playerCountHeaderRect();
+    if (rl.checkCollisionPointRec(rl.getMousePosition(), selector) and rl.isMouseButtonPressed(.left)) {
+        state.player_list_open = true;
+        state.player_count_selection = player_count - 1;
+        return .{ .play_button_click = true };
+    }
+    if ((rl.isKeyPressed(.left) or rl.isKeyPressed(.right)) and state.panel.selection == buttons.len - 1) {
+        state.player_list_open = true;
+        state.player_count_selection = player_count - 1;
+        return .{ .play_button_click = true };
+    }
+
+    if (!window_ui.buttonActivated(buttons[0..], state.panel.selection)) {
+        return .{
+            .play_panel_click = dt_ms > 0 and state.panel.timeline_ms >= panel_timeline_max_ms and !state.panel.panel_open_sfx_played,
+        };
+    }
+
+    return switch (state.panel.selection) {
+        0 => .{ .action = .open_quests, .play_button_click = true },
+        1 => .{ .action = .start_rush, .play_button_click = true, .config_dirty = setConfigGameMode(config, .rush) },
+        2 => .{ .action = .start_survival, .play_button_click = true, .config_dirty = setConfigGameMode(config, .survival) },
+        3 => .{ .action = .back_to_menu, .play_button_click = true },
+        else => .{},
+    };
+}
+
+fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.CrimsonCfg, dt_ms: i32) PlayGameResult {
+    _ = dt_ms;
+    if (rl.isKeyPressed(.escape)) {
+        state.player_list_open = false;
+        return .{};
+    }
+    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
+        state.player_count_selection = if (state.player_count_selection == 0) player_count_labels.len - 1 else state.player_count_selection - 1;
+    }
+    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
+        state.player_count_selection = (state.player_count_selection + 1) % player_count_labels.len;
+    }
+
+    const mouse = rl.getMousePosition();
+    for (0..player_count_labels.len) |idx| {
+        if (rl.checkCollisionPointRec(mouse, playerCountRowRect(idx)) and rl.isMouseButtonPressed(.left)) {
+            config.player_count = @intCast(idx + 1);
+            state.player_list_open = false;
+            return .{ .play_button_click = true, .config_dirty = true };
+        }
+    }
+
+    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space)) {
+        config.player_count = @intCast(state.player_count_selection + 1);
+        state.player_list_open = false;
+        return .{ .play_button_click = true, .config_dirty = true };
+    }
+
+    if (rl.isMouseButtonPressed(.left) and !rl.checkCollisionPointRec(mouse, playerCountListRect())) {
+        state.player_list_open = false;
+    }
+
+    return .{};
+}
+
+pub fn drawPlayGame(state: *const PlayGameState, runtime_assets: ?*const window_assets.RuntimeAssets, status: formats.game_cfg.Status, player_count_raw: u32) void {
+    if (runtime_assets) |assets| {
+        drawMenuPanelShell(state.panel.timeline_ms, assets, .{ .x = 420.0, .y = 180.0, .width = 430.0, .height = 330.0 }, window_menu.label_row_play_game);
+        drawPlayGameContent(state, assets, status, player_count_raw);
+        return;
+    }
+    rl.clearBackground(panel_color);
+}
+
+fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const window_assets.RuntimeAssets, status: formats.game_cfg.Status, player_count_raw: u32) void {
+    const buttons = playGameButtons();
+    for (buttons, 0..) |button, idx| {
+        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
+        window_ui.drawButton(button, idx == state.panel.selection and !state.player_list_open, hovered, runtime_assets);
+    }
+
+    window_ui.drawSmallText(runtime_assets, "PLAYER COUNT", 492.0, 244.0, muted_text);
+    drawPlayerCountWidget(state, runtime_assets, player_count_raw);
+
+    window_ui.drawSmallText(runtime_assets, "QUESTS", 628.0, 288.0, muted_text);
+    window_ui.drawSmallText(runtime_assets, "RUSH", 640.0, 344.0, muted_text);
+    window_ui.drawSmallText(runtime_assets, "SURVIVAL", 616.0, 400.0, muted_text);
+    window_ui.drawSmallTextFmt("{d}", runtime_assets, .{questTotalPlayed(status)}, 760.0, 288.0, text_color);
+    window_ui.drawSmallTextFmt("{d}", runtime_assets, .{status.mode_play_rush}, 760.0, 344.0, text_color);
+    window_ui.drawSmallTextFmt("{d}", runtime_assets, .{status.mode_play_survival}, 760.0, 400.0, text_color);
+}
+
+fn drawPlayerCountWidget(state: *const PlayGameState, runtime_assets: *const window_assets.RuntimeAssets, player_count_raw: u32) void {
+    const rect = playerCountHeaderRect();
+    const selected_index = @as(usize, @intCast(std.math.clamp(player_count_raw, @as(u32, 1), @as(u32, 4)))) - 1;
+    const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), rect);
+    const texture = if (state.player_list_open or hovered) runtime_assets.texture(.ui_drop_on) else runtime_assets.texture(.ui_drop_off);
+
+    rl.drawRectangleRec(rect, rl.Color.white);
+    rl.drawRectangle(@intFromFloat(rect.x + 1.0), @intFromFloat(rect.y + 1.0), @intFromFloat(rect.width - 2.0), @intFromFloat(rect.height - 2.0), rl.Color.black);
+    window_ui.drawSmallText(runtime_assets, player_count_labels[selected_index], rect.x + 4.0, rect.y + 1.0, if (hovered or state.player_list_open) text_color else muted_text);
+    rl.drawTexturePro(
+        texture,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height)),
+        rl.Rectangle.init(rect.x + rect.width - 17.0, rect.y, 16.0, 16.0),
+        rl.Vector2.zero(),
+        0.0,
+        rl.Color.white,
+    );
+
+    if (!state.player_list_open) return;
+
+    const list_rect = playerCountListRect();
+    rl.drawRectangleRec(list_rect, rl.Color.white);
+    rl.drawRectangle(@intFromFloat(list_rect.x + 1.0), @intFromFloat(list_rect.y + 1.0), @intFromFloat(list_rect.width - 2.0), @intFromFloat(list_rect.height - 2.0), rl.Color.black);
+    for (player_count_labels, 0..) |label, idx| {
+        const row_rect = playerCountRowRect(idx);
+        const row_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), row_rect);
+        window_ui.drawSmallText(runtime_assets, label, row_rect.x + 4.0, row_rect.y + 1.0, if (row_hovered or idx == state.player_count_selection) text_color else muted_text);
+    }
+}
+
+fn questTotalPlayed(status: formats.game_cfg.Status) u32 {
+    var total: u32 = 0;
+    var idx: usize = 11;
+    while (idx <= 50 and idx < status.quest_play_counts.len) : (idx += 1) {
+        total +%= status.quest_play_counts[idx];
+    }
+    return total;
+}
+
+pub const QuestState = struct {
+    panel: PanelState = .{},
+    stage: i32 = 1,
+    row_selection: usize = 0,
+
+    pub fn reset(self: *QuestState) void {
+        self.* = .{};
+    }
+};
+
+pub const QuestResult = struct {
+    start_level_key: ?i32 = null,
+    back_to_play_game: bool = false,
+    play_panel_click: bool = false,
+    play_button_click: bool = false,
+    config_dirty: bool = false,
+};
+
+pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) QuestResult {
+    const dt_ms = panelAdvance(&state.panel, frame_dt);
+    if (rl.isKeyPressed(.escape)) return .{ .back_to_play_game = true, .play_button_click = true };
+
+    if (rl.isKeyPressed(.left)) state.stage = @max(1, state.stage - 1);
+    if (rl.isKeyPressed(.right)) state.stage = @min(5, state.stage + 1);
+    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
+        state.row_selection = if (state.row_selection == 0) 9 else state.row_selection - 1;
+    }
+    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
+        state.row_selection = (state.row_selection + 1) % 10;
+    }
+
+    const hovered_stage = hoveredQuestStage();
+    if (hovered_stage) |stage| {
+        state.stage = stage;
+        if (rl.isMouseButtonPressed(.left)) return .{ .play_button_click = true };
+    }
+
+    const hovered_row = hoveredQuestRow(hardcoreUnlocked(status));
+    if (hovered_row) |row| {
+        state.row_selection = row;
+    }
+
+    if (hardcoreUnlocked(status)) {
+        const hardcore_rect = hardcoreCheckRect();
+        if (rl.checkCollisionPointRec(rl.getMousePosition(), hardcore_rect) and rl.isMouseButtonPressed(.left)) {
+            config.hardcore_flag = if (config.hardcore_flag == 0) 1 else 0;
+            return .{ .play_button_click = true, .config_dirty = true };
+        }
+    }
+
+    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space) or (hovered_row != null and rl.isMouseButtonPressed(.left))) {
+        if (questUnlocked(status, config.hardcore_flag != 0, state.stage, @intCast(state.row_selection + 1))) {
+            const level_key = state.stage * 100 + @as(i32, @intCast(state.row_selection + 1));
+            config.game_mode = @intFromEnum(game_ids.GameModeId.quests);
+            return .{ .start_level_key = level_key, .play_button_click = true, .config_dirty = true };
+        }
+    }
+
+    if (backButtonActivated()) {
+        return .{ .back_to_play_game = true, .play_button_click = true };
+    }
+
+    return .{
+        .play_panel_click = dt_ms > 0 and state.panel.timeline_ms >= panel_timeline_max_ms and !state.panel.panel_open_sfx_played,
+    };
+}
+
+pub fn drawQuests(state: *const QuestState, runtime_assets: ?*const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) void {
+    if (runtime_assets) |assets| {
+        drawMenuPanelShell(state.panel.timeline_ms, assets, .{ .x = 320.0, .y = 132.0, .width = 620.0, .height = 430.0 }, window_assets.TextureId.ui_text_quest);
+        drawQuestContent(state, assets, config, status);
+        return;
+    }
+    rl.clearBackground(panel_color);
+}
+
+fn drawQuestContent(state: *const QuestState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) void {
+    const base_x: f32 = 390.0;
+    const base_y: f32 = 182.0;
+    drawTextureLabel(runtime_assets, .ui_text_quest, 480.0, 166.0, 128.0, 32.0, rl.Color.init(179, 179, 179, 179));
+
+    const stage_textures = [_]window_assets.TextureId{ .ui_num1, .ui_num2, .ui_num3, .ui_num4, .ui_num5 };
+    for (stage_textures, 0..) |texture_id, idx| {
+        const stage = @as(i32, @intCast(idx + 1));
+        const rect = questStageRect(stage);
+        const tint = if (stage == state.stage) rl.Color.white else if (hoveredQuestStage() != null and hoveredQuestStage().? == stage) rl.Color.init(255, 255, 255, 204) else rl.Color.init(179, 179, 179, 179);
+        window_ui.drawTextureFit(runtime_assets.texture(texture_id), rect, tint);
+    }
+
+    if (hardcoreUnlocked(status)) {
+        const check_tex = if (config.hardcore_flag != 0) runtime_assets.texture(.ui_check_on) else runtime_assets.texture(.ui_check_off);
+        const rect = hardcoreCheckRect();
+        window_ui.drawTextureFit(check_tex, rl.Rectangle.init(rect.x, rect.y, @floatFromInt(check_tex.width), @floatFromInt(check_tex.height)), rl.Color.white);
+        window_ui.drawSmallText(runtime_assets, "Hardcore", rect.x + @as(f32, @floatFromInt(check_tex.width)) + 6.0, rect.y + 1.0, muted_text);
+    }
+
+    var y = base_y + (if (hardcoreUnlocked(status)) @as(f32, 26.0) else @as(f32, 0.0));
+    const hovered_row = hoveredQuestRow(hardcoreUnlocked(status));
+    for (0..10) |row| {
+        const level_minor = @as(i32, @intCast(row + 1));
+        const unlocked = questUnlocked(status, config.hardcore_flag != 0, state.stage, level_minor);
+        const hovered = hovered_row != null and hovered_row.? == row;
+        const color = if (hovered or row == state.row_selection) rl.Color.init(70, 180, 240, 255) else rl.Color.init(70, 180, 240, 153);
+        window_ui.drawSmallTextFmt("{d}.{d}", runtime_assets, .{ state.stage, level_minor }, base_x, y, color);
+        const title = if (unlocked) questTitle(state.stage, level_minor) else "???";
+        window_ui.drawSmallText(runtime_assets, title, base_x + 52.0, y, color);
+        y += 18.0;
+    }
+
+    const back = backOnlyButton()[0];
+    const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
+    window_ui.drawButton(back, false, hovered, runtime_assets);
+}
+
+fn questUnlocked(status: formats.game_cfg.Status, hardcore: bool, stage: i32, minor: i32) bool {
+    const global_index = (stage - 1) * 10 + (minor - 1);
+    const unlock = if (hardcore) status.quest_unlock_index_full else status.quest_unlock_index;
+    return @as(i32, unlock) >= global_index;
+}
+
+fn hardcoreUnlocked(status: formats.game_cfg.Status) bool {
+    return status.quest_unlock_index >= 49;
+}
+
+fn questTitle(stage: i32, minor: i32) []const u8 {
+    const index = (stage - 1) * 10 + (minor - 1);
+    return quest_titles[@intCast(std.math.clamp(index, @as(i32, 0), @as(i32, @intCast(quest_titles.len - 1))))];
+}
+
+fn questStageRect(stage: i32) rl.Rectangle {
+    return rl.Rectangle.init(554.0 + @as(f32, @floatFromInt(stage - 1)) * 40.0, 170.0, 32.0, 32.0);
+}
+
+fn hoveredQuestStage() ?i32 {
+    const mouse = rl.getMousePosition();
+    for (1..6) |stage| {
+        if (rl.checkCollisionPointRec(mouse, questStageRect(@intCast(stage)))) return @intCast(stage);
+    }
+    return null;
+}
+
+fn hoveredQuestRow(show_hardcore_toggle: bool) ?usize {
+    const mouse = rl.getMousePosition();
+    var y: f32 = 182.0 + if (show_hardcore_toggle) @as(f32, 26.0) else @as(f32, 0.0);
+    for (0..10) |row| {
+        const rect = rl.Rectangle.init(382.0, y - 3.0, 340.0, 16.0);
+        if (rl.checkCollisionPointRec(mouse, rect)) return row;
+        y += 18.0;
+    }
+    return null;
+}
+
+fn hardcoreCheckRect() rl.Rectangle {
+    return rl.Rectangle.init(390.0, 182.0, 90.0, 16.0);
+}
+
+pub const StatisticsState = struct {
+    panel: PanelState = .{},
+
+    pub fn reset(self: *StatisticsState) void {
+        self.* = .{};
+    }
+};
+
+pub const StatisticsResult = struct {
+    action: ?StatisticsAction = null,
+    play_panel_click: bool = false,
+    play_button_click: bool = false,
+};
+
+pub fn updateStatistics(state: *StatisticsState, frame_dt: f32) StatisticsResult {
+    const dt_ms = panelAdvance(&state.panel, frame_dt);
+    const buttons = statisticsButtons();
+    window_ui.updateSelectionFromPointer(&state.panel.selection, buttons[0..]);
+    if (rl.isKeyPressed(.escape)) return .{ .action = .back_to_menu, .play_button_click = true };
+    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
+        state.panel.selection = if (state.panel.selection == 0) buttons.len - 1 else state.panel.selection - 1;
+    }
+    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
+        state.panel.selection = (state.panel.selection + 1) % buttons.len;
+    }
+    if (!window_ui.buttonActivated(buttons[0..], state.panel.selection)) {
+        return .{
+            .play_panel_click = dt_ms > 0 and state.panel.timeline_ms >= panel_timeline_max_ms and !state.panel.panel_open_sfx_played,
+        };
+    }
+    return .{
+        .play_button_click = true,
+        .action = switch (state.panel.selection) {
+            0 => .open_high_scores,
+            1 => .open_weapons,
+            2 => .open_perks,
+            3 => .open_credits,
+            4 => .back_to_menu,
+            else => null,
+        },
+    };
+}
+
+pub fn drawStatistics(state: *const StatisticsState, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+    if (runtime_assets) |assets| {
+        drawMenuPanelShell(state.panel.timeline_ms, assets, .{ .x = 390.0, .y = 168.0, .width = 500.0, .height = 360.0 }, window_menu.label_row_statistics);
+        const buttons = statisticsButtons();
+        for (buttons, 0..) |button, idx| {
+            const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
+            window_ui.drawButton(button, idx == state.panel.selection, hovered, assets);
+        }
+        return;
+    }
+    rl.clearBackground(panel_color);
+}
+
+pub const InfoViewState = struct {
+    kind: InfoKind = .weapons,
+    scroll: usize = 0,
+
+    pub fn open(self: *InfoViewState, kind: InfoKind) void {
+        self.* = .{ .kind = kind };
+    }
+};
+
+pub const InfoResult = struct {
+    back_to_statistics: bool = false,
+};
+
+pub fn updateInfoView(state: *InfoViewState) InfoResult {
+    const max_scroll = infoMaxScroll(state.kind);
+    if (rl.isKeyPressed(.escape) or backButtonActivated()) {
+        return .{ .back_to_statistics = true };
+    }
+    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
+        if (state.scroll > 0) state.scroll -= 1;
+    }
+    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
+        state.scroll = @min(state.scroll + 1, max_scroll);
+    }
+    return .{};
+}
+
+pub fn drawInfoView(state: *const InfoViewState, runtime_assets: ?*const window_assets.RuntimeAssets, status: formats.game_cfg.Status) void {
+    if (runtime_assets) |assets| {
+        drawMenuPanelShell(300, assets, .{ .x = 250.0, .y = 118.0, .width = 780.0, .height = 500.0 }, infoLabelRow(state.kind));
+        drawInfoContents(state, assets, status);
+        return;
+    }
+    rl.clearBackground(panel_color);
+}
+
+fn drawInfoContents(state: *const InfoViewState, runtime_assets: *const window_assets.RuntimeAssets, status: formats.game_cfg.Status) void {
+    const lines = infoLines(state.kind, status);
+    const start = state.scroll;
+    const end = @min(start + 20, lines.len);
+    var y: f32 = 178.0;
+    for (lines[start..end]) |line| {
+        window_ui.drawSmallText(runtime_assets, line, 300.0, y, text_color);
+        y += 16.0;
+    }
+    const back = backOnlyButton()[0];
+    const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
+    window_ui.drawButton(back, false, hovered, runtime_assets);
+}
+
+fn infoLines(kind: InfoKind, status: formats.game_cfg.Status) []const []const u8 {
+    _ = status;
+    return switch (kind) {
+        .credits => credits_lines[0..],
+        .weapons => weapon_lines[0..],
+        .perks => perk_lines[0..],
+    };
+}
+
+fn infoMaxScroll(kind: InfoKind) usize {
+    const total = switch (kind) {
+        .credits => credits_lines.len,
+        .weapons => weapon_lines.len,
+        .perks => perk_lines.len,
+    };
+    return if (total > 20) total - 20 else 0;
+}
+
+fn infoLabelRow(kind: InfoKind) i32 {
+    return switch (kind) {
+        .credits => window_menu.label_row_statistics,
+        .weapons => window_menu.label_row_statistics,
+        .perks => window_menu.label_row_statistics,
+    };
+}
+
+fn panelAdvance(panel: *PanelState, frame_dt: f32) i32 {
+    const dt_ms = @as(i32, @intFromFloat(@min(frame_dt, 0.1) * 1000.0));
+    if (dt_ms > 0) {
+        panel.timeline_ms = @min(panel_timeline_max_ms, panel.timeline_ms + dt_ms);
+    }
+    return dt_ms;
+}
+
+const panel_timeline_max_ms: i32 = 300;
+
+fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle, title_row_or_texture: anytype) void {
+    window_menu.drawMenuBackdrop(runtime_assets);
+    window_menu.drawSign(timeline_ms, runtime_assets);
+
+    const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
+    const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
+    window_ui.drawTextureFit(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+
+    const T = @TypeOf(title_row_or_texture);
+    if (T == i32) {
+        window_menu.drawAtlasLabelCentered(runtime_assets, title_row_or_texture, rect.y + 42.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    } else {
+        drawTextureLabel(runtime_assets, title_row_or_texture, rect.x + rect.width * 0.5 - 64.0, rect.y + 34.0, 128.0, 32.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    }
+}
+
+fn drawTextureLabel(runtime_assets: *const window_assets.RuntimeAssets, texture_id: window_assets.TextureId, x: f32, y: f32, w: f32, h: f32, tint: rl.Color) void {
+    window_ui.drawTextureFit(runtime_assets.texture(texture_id), rl.Rectangle.init(x, y, w, h), tint);
+}
+
+fn playGameButtons() [4]window_ui.UiButton {
+    const center_x = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
+    return .{
+        .{ .label = "QUESTS", .rect = window_ui.centeredRect(center_x - 44.0, 276.0, 210.0, 48.0) },
+        .{ .label = "RUSH", .rect = window_ui.centeredRect(center_x - 44.0, 332.0, 210.0, 48.0) },
+        .{ .label = "SURVIVAL", .rect = window_ui.centeredRect(center_x - 44.0, 388.0, 210.0, 48.0) },
+        .{ .label = "BACK", .rect = window_ui.centeredRect(center_x, 454.0, 180.0, 44.0) },
+    };
+}
+
+fn playerCountHeaderRect() rl.Rectangle {
+    return rl.Rectangle.init(492.0, 258.0, 124.0, 16.0);
+}
+
+fn playerCountListRect() rl.Rectangle {
+    return rl.Rectangle.init(492.0, 258.0, 124.0, 80.0);
+}
+
+fn playerCountRowRect(idx: usize) rl.Rectangle {
+    return rl.Rectangle.init(492.0, 275.0 + @as(f32, @floatFromInt(idx)) * 16.0, 124.0, 16.0);
+}
+
+fn statisticsButtons() [5]window_ui.UiButton {
+    const center_x = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
+    return .{
+        .{ .label = "HIGH SCORES", .rect = window_ui.centeredRect(center_x, 250.0, 240.0, 44.0) },
+        .{ .label = "WEAPONS", .rect = window_ui.centeredRect(center_x, 304.0, 240.0, 44.0) },
+        .{ .label = "PERKS", .rect = window_ui.centeredRect(center_x, 358.0, 240.0, 44.0) },
+        .{ .label = "CREDITS", .rect = window_ui.centeredRect(center_x, 412.0, 240.0, 44.0) },
+        .{ .label = "BACK", .rect = window_ui.centeredRect(center_x, 478.0, 180.0, 44.0) },
+    };
+}
+
+fn backOnlyButton() [1]window_ui.UiButton {
+    return .{
+        .{ .label = "BACK", .rect = window_ui.centeredRect(@as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5, 562.0, 180.0, 44.0) },
+    };
+}
+
+fn setConfigGameMode(config: *formats.crimson_cfg.CrimsonCfg, mode: game_ids.GameModeId) bool {
+    const mode_value: u32 = @intCast(@intFromEnum(mode));
+    if (config.game_mode == mode_value) return false;
+    config.game_mode = mode_value;
+    return true;
+}
+
+fn backButtonActivated() bool {
+    const back = backOnlyButton()[0];
+    return rl.isMouseButtonPressed(.left) and rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
+}
+
+const weapon_lines = buildWeaponLines();
+const perk_lines = buildPerkLines();
+
+fn buildWeaponLines() [53][]const u8 {
+    var lines: [53][]const u8 = undefined;
+    var idx: usize = 0;
+    inline for (std.meta.fields(game_ids.WeaponId)) |field| {
+        const weapon_id: game_ids.WeaponId = @enumFromInt(field.value);
+        if (weapon_id == .none) continue;
+        lines[idx] = game_ids.weaponDisplayName(weapon_id, false);
+        idx += 1;
+    }
+    return lines;
+}
+
+fn buildPerkLines() [58][]const u8 {
+    var lines: [58][]const u8 = undefined;
+    inline for (std.meta.fields(game_ids.PerkId), 0..) |field, idx| {
+        const perk_id: game_ids.PerkId = @enumFromInt(field.value);
+        lines[idx] = game_ids.perkDisplayName(perk_id, 0, false);
+    }
+    return lines;
+}

--- a/crimson-zig/src/window_ui.zig
+++ b/crimson-zig/src/window_ui.zig
@@ -164,3 +164,27 @@ pub fn measureSmallText(runtime_assets: *const window_assets.RuntimeAssets, text
     }
     return @max(best, width);
 }
+
+pub fn drawSmallTextCentered(
+    runtime_assets: *const window_assets.RuntimeAssets,
+    text: []const u8,
+    y: f32,
+    color: rl.Color,
+) void {
+    const width = measureSmallText(runtime_assets, text);
+    const x = (@as(f32, @floatFromInt(rl.getScreenWidth())) - width) * 0.5;
+    drawSmallText(runtime_assets, text, x, y, color);
+}
+
+pub fn drawSmallTextFmt(
+    comptime fmt: []const u8,
+    runtime_assets: *const window_assets.RuntimeAssets,
+    args: anytype,
+    x: f32,
+    y: f32,
+    color: rl.Color,
+) void {
+    var buf: [256]u8 = undefined;
+    const text = std.fmt.bufPrint(&buf, fmt, args) catch return;
+    drawSmallText(runtime_assets, text, x, y, color);
+}


### PR DESCRIPTION
## Summary
- split the Zig shell menu flow into dedicated menu-panel modules instead of growing `window_main.zig`
- replace the direct `QUEST 1.1` launcher with a real `PLAY GAME -> QUESTS` panel flow
- add a `STATISTICS` hub with routes to high scores, weapons, perks, and credits

## Testing
- zig build window
- zig build test
- zig build wasm
- zig build run-window
