### PR TITLE
fix(zig): tighten menu shell parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,22 @@ jobs:
         with:
           version: "0.15.2"
 
+      - name: Install Zig system libraries
+        if: matrix.use_zig
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgl1-mesa-dev \
+            libglx-dev \
+            libx11-dev \
+            libxcursor-dev \
+            libxext-dev \
+            libxfixes-dev \
+            libxi-dev \
+            libxinerama-dev \
+            libxrandr-dev \
+            libxrender-dev
+
       - name: Setup Node
         if: ${{ matrix.task == 'ast-grep' }}
         uses: actions/setup-node@v6

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -30,6 +30,21 @@ jobs:
         with:
           version: "0.15.2"
 
+      - name: Install Zig system libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgl1-mesa-dev \
+            libglx-dev \
+            libx11-dev \
+            libxcursor-dev \
+            libxext-dev \
+            libxfixes-dev \
+            libxi-dev \
+            libxinerama-dev \
+            libxrandr-dev \
+            libxrender-dev
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/crimson-zig/src/formats/crimson_cfg.zig
+++ b/crimson-zig/src/formats/crimson_cfg.zig
@@ -419,11 +419,11 @@ pub fn setSelectedSavedNameSlot(cfg: *CrimsonCfg, slot_index: usize) void {
 }
 
 pub fn savedNameLabel(cfg: *const CrimsonCfg, slot_index: usize) []const u8 {
-    const safe_index = @min(slot_index, saved_name_slot_count - 1);
-    const order_offset = safe_index * 4;
+    const safe_index: usize = @min(slot_index, saved_name_slot_count - 1);
+    const order_offset: usize = safe_index * 4;
     const raw_slot = std.mem.readInt(u32, cfg.saved_name_order[order_offset..][0..4], .little);
-    const mapped_slot = @min(raw_slot, saved_name_slot_count - 1);
-    const start = mapped_slot * saved_name_entry_size;
+    const mapped_slot: usize = @min(@as(usize, raw_slot), saved_name_slot_count - 1);
+    const start: usize = mapped_slot * saved_name_entry_size;
     const bytes = cfg.saved_names[start .. start + saved_name_entry_size];
     return std.mem.sliceTo(bytes, 0);
 }

--- a/crimson-zig/src/runtime/weapon_data.zig
+++ b/crimson-zig/src/runtime/weapon_data.zig
@@ -132,15 +132,22 @@ pub fn weaponIdFromInt(value: i32) WeaponId {
     return @enumFromInt(value);
 }
 
+// Mirror Python/native `PROJECTILE_TEMPLATE_OVERRIDES`: explicit remaps and
+// non-primary paths live here; other projectile-backed weapons default to
+// `type_id == weapon_id` when the projectile enum has that slot.
 pub fn projectileTypeIdFromWeaponId(weapon_id: WeaponId) ?ProjectileTypeId {
-    // Mirror Python/native `PROJECTILE_TEMPLATE_OVERRIDES`: explicit remaps and
-    // non-primary paths live here; other projectile-backed weapons default to
-    // `type_id == weapon_id` when the projectile enum has that slot.
     return switch (weapon_id) {
+        .pistol => ProjectileTypeId.pistol,
+        .assault_rifle => ProjectileTypeId.assault_rifle,
+        .shotgun => ProjectileTypeId.shotgun,
         .sawed_off_shotgun => ProjectileTypeId.shotgun,
+        .submachine_gun => ProjectileTypeId.submachine_gun,
+        .gauss_gun => ProjectileTypeId.gauss_gun,
         .mean_minigun => ProjectileTypeId.pistol,
         .flamethrower => null,
         .multi_plasma => ProjectileTypeId.plasma_rifle,
+        .plasma_rifle => ProjectileTypeId.plasma_rifle,
+        .plasma_minigun => ProjectileTypeId.plasma_minigun,
         .rocket_launcher => null,
         .seeker_rockets => null,
         .plasma_shotgun => ProjectileTypeId.plasma_minigun,
@@ -148,11 +155,31 @@ pub fn projectileTypeIdFromWeaponId(weapon_id: WeaponId) ?ProjectileTypeId {
         .hr_flamer => null,
         .mini_rocket_swarmers => null,
         .rocket_minigun => null,
+        .pulse_gun => ProjectileTypeId.pulse_gun,
         .jackhammer => ProjectileTypeId.shotgun,
+        .ion_rifle => ProjectileTypeId.ion_rifle,
+        .ion_minigun => ProjectileTypeId.ion_minigun,
+        .ion_cannon => ProjectileTypeId.ion_cannon,
+        .shrinkifier_5k => ProjectileTypeId.shrinkifier,
+        .blade_gun => ProjectileTypeId.blade_gun,
+        .spider_plasma => ProjectileTypeId.spider_plasma,
+        .evil_scythe => ProjectileTypeId.evil_scythe,
+        .plasma_cannon => ProjectileTypeId.plasma_cannon,
+        .splitter_gun => ProjectileTypeId.splitter_gun,
         .gauss_shotgun => ProjectileTypeId.gauss_gun,
         .ion_shotgun => ProjectileTypeId.ion_minigun,
+        .flameburst => ProjectileTypeId.flameburst,
+        .raygun => ProjectileTypeId.raygun,
+        .plague_spreader_gun => ProjectileTypeId.plague_spreader,
         .bubblegun => null,
-        else => std.meta.intToEnum(ProjectileTypeId, @intFromEnum(weapon_id)) catch null,
+        .rainbow_gun => ProjectileTypeId.rainbow_gun,
+        .grim_weapon => ProjectileTypeId.grim_weapon,
+        .fire_bullets => ProjectileTypeId.fire_bullets,
+        .transmutator => ProjectileTypeId.transmutator,
+        .blaster_r_300 => ProjectileTypeId.blaster_r_300,
+        .lightning_rifle => ProjectileTypeId.lightning_rifle,
+        .nuke_launcher => ProjectileTypeId.nuke_launcher,
+        else => null,
     };
 }
 

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -425,6 +425,7 @@ const App = struct {
             self.runtime.base_dir,
             &self.runtime.config,
             self.runtime.status,
+            if (self.runtime_assets) |*assets| assets else null,
         );
         if (statistics_update.play_panel_click and !self.statistics_menu.hub.panel.panel_open_sfx_played) {
             self.audio.playUiPanelClick();

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -374,7 +374,7 @@ const App = struct {
 
     fn updatePlayGameMenu(self: *App, frame_dt: f32) void {
         self.audio.ensureMenuTheme();
-        const play_game_update = window_menu_panels.updatePlayGame(&self.play_game_menu, frame_dt, &self.runtime.config, self.runtime.status);
+        const play_game_update = window_menu_panels.updatePlayGame(&self.play_game_menu, frame_dt, &self.runtime.config, self.runtime.status, if (self.runtime_assets) |*assets| assets else null);
         if (play_game_update.config_dirty) self.runtime.config_dirty = true;
         if (play_game_update.play_panel_click and !self.play_game_menu.panel.panel_open_sfx_played) {
             self.audio.playUiPanelClick();
@@ -526,7 +526,7 @@ const App = struct {
 
     fn updateOptions(self: *App, frame_dt: f32) void {
         self.audio.ensureMenuTheme();
-        const options_update = window_options.updateOptions(&self.options, frame_dt, &self.runtime.config);
+        const options_update = window_options.updateOptions(&self.options, frame_dt, &self.runtime.config, if (self.runtime_assets) |*assets| assets else null);
         if (options_update.config_dirty) self.runtime.config_dirty = true;
         if (options_update.reload_audio) self.reloadAudioConfig();
         if (options_update.play_panel_click and !self.options.panel.panel_open_sfx_played) {
@@ -549,7 +549,7 @@ const App = struct {
 
     fn updateControls(self: *App, frame_dt: f32) void {
         self.audio.ensureMenuTheme();
-        const controls_update = window_options.updateControls(&self.controls, frame_dt, &self.runtime.config);
+        const controls_update = window_options.updateControls(&self.controls, frame_dt, &self.runtime.config, if (self.runtime_assets) |*assets| assets else null);
         if (controls_update.config_dirty) self.runtime.config_dirty = true;
         if (controls_update.play_panel_click and !self.controls.panel_open_sfx_played) {
             self.audio.playUiPanelClick();

--- a/crimson-zig/src/window_menu.zig
+++ b/crimson-zig/src/window_menu.zig
@@ -33,6 +33,8 @@ pub const label_row_options: i32 = 2;
 pub const label_row_statistics: i32 = 3;
 pub const label_row_quit: i32 = 6;
 pub const label_row_back: i32 = 7;
+pub const panel_back_pos_x: f32 = -55.0;
+pub const panel_back_pos_y: f32 = 430.0;
 
 pub const Action = enum {
     open_play_game,
@@ -225,6 +227,60 @@ pub fn menuWidescreenYShift(screen_w: f32) f32 {
 
 pub fn menuScale(screen_w: i32) struct { scale: f32, shift_x: f32 } {
     return mainMenuSignLayoutScale(screen_w);
+}
+
+pub fn panelBackHitRect(runtime_assets: *const window_assets.RuntimeAssets, timeline_ms: i32) rl.Rectangle {
+    const item = runtime_assets.texture(.ui_menu_item);
+    const item_w = @as(f32, @floatFromInt(item.width));
+    const item_h = @as(f32, @floatFromInt(item.height));
+    const scale_info = menuItemScale(0);
+    const anim = uiElementAnim(2, 300, 0, item_w * scale_info.scale, timeline_ms);
+    const pos = rl.Vector2.init(panel_back_pos_x + anim.offset_x, panel_back_pos_y + menuWidescreenYShift(@floatFromInt(rl.getScreenWidth())));
+    const offset_min = rl.Vector2.init(
+        menu_item_offset_x * scale_info.scale,
+        menu_item_offset_y * scale_info.scale - scale_info.local_y_shift,
+    );
+    const offset_max = rl.Vector2.init(
+        (menu_item_offset_x + item_w) * scale_info.scale,
+        (menu_item_offset_y + item_h) * scale_info.scale - scale_info.local_y_shift,
+    );
+    const size = rl.Vector2.init(offset_max.x - offset_min.x, offset_max.y - offset_min.y);
+    const top_left = rl.Vector2.init(pos.x + offset_min.x + size.x * 0.54, pos.y + offset_min.y + size.y * 0.28);
+    const bottom_right = rl.Vector2.init(pos.x + offset_max.x - size.x * 0.05, pos.y + offset_max.y - size.y * 0.10);
+    return rl.Rectangle.init(top_left.x, top_left.y, bottom_right.x - top_left.x, bottom_right.y - top_left.y);
+}
+
+pub fn drawPanelBackEntry(runtime_assets: *const window_assets.RuntimeAssets, timeline_ms: i32, hover_amount: i32) void {
+    const item = runtime_assets.texture(.ui_menu_item);
+    const labels = runtime_assets.texture(.ui_item_texts);
+    const item_w = @as(f32, @floatFromInt(item.width));
+    const item_h = @as(f32, @floatFromInt(item.height));
+    const scale_info = menuItemScale(0);
+    const pos_x = panel_back_pos_x;
+    const pos_y = panel_back_pos_y + menuWidescreenYShift(@floatFromInt(rl.getScreenWidth()));
+    const anim = uiElementAnim(2, 300, 0, item_w * scale_info.scale, timeline_ms);
+    const dst = rl.Rectangle.init(pos_x + anim.offset_x, pos_y, item_w * scale_info.scale, item_h * scale_info.scale);
+    const origin = rl.Vector2.init(-(menu_item_offset_x * scale_info.scale), -(menu_item_offset_y * scale_info.scale - scale_info.local_y_shift));
+    const rotation_deg = radiansToDegrees(anim.angle_rad);
+
+    rl.drawTexturePro(
+        item,
+        rl.Rectangle.init(0.0, 0.0, item_w, item_h),
+        dst,
+        origin,
+        rotation_deg,
+        rl.Color.white,
+    );
+
+    const label_alpha = mainMenuLabelAlpha(hover_amount);
+    const tint = rl.Color.init(255, 255, 255, label_alpha);
+    const src = rl.Rectangle.init(0.0, @as(f32, @floatFromInt(label_row_back)) * menu_label_row_height, menu_label_width, menu_label_row_height);
+    const label_dst = rl.Rectangle.init(pos_x + anim.offset_x, pos_y, menu_label_width * scale_info.scale, menu_label_height * scale_info.scale);
+    const label_origin = rl.Vector2.init(-(menu_label_offset_x * scale_info.scale), -(menu_label_offset_y * scale_info.scale - scale_info.local_y_shift));
+    rl.drawTexturePro(labels, src, label_dst, label_origin, rotation_deg, tint);
+    rl.beginBlendMode(.additive);
+    rl.drawTexturePro(labels, src, label_dst, label_origin, rotation_deg, tint);
+    rl.endBlendMode();
 }
 
 fn drawFallbackBackdrop() void {

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -987,9 +987,9 @@ fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.Run
 
     const T = @TypeOf(title_row_or_texture);
     if (T == i32) {
-        drawAtlasLabelAt(runtime_assets, panel_rect.x + (panel_rect.width - 128.0) * 0.5, rect.y + 42.0, title_row_or_texture, rl.Color.white);
+        drawAtlasLabelAt(runtime_assets, panel_rect.x + (panel_rect.width - 128.0) * 0.5, panel_rect.y + 42.0, title_row_or_texture, rl.Color.white);
     } else {
-        drawTextureLabel(runtime_assets, title_row_or_texture, panel_rect.x + rect.width * 0.5 - 64.0, rect.y + 34.0, 128.0, 32.0, rl.Color.white);
+        drawTextureLabel(runtime_assets, title_row_or_texture, panel_rect.x + rect.width * 0.5 - 64.0, panel_rect.y + 34.0, 128.0, 32.0, rl.Color.white);
     }
 }
 

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -22,7 +22,7 @@ const player_count_labels = [_][:0]const u8{
     "4 players",
 };
 
-const quest_titles = [_][]const u8{
+pub const quest_titles = [_][]const u8{
     "Land Hostile",          "Minor Alien Breach",       "Target Practice",    "Frontline Assault", "Alien Dens",
     "The Random Factor",     "Spider Wave Syndrome",     "Alien Squads",       "Nesting Grounds",   "8-legged Terror",
     "Everred Pastures",      "Spider Spawns",            "Arachnoid Farm",     "Two Fronts",        "Sweep Stakes",

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -505,11 +505,15 @@ fn drawPlayerCountWidget(state: *const PlayGameState, runtime_assets: *const win
     const rect = playerCountHeaderRect();
     const selected_index = @as(usize, @intCast(std.math.clamp(player_count_raw, @as(u32, 1), @as(u32, 4)))) - 1;
     const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), rect);
-    const texture = if (state.player_list_open or hovered) runtime_assets.texture(.ui_drop_on) else runtime_assets.texture(.ui_drop_off);
+    const active = state.player_list_open or hovered;
+    const texture = if (active) runtime_assets.texture(.ui_drop_on) else runtime_assets.texture(.ui_drop_off);
 
     rl.drawRectangleRec(rect, rl.Color.white);
     rl.drawRectangle(@intFromFloat(rect.x + 1.0), @intFromFloat(rect.y + 1.0), @intFromFloat(rect.width - 2.0), @intFromFloat(rect.height - 2.0), rl.Color.black);
-    window_ui.drawSmallText(runtime_assets, player_count_labels[selected_index], rect.x + 4.0, rect.y + 1.0, if (hovered or state.player_list_open) text_color else muted_text);
+    if (active) {
+        rl.drawRectangle(@intFromFloat(rect.x), @intFromFloat(rect.y + 15.0), @intFromFloat(rect.width), 1, rl.Color.init(255, 255, 255, 128));
+    }
+    window_ui.drawSmallText(runtime_assets, player_count_labels[selected_index], rect.x + 4.0, rect.y + 1.0, rl.Color.init(255, 255, 255, if (active) 242 else 191));
     rl.drawTexturePro(
         texture,
         rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height)),
@@ -527,7 +531,8 @@ fn drawPlayerCountWidget(state: *const PlayGameState, runtime_assets: *const win
     for (player_count_labels, 0..) |label, idx| {
         const row_rect = playerCountRowRect(idx);
         const row_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), row_rect);
-        window_ui.drawSmallText(runtime_assets, label, row_rect.x + 4.0, row_rect.y + 1.0, if (row_hovered or idx == state.player_count_selection) text_color else muted_text);
+        const alpha: u8 = if (row_hovered) 242 else if (idx == state.player_count_selection) 245 else 153;
+        window_ui.drawSmallText(runtime_assets, label, row_rect.x + 4.0, row_rect.y + 1.0, rl.Color.init(255, 255, 255, alpha));
     }
 }
 

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -644,7 +644,7 @@ fn drawQuestContent(state: *const QuestState, runtime_assets: *const window_asse
         rl.Rectangle.init(layout.title_pos.x, layout.title_pos.y, quest_title_w, quest_title_h),
         rl.Vector2.zero(),
         0.0,
-        rl.Color.white,
+        rl.Color.init(179, 179, 179, 179),
     );
 
     const stage_textures = [_]window_assets.TextureId{ .ui_num1, .ui_num2, .ui_num3, .ui_num4, .ui_num5 };

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -1001,7 +1001,7 @@ fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.Run
 
     const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
     const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
-    window_ui.drawTextureFit(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
 
     const T = @TypeOf(title_row_or_texture);
     if (T == i32) {
@@ -1017,7 +1017,7 @@ fn drawMenuPanelShellNoTitle(timeline_ms: i32, runtime_assets: *const window_ass
 
     const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
     const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
-    window_ui.drawTextureFit(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
 }
 
 fn drawTextureLabel(runtime_assets: *const window_assets.RuntimeAssets, texture_id: window_assets.TextureId, x: f32, y: f32, w: f32, h: f32, tint: rl.Color) void {

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -237,11 +237,11 @@ pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.cri
     }
 
     if (state.player_list_open) {
-        return updatePlayGamePlayerList(state, config, dt_ms);
+        return updatePlayGamePlayerList(state, config, status, dt_ms, state.panel.timeline_ms);
     }
 
     const entries = playGameEntries(config, status);
-    const layout = playGameLayout(config, status);
+    const layout = playGameLayout(config, status, state.panel.timeline_ms);
     const hovered = hoveredPlayGameEntry(entries[0..], layout);
     updatePlayGameTooltipTimers(state, entries[0..], hovered, dt_ms);
     const back_hovered = if (runtime_assets) |assets|
@@ -254,7 +254,7 @@ pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.cri
         state.back_hover_amount = std.math.clamp(state.back_hover_amount - dt_ms * 2, 0, 1000);
     }
 
-    const selector = playerCountHeaderRect();
+    const selector = playerCountHeaderRect(layout);
     if (rl.checkCollisionPointRec(rl.getMousePosition(), selector) and rl.isMouseButtonPressed(.left)) {
         state.player_list_open = true;
         state.player_count_selection = player_count - 1;
@@ -282,8 +282,9 @@ pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.cri
     };
 }
 
-fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.CrimsonCfg, dt_ms: i32) PlayGameResult {
+fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, dt_ms: i32, timeline_ms: i32) PlayGameResult {
     _ = dt_ms;
+    const layout = playGameLayout(config, status, timeline_ms);
     if (rl.isKeyPressed(.escape)) {
         state.player_list_open = false;
         return .{};
@@ -297,7 +298,7 @@ fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.
 
     const mouse = rl.getMousePosition();
     for (0..player_count_labels.len) |idx| {
-        if (rl.checkCollisionPointRec(mouse, playerCountRowRect(idx)) and rl.isMouseButtonPressed(.left)) {
+        if (rl.checkCollisionPointRec(mouse, playerCountRowRect(layout, idx)) and rl.isMouseButtonPressed(.left)) {
             config.player_count = @intCast(idx + 1);
             state.player_list_open = false;
             return .{ .play_button_click = true, .config_dirty = true };
@@ -310,7 +311,7 @@ fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.
         return .{ .play_button_click = true, .config_dirty = true };
     }
 
-    if (rl.isMouseButtonPressed(.left) and !rl.checkCollisionPointRec(mouse, playerCountListRect())) {
+    if (rl.isMouseButtonPressed(.left) and !rl.checkCollisionPointRec(mouse, playerCountListRect(layout))) {
         state.player_list_open = false;
     }
 
@@ -319,7 +320,7 @@ fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.
 
 pub fn drawPlayGame(state: *const PlayGameState, runtime_assets: ?*const window_assets.RuntimeAssets, status: formats.game_cfg.Status, player_count_raw: u32) void {
     if (runtime_assets) |assets| {
-        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, playGameLayoutFromPlayerCount(player_count_raw, status).panel_rect);
+        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, playGameLayoutFromPlayerCount(player_count_raw, status, state.panel.timeline_ms).panel_rect);
         drawPlayGameContent(state, assets, status, player_count_raw);
         window_menu.drawPanelBackEntry(assets, state.panel.timeline_ms, state.back_hover_amount);
         return;
@@ -329,12 +330,12 @@ pub fn drawPlayGame(state: *const PlayGameState, runtime_assets: ?*const window_
 
 fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const window_assets.RuntimeAssets, status: formats.game_cfg.Status, player_count_raw: u32) void {
     const clamped_player_count = std.math.clamp(player_count_raw, @as(u32, 1), @as(u32, 4));
-    const layout = playGameLayoutFromPlayerCount(clamped_player_count, status);
+    const layout = playGameLayoutFromPlayerCount(clamped_player_count, status, state.panel.timeline_ms);
     const entries = playGameEntriesFromPlayerCount(clamped_player_count, status);
     const show_counts = rl.isKeyDown(.f1);
 
     drawAtlasLabelAt(runtime_assets, layout.title_pos.x, layout.title_pos.y, window_menu.label_row_play_game, rl.Color.white);
-    drawPlayerCountWidget(state, runtime_assets, player_count_raw);
+    drawPlayerCountWidget(state, runtime_assets, layout, player_count_raw);
 
     var y = layout.content_y + layout.y_start;
     for (entries) |entry| {
@@ -366,25 +367,26 @@ fn playGameEntriesFromPlayerCount(player_count_raw: u32, status: formats.game_cf
     return play_game_entries_single[0..];
 }
 
-fn playGameLayout(config: *const formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) PlayGameLayout {
-    return playGameLayoutFromPlayerCount(config.player_count, status);
+fn playGameLayout(config: *const formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, timeline_ms: i32) PlayGameLayout {
+    return playGameLayoutFromPlayerCount(config.player_count, status, timeline_ms);
 }
 
-fn playGameLayoutFromPlayerCount(player_count_raw: u32, status: formats.game_cfg.Status) PlayGameLayout {
+fn playGameLayoutFromPlayerCount(player_count_raw: u32, status: formats.game_cfg.Status, timeline_ms: i32) PlayGameLayout {
     const entries = playGameEntriesFromPlayerCount(player_count_raw, status);
     const player_count = std.math.clamp(player_count_raw, @as(u32, 1), @as(u32, 4));
     const tight_spacing = player_count == 1 and status.quest_unlock_index >= 40;
     const y_step: f32 = if (tight_spacing) 28.0 else 32.0;
     const y_start: f32 = if (tight_spacing) 42.0 else 48.0;
+    const panel_rect = animatedPanelRect(.{ .x = 352.0, .y = 150.0, .width = 510.0, .height = 278.0 }, timeline_ms);
     return .{
-        .panel_rect = .{ .x = 352.0, .y = 150.0, .width = 510.0, .height = 278.0 },
-        .title_pos = .{ .x = 496.0, .y = 184.0 },
-        .content_x = 470.0,
+        .panel_rect = panel_rect,
+        .title_pos = .{ .x = panel_rect.x + 144.0, .y = 184.0 },
+        .content_x = panel_rect.x + 118.0,
         .content_y = 206.0,
-        .drop_x = 522.0,
+        .drop_x = panel_rect.x + 170.0,
         .y_start = if (tight_spacing) 26.0 else 32.0,
         .y_step = y_step,
-        .count_x = 744.0,
+        .count_x = panel_rect.x + 392.0,
         .tooltip_y = 222.0 + y_start + y_step * @as(f32, @floatFromInt(entries.len)),
     };
 }
@@ -501,8 +503,8 @@ const play_game_entries_single_typo = [_]PlayGameEntry{
     .{ .key = .tutorial, .label = "Tutorial", .tooltip = "Learn how to play Crimsonland.", .action = .start_tutorial, .game_mode = .tutorial },
 };
 
-fn drawPlayerCountWidget(state: *const PlayGameState, runtime_assets: *const window_assets.RuntimeAssets, player_count_raw: u32) void {
-    const rect = playerCountHeaderRect();
+fn drawPlayerCountWidget(state: *const PlayGameState, runtime_assets: *const window_assets.RuntimeAssets, layout: PlayGameLayout, player_count_raw: u32) void {
+    const rect = playerCountHeaderRect(layout);
     const selected_index = @as(usize, @intCast(std.math.clamp(player_count_raw, @as(u32, 1), @as(u32, 4)))) - 1;
     const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), rect);
     const active = state.player_list_open or hovered;
@@ -525,11 +527,11 @@ fn drawPlayerCountWidget(state: *const PlayGameState, runtime_assets: *const win
 
     if (!state.player_list_open) return;
 
-    const list_rect = playerCountListRect();
+    const list_rect = playerCountListRect(layout);
     rl.drawRectangleRec(list_rect, rl.Color.white);
     rl.drawRectangle(@intFromFloat(list_rect.x + 1.0), @intFromFloat(list_rect.y + 1.0), @intFromFloat(list_rect.width - 2.0), @intFromFloat(list_rect.height - 2.0), rl.Color.black);
     for (player_count_labels, 0..) |label, idx| {
-        const row_rect = playerCountRowRect(idx);
+        const row_rect = playerCountRowRect(layout, idx);
         const row_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), row_rect);
         const alpha: u8 = if (row_hovered) 242 else if (idx == state.player_count_selection) 245 else 153;
         window_ui.drawSmallText(runtime_assets, label, row_rect.x + 4.0, row_rect.y + 1.0, rl.Color.init(255, 255, 255, alpha));
@@ -591,7 +593,7 @@ pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_
 
     if (rl.isKeyPressed(.left)) state.stage = @max(1, state.stage - 1);
     if (rl.isKeyPressed(.right)) state.stage = @min(5, state.stage + 1);
-    const layout = questLayout();
+    const layout = questLayout(state.panel.timeline_ms);
     const hovered_stage = hoveredQuestStage(layout);
     if (hovered_stage) |stage| {
         state.stage = stage;
@@ -630,7 +632,7 @@ pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_
 
 pub fn drawQuests(state: *const QuestState, runtime_assets: ?*const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) void {
     if (runtime_assets) |assets| {
-        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, questLayout().panel_rect);
+        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, questLayout(state.panel.timeline_ms).panel_rect);
         drawQuestContent(state, assets, config, status);
         return;
     }
@@ -638,7 +640,7 @@ pub fn drawQuests(state: *const QuestState, runtime_assets: ?*const window_asset
 }
 
 fn drawQuestContent(state: *const QuestState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) void {
-    const layout = questLayout();
+    const layout = questLayout(state.panel.timeline_ms);
     const title_tex = runtime_assets.texture(.ui_text_quest);
     const hovered_stage = hoveredQuestStage(layout);
     const hovered_row = hoveredQuestRow(layout, hardcoreUnlocked(status));
@@ -784,13 +786,14 @@ fn questDigitRowPressed() ?usize {
     return null;
 }
 
-fn questLayout() QuestLayout {
+fn questLayout(timeline_ms: i32) QuestLayout {
+    const panel_rect = animatedPanelRect(.{ .x = 390.0, .y = 168.0, .width = 510.0, .height = 378.0 }, timeline_ms);
     return .{
-        .panel_rect = .{ .x = 390.0, .y = 168.0, .width = 510.0, .height = 378.0 },
-        .title_pos = .{ .x = 609.0, .y = 212.0 },
-        .icons_start_pos = .{ .x = 689.0, .y = 215.0 },
-        .list_pos = .{ .x = 641.0, .y = 262.0 },
-        .back_pos = .{ .x = 779.0, .y = 474.0 },
+        .panel_rect = panel_rect,
+        .title_pos = .{ .x = panel_rect.x + 219.0, .y = 212.0 },
+        .icons_start_pos = .{ .x = panel_rect.x + 299.0, .y = 215.0 },
+        .list_pos = .{ .x = panel_rect.x + 251.0, .y = 262.0 },
+        .back_pos = .{ .x = panel_rect.x + 389.0, .y = 474.0 },
     };
 }
 
@@ -845,7 +848,7 @@ pub const StatisticsResult = struct {
 
 pub fn updateStatistics(state: *StatisticsState, frame_dt: f32) StatisticsResult {
     const dt_ms = panelAdvance(&state.panel, frame_dt);
-    const buttons = statisticsButtons();
+    const buttons = statisticsButtons(state.panel.timeline_ms);
     window_ui.updateSelectionFromPointer(&state.panel.selection, buttons[0..]);
     if (rl.isKeyPressed(.escape)) return .{ .action = .back_to_menu, .play_button_click = true };
     if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
@@ -875,7 +878,7 @@ pub fn updateStatistics(state: *StatisticsState, frame_dt: f32) StatisticsResult
 pub fn drawStatistics(state: *const StatisticsState, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     if (runtime_assets) |assets| {
         drawMenuPanelShell(state.panel.timeline_ms, assets, .{ .x = 390.0, .y = 168.0, .width = 500.0, .height = 360.0 }, window_menu.label_row_statistics);
-        const buttons = statisticsButtons();
+        const buttons = statisticsButtons(state.panel.timeline_ms);
         for (buttons, 0..) |button, idx| {
             const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
             window_ui.drawButton(button, idx == state.panel.selection, hovered, assets);
@@ -979,15 +982,14 @@ fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.Run
     window_menu.drawMenuBackdrop(runtime_assets);
     window_menu.drawSign(timeline_ms, runtime_assets);
 
-    const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
-    const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
+    const panel_rect = animatedPanelRect(rect, timeline_ms);
     window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, rl.Color.white, false);
 
     const T = @TypeOf(title_row_or_texture);
     if (T == i32) {
-        window_menu.drawAtlasLabelCentered(runtime_assets, title_row_or_texture, rect.y + 42.0, rl.Color.white);
+        drawAtlasLabelAt(runtime_assets, panel_rect.x + (panel_rect.width - 128.0) * 0.5, rect.y + 42.0, title_row_or_texture, rl.Color.white);
     } else {
-        drawTextureLabel(runtime_assets, title_row_or_texture, rect.x + rect.width * 0.5 - 64.0, rect.y + 34.0, 128.0, 32.0, rl.Color.white);
+        drawTextureLabel(runtime_assets, title_row_or_texture, panel_rect.x + rect.width * 0.5 - 64.0, rect.y + 34.0, 128.0, 32.0, rl.Color.white);
     }
 }
 
@@ -995,8 +997,7 @@ fn drawMenuPanelShellNoTitle(timeline_ms: i32, runtime_assets: *const window_ass
     window_menu.drawMenuBackdrop(runtime_assets);
     window_menu.drawSign(timeline_ms, runtime_assets);
 
-    const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
-    const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
+    const panel_rect = animatedPanelRect(rect, timeline_ms);
     window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, rl.Color.white, false);
 }
 
@@ -1026,20 +1027,21 @@ fn playGameButtons() [4]window_ui.UiButton {
     };
 }
 
-fn playerCountHeaderRect() rl.Rectangle {
-    return rl.Rectangle.init(492.0, 258.0, 124.0, 16.0);
+fn playerCountHeaderRect(layout: PlayGameLayout) rl.Rectangle {
+    return rl.Rectangle.init(layout.drop_x - 30.0, 258.0, 124.0, 16.0);
 }
 
-fn playerCountListRect() rl.Rectangle {
-    return rl.Rectangle.init(492.0, 258.0, 124.0, 80.0);
+fn playerCountListRect(layout: PlayGameLayout) rl.Rectangle {
+    return rl.Rectangle.init(layout.drop_x - 30.0, 258.0, 124.0, 80.0);
 }
 
-fn playerCountRowRect(idx: usize) rl.Rectangle {
-    return rl.Rectangle.init(492.0, 275.0 + @as(f32, @floatFromInt(idx)) * 16.0, 124.0, 16.0);
+fn playerCountRowRect(layout: PlayGameLayout, idx: usize) rl.Rectangle {
+    return rl.Rectangle.init(layout.drop_x - 30.0, 275.0 + @as(f32, @floatFromInt(idx)) * 16.0, 124.0, 16.0);
 }
 
-fn statisticsButtons() [5]window_ui.UiButton {
-    const center_x = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
+fn statisticsButtons(timeline_ms: i32) [5]window_ui.UiButton {
+    const panel_rect = animatedPanelRect(.{ .x = 390.0, .y = 168.0, .width = 500.0, .height = 360.0 }, timeline_ms);
+    const center_x = panel_rect.x + panel_rect.width * 0.5;
     return .{
         .{ .label = "HIGH SCORES", .rect = window_ui.centeredRect(center_x, 250.0, 240.0, 44.0) },
         .{ .label = "WEAPONS", .rect = window_ui.centeredRect(center_x, 304.0, 240.0, 44.0) },
@@ -1047,6 +1049,11 @@ fn statisticsButtons() [5]window_ui.UiButton {
         .{ .label = "CREDITS", .rect = window_ui.centeredRect(center_x, 412.0, 240.0, 44.0) },
         .{ .label = "BACK", .rect = window_ui.centeredRect(center_x, 478.0, 180.0, 44.0) },
     };
+}
+
+fn animatedPanelRect(rect: rl.Rectangle, timeline_ms: i32) rl.Rectangle {
+    const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
+    return rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
 }
 
 fn backOnlyButton() [1]window_ui.UiButton {

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -147,10 +147,10 @@ pub const PlayGameState = struct {
     panel: PanelState = .{},
     player_list_open: bool = false,
     player_count_selection: usize = 0,
-    selection: usize = 0,
     closing: bool = false,
     close_action: ?PlayGameAction = null,
     tooltip_ms: [5]i32 = [_]i32{0} ** 5,
+    back_hover_amount: i32 = 0,
 
     pub fn reset(self: *PlayGameState) void {
         self.* = .{};
@@ -214,7 +214,7 @@ const quest_list_hover_top_pad: f32 = 2.0;
 const quest_list_hover_bottom_pad: f32 = 18.0;
 const quest_hardcore_unlock_index: u32 = 40;
 
-pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) PlayGameResult {
+pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, runtime_assets: ?*const window_assets.RuntimeAssets) PlayGameResult {
     const dt_ms = frameDeltaMs(frame_dt);
     if (state.closing) {
         if (dt_ms > 0) state.panel.timeline_ms -= dt_ms;
@@ -241,22 +241,17 @@ pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.cri
     }
 
     const entries = playGameEntries(config, status);
-    const button_count = entries.len + 1;
-    if (state.selection >= button_count) state.selection = button_count - 1;
-
     const layout = playGameLayout(config, status);
     const hovered = hoveredPlayGameEntry(entries[0..], layout);
     updatePlayGameTooltipTimers(state, entries[0..], hovered, dt_ms);
-    if (hovered) |hovered_idx| {
-        state.selection = hovered_idx;
-    } else if (rl.checkCollisionPointRec(rl.getMousePosition(), backOnlyButton()[0].rect)) {
-        state.selection = entries.len;
-    }
-    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
-        state.selection = if (state.selection == 0) button_count - 1 else state.selection - 1;
-    }
-    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
-        state.selection = (state.selection + 1) % button_count;
+    const back_hovered = if (runtime_assets) |assets|
+        state.panel.timeline_ms >= panel_timeline_max_ms and rl.checkCollisionPointRec(rl.getMousePosition(), window_menu.panelBackHitRect(assets, state.panel.timeline_ms))
+    else
+        false;
+    if (back_hovered) {
+        state.back_hover_amount = std.math.clamp(state.back_hover_amount + dt_ms * 6, 0, 1000);
+    } else {
+        state.back_hover_amount = std.math.clamp(state.back_hover_amount - dt_ms * 2, 0, 1000);
     }
 
     const selector = playerCountHeaderRect();
@@ -265,28 +260,25 @@ pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.cri
         state.player_count_selection = player_count - 1;
         return .{ .play_button_click = true };
     }
-    if ((rl.isKeyPressed(.left) or rl.isKeyPressed(.right)) and state.selection == entries.len) {
-        state.player_list_open = true;
-        state.player_count_selection = player_count - 1;
-        return .{ .play_button_click = true };
-    }
 
-    if (!playGameActivated(entries[0..], layout, state.selection)) {
-        return .{
-            .play_panel_click = dt_ms > 0 and state.panel.timeline_ms >= panel_timeline_max_ms and !state.panel.panel_open_sfx_played,
-        };
-    }
-
-    if (state.selection == entries.len) {
+    if (back_hovered and rl.isMouseButtonPressed(.left)) {
         beginClosePlayGame(state, .back_to_menu);
         return .{ .play_button_click = true };
     }
 
-    const entry = entries[state.selection];
-    beginClosePlayGame(state, entry.action);
+    if (hovered) |hovered_idx| {
+        const entry = entries[hovered_idx];
+        if (rl.isMouseButtonPressed(.left)) {
+            beginClosePlayGame(state, entry.action);
+            return .{
+                .play_button_click = true,
+                .config_dirty = if (entry.game_mode) |mode| setConfigGameMode(config, mode) else false,
+            };
+        }
+    }
+
     return .{
-        .play_button_click = true,
-        .config_dirty = if (entry.game_mode) |mode| setConfigGameMode(config, mode) else false,
+        .play_panel_click = dt_ms > 0 and state.panel.timeline_ms >= panel_timeline_max_ms and !state.panel.panel_open_sfx_played,
     };
 }
 
@@ -329,6 +321,7 @@ pub fn drawPlayGame(state: *const PlayGameState, runtime_assets: ?*const window_
     if (runtime_assets) |assets| {
         drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, playGameLayoutFromPlayerCount(player_count_raw, status).panel_rect);
         drawPlayGameContent(state, assets, status, player_count_raw);
+        window_menu.drawPanelBackEntry(assets, state.panel.timeline_ms, state.back_hover_amount);
         return;
     }
     rl.clearBackground(panel_color);
@@ -344,20 +337,15 @@ fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const windo
     drawPlayerCountWidget(state, runtime_assets, player_count_raw);
 
     var y = layout.content_y + layout.y_start;
-    for (entries, 0..) |entry, idx| {
+    for (entries) |entry| {
         const button = playGameButton(entry.label, layout.content_x, y);
         const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
-        const selected = idx == state.selection and !state.player_list_open;
-        window_ui.drawButton(button, selected, hovered, runtime_assets);
+        window_ui.drawButton(button, false, hovered, runtime_assets);
         if (show_counts and entry.show_count) {
-            window_ui.drawSmallTextFmt("{d}", runtime_assets, .{playGameCount(entry.key, status)}, layout.count_x, y + 8.0, if (selected or hovered) text_color else muted_text);
+            window_ui.drawSmallTextFmt("{d}", runtime_assets, .{playGameCount(entry.key, status)}, layout.count_x, y + 8.0, if (hovered) text_color else muted_text);
         }
         y += layout.y_step;
     }
-
-    const back = backOnlyButton()[0];
-    const back_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
-    window_ui.drawButton(back, state.selection == entries.len and !state.player_list_open, back_hovered, runtime_assets);
 
     drawPlayGameTooltips(state, runtime_assets, entries[0..], layout);
 }
@@ -414,21 +402,6 @@ fn hoveredPlayGameEntry(entries: []const PlayGameEntry, layout: PlayGameLayout) 
         y += layout.y_step;
     }
     return null;
-}
-
-fn playGameActivated(entries: []const PlayGameEntry, layout: PlayGameLayout, selection: usize) bool {
-    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space)) return true;
-    if (!rl.isMouseButtonPressed(.left)) return false;
-    if (selection == entries.len) return rl.checkCollisionPointRec(rl.getMousePosition(), backOnlyButton()[0].rect);
-
-    var y = layout.content_y + layout.y_start;
-    for (entries, 0..) |entry, idx| {
-        _ = entry;
-        const button = playGameButton(entries[idx].label, layout.content_x, y);
-        if (idx == selection and rl.checkCollisionPointRec(rl.getMousePosition(), button.rect)) return true;
-        y += layout.y_step;
-    }
-    return false;
 }
 
 fn playGameCount(key: PlayGameModeKey, status: formats.game_cfg.Status) u32 {

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -148,6 +148,9 @@ pub const PlayGameState = struct {
     player_list_open: bool = false,
     player_count_selection: usize = 0,
     selection: usize = 0,
+    closing: bool = false,
+    close_action: ?PlayGameAction = null,
+    tooltip_ms: [5]i32 = [_]i32{0} ** 5,
 
     pub fn reset(self: *PlayGameState) void {
         self.* = .{};
@@ -180,6 +183,7 @@ const PlayGameEntry = struct {
 
 const PlayGameLayout = struct {
     panel_rect: rl.Rectangle,
+    title_pos: rl.Vector2,
     content_x: f32,
     content_y: f32,
     drop_x: f32,
@@ -189,14 +193,47 @@ const PlayGameLayout = struct {
     tooltip_y: f32,
 };
 
+const QuestLayout = struct {
+    panel_rect: rl.Rectangle,
+    title_pos: rl.Vector2,
+    icons_start_pos: rl.Vector2,
+    list_pos: rl.Vector2,
+    back_pos: rl.Vector2,
+};
+
+const quest_title_w: f32 = 64.0;
+const quest_title_h: f32 = 32.0;
+const quest_stage_icon_size: f32 = 32.0;
+const quest_stage_icon_step: f32 = 36.0;
+const quest_stage_icon_scale_unselected: f32 = 0.8;
+const quest_list_row_step: f32 = 20.0;
+const quest_list_name_x_offset: f32 = 32.0;
+const quest_list_hover_left_pad: f32 = 10.0;
+const quest_list_hover_right_pad: f32 = 210.0;
+const quest_list_hover_top_pad: f32 = 2.0;
+const quest_list_hover_bottom_pad: f32 = 18.0;
+const quest_hardcore_unlock_index: u32 = 40;
+
 pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) PlayGameResult {
-    const dt_ms = panelAdvance(&state.panel, frame_dt);
+    const dt_ms = frameDeltaMs(frame_dt);
+    if (state.closing) {
+        if (dt_ms > 0) state.panel.timeline_ms -= dt_ms;
+        if (state.panel.timeline_ms < 0) {
+            const action = state.close_action;
+            state.closing = false;
+            state.close_action = null;
+            if (action) |resolved| return .{ .action = resolved };
+        }
+        return .{};
+    }
+    if (dt_ms > 0) state.panel.timeline_ms = @min(panel_timeline_max_ms, state.panel.timeline_ms + dt_ms);
     const player_count = @as(usize, @intCast(std.math.clamp(config.player_count, @as(u32, 1), @as(u32, 4))));
     if (state.player_count_selection >= player_count_labels.len) state.player_count_selection = player_count - 1;
 
     if (rl.isKeyPressed(.escape)) {
         state.player_list_open = false;
-        return .{ .action = .back_to_menu, .play_button_click = true };
+        beginClosePlayGame(state, .back_to_menu);
+        return .{ .play_button_click = true };
     }
 
     if (state.player_list_open) {
@@ -208,8 +245,10 @@ pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.cri
     if (state.selection >= button_count) state.selection = button_count - 1;
 
     const layout = playGameLayout(config, status);
-    if (hoveredPlayGameEntry(entries[0..], layout)) |hovered| {
-        state.selection = hovered;
+    const hovered = hoveredPlayGameEntry(entries[0..], layout);
+    updatePlayGameTooltipTimers(state, entries[0..], hovered, dt_ms);
+    if (hovered) |hovered_idx| {
+        state.selection = hovered_idx;
     } else if (rl.checkCollisionPointRec(rl.getMousePosition(), backOnlyButton()[0].rect)) {
         state.selection = entries.len;
     }
@@ -239,12 +278,13 @@ pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.cri
     }
 
     if (state.selection == entries.len) {
-        return .{ .action = .back_to_menu, .play_button_click = true };
+        beginClosePlayGame(state, .back_to_menu);
+        return .{ .play_button_click = true };
     }
 
     const entry = entries[state.selection];
+    beginClosePlayGame(state, entry.action);
     return .{
-        .action = entry.action,
         .play_button_click = true,
         .config_dirty = if (entry.game_mode) |mode| setConfigGameMode(config, mode) else false,
     };
@@ -287,7 +327,7 @@ fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.
 
 pub fn drawPlayGame(state: *const PlayGameState, runtime_assets: ?*const window_assets.RuntimeAssets, status: formats.game_cfg.Status, player_count_raw: u32) void {
     if (runtime_assets) |assets| {
-        drawMenuPanelShell(state.panel.timeline_ms, assets, playGameLayoutFromPlayerCount(player_count_raw, status).panel_rect, window_menu.label_row_play_game);
+        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, playGameLayoutFromPlayerCount(player_count_raw, status).panel_rect);
         drawPlayGameContent(state, assets, status, player_count_raw);
         return;
     }
@@ -298,8 +338,10 @@ fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const windo
     const clamped_player_count = std.math.clamp(player_count_raw, @as(u32, 1), @as(u32, 4));
     const layout = playGameLayoutFromPlayerCount(clamped_player_count, status);
     const entries = playGameEntriesFromPlayerCount(clamped_player_count, status);
+    const show_counts = rl.isKeyDown(.f1);
 
-    window_ui.drawSmallText(runtime_assets, "PLAYER COUNT", layout.drop_x, layout.content_y - 14.0, muted_text);
+    drawAtlasLabelAt(runtime_assets, layout.title_pos.x, layout.title_pos.y, window_menu.label_row_play_game, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    window_ui.drawSmallText(runtime_assets, "player count", layout.drop_x, layout.content_y - 12.0, muted_text);
     drawPlayerCountWidget(state, runtime_assets, player_count_raw);
 
     var y = layout.content_y + layout.y_start;
@@ -308,7 +350,7 @@ fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const windo
         const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
         const selected = idx == state.selection and !state.player_list_open;
         window_ui.drawButton(button, selected, hovered, runtime_assets);
-        if (entry.show_count) {
+        if (show_counts and entry.show_count) {
             window_ui.drawSmallTextFmt("{d}", runtime_assets, .{playGameCount(entry.key, status)}, layout.count_x, y + 8.0, if (selected or hovered) text_color else muted_text);
         }
         y += layout.y_step;
@@ -318,10 +360,7 @@ fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const windo
     const back_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
     window_ui.drawButton(back, state.selection == entries.len and !state.player_list_open, back_hovered, runtime_assets);
 
-    const tooltip_entry = tooltipEntry(entries, state.selection, layout);
-    if (tooltip_entry) |entry| {
-        drawTooltip(runtime_assets, entry.tooltip, layout.content_x, layout.tooltip_y);
-    }
+    drawPlayGameTooltips(state, runtime_assets, entries[0..], layout);
 }
 
 fn playGameEntries(config: *const formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) []const PlayGameEntry {
@@ -353,13 +392,14 @@ fn playGameLayoutFromPlayerCount(player_count_raw: u32, status: formats.game_cfg
     const panel_height = 206.0 + y_start + y_step * @as(f32, @floatFromInt(entries.len));
     return .{
         .panel_rect = .{ .x = 352.0, .y = 150.0, .width = 510.0, .height = panel_height },
+        .title_pos = .{ .x = 496.0, .y = 184.0 },
         .content_x = 470.0,
         .content_y = 206.0,
         .drop_x = 522.0,
-        .y_start = y_start,
+        .y_start = if (tight_spacing) 26.0 else 32.0,
         .y_step = y_step,
         .count_x = 744.0,
-        .tooltip_y = 230.0 + y_start + y_step * @as(f32, @floatFromInt(entries.len)),
+        .tooltip_y = 222.0 + y_start + y_step * @as(f32, @floatFromInt(entries.len)),
     };
 }
 
@@ -393,16 +433,6 @@ fn playGameActivated(entries: []const PlayGameEntry, layout: PlayGameLayout, sel
     return false;
 }
 
-fn tooltipEntry(entries: []const PlayGameEntry, selection: usize, layout: PlayGameLayout) ?PlayGameEntry {
-    if (hoveredPlayGameEntry(entries, layout)) |hovered| return entries[hovered];
-    if (selection < entries.len) return entries[selection];
-    return null;
-}
-
-fn drawTooltip(runtime_assets: *const window_assets.RuntimeAssets, text: []const u8, x: f32, y: f32) void {
-    window_ui.drawSmallText(runtime_assets, text, x - 40.0, y, rl.Color.init(185, 185, 196, 255));
-}
-
 fn playGameCount(key: PlayGameModeKey, status: formats.game_cfg.Status) u32 {
     return switch (key) {
         .quests => questTotalPlayed(status),
@@ -413,40 +443,91 @@ fn playGameCount(key: PlayGameModeKey, status: formats.game_cfg.Status) u32 {
     };
 }
 
+fn beginClosePlayGame(state: *PlayGameState, action: PlayGameAction) void {
+    if (state.closing) return;
+    state.closing = true;
+    state.close_action = action;
+    state.player_list_open = false;
+}
+
+fn tooltipIndexForKey(key: PlayGameModeKey) usize {
+    return switch (key) {
+        .tutorial => 0,
+        .quests => 1,
+        .rush => 2,
+        .survival => 3,
+        .typo => 4,
+    };
+}
+
+fn updatePlayGameTooltipTimers(state: *PlayGameState, entries: []const PlayGameEntry, hovered: ?usize, dt_ms: i32) void {
+    for (entries, 0..) |entry, idx| {
+        const tooltip_idx = tooltipIndexForKey(entry.key);
+        if (hovered != null and hovered.? == idx) {
+            state.tooltip_ms[tooltip_idx] = @min(1000, state.tooltip_ms[tooltip_idx] + dt_ms * 6);
+        } else {
+            state.tooltip_ms[tooltip_idx] = @max(0, state.tooltip_ms[tooltip_idx] - dt_ms * 2);
+        }
+    }
+}
+
+fn drawPlayGameTooltips(state: *const PlayGameState, runtime_assets: *const window_assets.RuntimeAssets, entries: []const PlayGameEntry, layout: PlayGameLayout) void {
+    const tooltip_x = layout.content_x - 55.0;
+    const tooltip_y = layout.tooltip_y + 16.0;
+    for (entries) |entry| {
+        const tooltip_idx = tooltipIndexForKey(entry.key);
+        const ms = state.tooltip_ms[tooltip_idx];
+        if (ms <= 0) continue;
+        const alpha = @as(u8, @intFromFloat(@min(@as(f32, 1.0), @as(f32, @floatFromInt(ms)) * 0.0009) * 255.0));
+        const offset = playGameTooltipOffset(entry.key);
+        window_ui.drawSmallText(runtime_assets, entry.tooltip, tooltip_x + offset.x, tooltip_y + offset.y, rl.Color.init(255, 255, 255, alpha));
+    }
+}
+
+fn playGameTooltipOffset(key: PlayGameModeKey) rl.Vector2 {
+    return switch (key) {
+        .quests => .{ .x = -8.0, .y = 0.0 },
+        .rush => .{ .x = 32.0, .y = 0.0 },
+        .survival => .{ .x = 20.0, .y = 0.0 },
+        .typo => .{ .x = 0.0, .y = -12.0 },
+        .tutorial => .{ .x = 38.0, .y = 0.0 },
+    };
+}
+
 const play_game_entries_multi = [_]PlayGameEntry{
-    .{ .key = .quests, .label = "QUESTS", .tooltip = "Unlock new weapons and perks in Quest mode.", .action = .open_quests, .show_count = true },
-    .{ .key = .rush, .label = "RUSH", .tooltip = "Face a rush of aliens in Rush mode.", .action = .start_rush, .game_mode = .rush, .show_count = true },
-    .{ .key = .survival, .label = "SURVIVAL", .tooltip = "Gain perks and weapons and fight back.", .action = .start_survival, .game_mode = .survival, .show_count = true },
+    .{ .key = .quests, .label = " Quests ", .tooltip = "Unlock new weapons and perks in Quest mode.", .action = .open_quests, .show_count = true },
+    .{ .key = .rush, .label = "  Rush  ", .tooltip = "Face a rush of aliens in Rush mode.", .action = .start_rush, .game_mode = .rush, .show_count = true },
+    .{ .key = .survival, .label = "Survival", .tooltip = "Gain perks and weapons and fight back.", .action = .start_survival, .game_mode = .survival, .show_count = true },
 };
 
 const play_game_entries_single_tutorial_first = [_]PlayGameEntry{
-    .{ .key = .tutorial, .label = "TUTORIAL", .tooltip = "Learn how to play Crimsonland.", .action = .start_tutorial, .game_mode = .tutorial },
-    .{ .key = .quests, .label = "QUESTS", .tooltip = "Unlock new weapons and perks in Quest mode.", .action = .open_quests, .show_count = true },
-    .{ .key = .rush, .label = "RUSH", .tooltip = "Face a rush of aliens in Rush mode.", .action = .start_rush, .game_mode = .rush, .show_count = true },
-    .{ .key = .survival, .label = "SURVIVAL", .tooltip = "Gain perks and weapons and fight back.", .action = .start_survival, .game_mode = .survival, .show_count = true },
+    .{ .key = .tutorial, .label = "Tutorial", .tooltip = "Learn how to play Crimsonland.", .action = .start_tutorial, .game_mode = .tutorial },
+    .{ .key = .quests, .label = " Quests ", .tooltip = "Unlock new weapons and perks in Quest mode.", .action = .open_quests, .show_count = true },
+    .{ .key = .rush, .label = "  Rush  ", .tooltip = "Face a rush of aliens in Rush mode.", .action = .start_rush, .game_mode = .rush, .show_count = true },
+    .{ .key = .survival, .label = "Survival", .tooltip = "Gain perks and weapons and fight back.", .action = .start_survival, .game_mode = .survival, .show_count = true },
 };
 
 const play_game_entries_single = [_]PlayGameEntry{
-    .{ .key = .quests, .label = "QUESTS", .tooltip = "Unlock new weapons and perks in Quest mode.", .action = .open_quests, .show_count = true },
-    .{ .key = .rush, .label = "RUSH", .tooltip = "Face a rush of aliens in Rush mode.", .action = .start_rush, .game_mode = .rush, .show_count = true },
-    .{ .key = .survival, .label = "SURVIVAL", .tooltip = "Gain perks and weapons and fight back.", .action = .start_survival, .game_mode = .survival, .show_count = true },
-    .{ .key = .tutorial, .label = "TUTORIAL", .tooltip = "Learn how to play Crimsonland.", .action = .start_tutorial, .game_mode = .tutorial },
+    .{ .key = .quests, .label = " Quests ", .tooltip = "Unlock new weapons and perks in Quest mode.", .action = .open_quests, .show_count = true },
+    .{ .key = .rush, .label = "  Rush  ", .tooltip = "Face a rush of aliens in Rush mode.", .action = .start_rush, .game_mode = .rush, .show_count = true },
+    .{ .key = .survival, .label = "Survival", .tooltip = "Gain perks and weapons and fight back.", .action = .start_survival, .game_mode = .survival, .show_count = true },
+    .{ .key = .tutorial, .label = "Tutorial", .tooltip = "Learn how to play Crimsonland.", .action = .start_tutorial, .game_mode = .tutorial },
 };
 
 const play_game_entries_single_typo_tutorial_first = [_]PlayGameEntry{
-    .{ .key = .tutorial, .label = "TUTORIAL", .tooltip = "Learn how to play Crimsonland.", .action = .start_tutorial, .game_mode = .tutorial },
-    .{ .key = .quests, .label = "QUESTS", .tooltip = "Unlock new weapons and perks in Quest mode.", .action = .open_quests, .show_count = true },
-    .{ .key = .rush, .label = "RUSH", .tooltip = "Face a rush of aliens in Rush mode.", .action = .start_rush, .game_mode = .rush, .show_count = true },
-    .{ .key = .survival, .label = "SURVIVAL", .tooltip = "Gain perks and weapons and fight back.", .action = .start_survival, .game_mode = .survival, .show_count = true },
-    .{ .key = .typo, .label = "TYP'O'SHOOTER", .tooltip = "Use your typing skills as the weapon to lay\nthem down.", .action = .start_typo, .game_mode = .typo, .show_count = true },
+    .{ .key = .tutorial, .label = "Tutorial", .tooltip = "Learn how to play Crimsonland.", .action = .start_tutorial, .game_mode = .tutorial },
+    .{ .key = .quests, .label = " Quests ", .tooltip = "Unlock new weapons and perks in Quest mode.", .action = .open_quests, .show_count = true },
+    .{ .key = .rush, .label = "  Rush  ", .tooltip = "Face a rush of aliens in Rush mode.", .action = .start_rush, .game_mode = .rush, .show_count = true },
+    .{ .key = .survival, .label = "Survival", .tooltip = "Gain perks and weapons and fight back.", .action = .start_survival, .game_mode = .survival, .show_count = true },
+    .{ .key = .typo, .label = "Typ'o'Shooter", .tooltip = "Use your typing skills as the weapon to lay\nthem down.", .action = .start_typo, .game_mode = .typo, .show_count = true },
 };
 
 const play_game_entries_single_typo = [_]PlayGameEntry{
-    .{ .key = .quests, .label = "QUESTS", .tooltip = "Unlock new weapons and perks in Quest mode.", .action = .open_quests, .show_count = true },
-    .{ .key = .rush, .label = "RUSH", .tooltip = "Face a rush of aliens in Rush mode.", .action = .start_rush, .game_mode = .rush, .show_count = true },
-    .{ .key = .survival, .label = "SURVIVAL", .tooltip = "Gain perks and weapons and fight back.", .action = .start_survival, .game_mode = .survival, .show_count = true },
-    .{ .key = .typo, .label = "TYP'O'SHOOTER", .tooltip = "Use your typing skills as the weapon to lay\nthem down.", .action = .start_typo, .game_mode = .typo, .show_count = true },
-    .{ .key = .tutorial, .label = "TUTORIAL", .tooltip = "Learn how to play Crimsonland.", .action = .start_tutorial, .game_mode = .tutorial },
+    .{ .key = .quests, .label = " Quests ", .tooltip = "Unlock new weapons and perks in Quest mode.", .action = .open_quests, .show_count = true },
+    .{ .key = .rush, .label = "  Rush  ", .tooltip = "Face a rush of aliens in Rush mode.", .action = .start_rush, .game_mode = .rush, .show_count = true },
+    .{ .key = .survival, .label = "Survival", .tooltip = "Gain perks and weapons and fight back.", .action = .start_survival, .game_mode = .survival, .show_count = true },
+    .{ .key = .typo, .label = "Typ'o'Shooter", .tooltip = "Use your typing skills as the weapon to lay\nthem down.", .action = .start_typo, .game_mode = .typo, .show_count = true },
+    .{ .key = .tutorial, .label = "Tutorial", .tooltip = "Learn how to play Crimsonland.", .action = .start_tutorial, .game_mode = .tutorial },
 };
 
 fn drawPlayerCountWidget(state: *const PlayGameState, runtime_assets: *const window_assets.RuntimeAssets, player_count_raw: u32) void {
@@ -491,7 +572,9 @@ fn questTotalPlayed(status: formats.game_cfg.Status) u32 {
 pub const QuestState = struct {
     panel: PanelState = .{},
     stage: i32 = 1,
-    row_selection: usize = 0,
+    closing: bool = false,
+    closing_level_key: ?i32 = null,
+    closing_back: bool = false,
 
     pub fn reset(self: *QuestState) void {
         self.* = .{};
@@ -507,47 +590,61 @@ pub const QuestResult = struct {
 };
 
 pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) QuestResult {
-    const dt_ms = panelAdvance(&state.panel, frame_dt);
-    if (rl.isKeyPressed(.escape)) return .{ .back_to_play_game = true, .play_button_click = true };
+    const dt_ms = frameDeltaMs(frame_dt);
+    if (state.closing) {
+        if (dt_ms > 0) state.panel.timeline_ms -= dt_ms;
+        if (state.panel.timeline_ms < 0) {
+            if (state.closing_back) {
+                state.closing = false;
+                state.closing_back = false;
+                return .{ .back_to_play_game = true };
+            }
+            if (state.closing_level_key) |level_key| {
+                state.closing = false;
+                state.closing_level_key = null;
+                return .{ .start_level_key = level_key };
+            }
+        }
+        return .{};
+    }
+    if (dt_ms > 0) state.panel.timeline_ms = @min(panel_timeline_max_ms, state.panel.timeline_ms + dt_ms);
+    if (rl.isKeyPressed(.escape)) {
+        beginCloseQuestBack(state);
+        return .{ .play_button_click = true };
+    }
 
     if (rl.isKeyPressed(.left)) state.stage = @max(1, state.stage - 1);
     if (rl.isKeyPressed(.right)) state.stage = @min(5, state.stage + 1);
-    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
-        state.row_selection = if (state.row_selection == 0) 9 else state.row_selection - 1;
-    }
-    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
-        state.row_selection = (state.row_selection + 1) % 10;
-    }
-
-    const hovered_stage = hoveredQuestStage();
+    const layout = questLayout();
+    const hovered_stage = hoveredQuestStage(layout);
     if (hovered_stage) |stage| {
         state.stage = stage;
         if (rl.isMouseButtonPressed(.left)) return .{ .play_button_click = true };
     }
 
-    const hovered_row = hoveredQuestRow(hardcoreUnlocked(status));
-    if (hovered_row) |row| {
-        state.row_selection = row;
+    if (questDigitRowPressed()) |row| {
+        return tryStartQuest(state, config, status, state.stage, row);
     }
 
+    const hovered_row = hoveredQuestRow(layout, hardcoreUnlocked(status));
+
     if (hardcoreUnlocked(status)) {
-        const hardcore_rect = hardcoreCheckRect();
+        const hardcore_rect = hardcoreCheckRect(layout);
         if (rl.checkCollisionPointRec(rl.getMousePosition(), hardcore_rect) and rl.isMouseButtonPressed(.left)) {
             config.hardcore_flag = if (config.hardcore_flag == 0) 1 else 0;
             return .{ .play_button_click = true, .config_dirty = true };
         }
     }
 
-    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space) or (hovered_row != null and rl.isMouseButtonPressed(.left))) {
-        if (questUnlocked(status, config.hardcore_flag != 0, state.stage, @intCast(state.row_selection + 1))) {
-            const level_key = state.stage * 100 + @as(i32, @intCast(state.row_selection + 1));
-            config.game_mode = @intFromEnum(game_ids.GameModeId.quests);
-            return .{ .start_level_key = level_key, .play_button_click = true, .config_dirty = true };
+    if (hovered_row) |row| {
+        if (rl.isMouseButtonPressed(.left) or rl.isKeyPressed(.enter)) {
+            return tryStartQuest(state, config, status, state.stage, row);
         }
     }
 
-    if (backButtonActivated()) {
-        return .{ .back_to_play_game = true, .play_button_click = true };
+    if (questBackButtonActivated(layout)) {
+        beginCloseQuestBack(state);
+        return .{ .play_button_click = true };
     }
 
     return .{
@@ -557,7 +654,7 @@ pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_
 
 pub fn drawQuests(state: *const QuestState, runtime_assets: ?*const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) void {
     if (runtime_assets) |assets| {
-        drawMenuPanelShell(state.panel.timeline_ms, assets, .{ .x = 320.0, .y = 132.0, .width = 620.0, .height = 430.0 }, window_assets.TextureId.ui_text_quest);
+        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, questLayout().panel_rect);
         drawQuestContent(state, assets, config, status);
         return;
     }
@@ -565,39 +662,65 @@ pub fn drawQuests(state: *const QuestState, runtime_assets: ?*const window_asset
 }
 
 fn drawQuestContent(state: *const QuestState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) void {
-    const base_x: f32 = 390.0;
-    const base_y: f32 = 182.0;
-    drawTextureLabel(runtime_assets, .ui_text_quest, 480.0, 166.0, 128.0, 32.0, rl.Color.init(179, 179, 179, 179));
+    const layout = questLayout();
+    const title_tex = runtime_assets.texture(.ui_text_quest);
+    const hovered_stage = hoveredQuestStage(layout);
+    const hovered_row = hoveredQuestRow(layout, hardcoreUnlocked(status));
+    const show_counts = rl.isKeyDown(.f1);
+    rl.drawTexturePro(
+        title_tex,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(title_tex.width), @floatFromInt(title_tex.height)),
+        rl.Rectangle.init(layout.title_pos.x, layout.title_pos.y, quest_title_w, quest_title_h),
+        rl.Vector2.zero(),
+        0.0,
+        rl.Color.init(179, 179, 179, 179),
+    );
 
     const stage_textures = [_]window_assets.TextureId{ .ui_num1, .ui_num2, .ui_num3, .ui_num4, .ui_num5 };
     for (stage_textures, 0..) |texture_id, idx| {
         const stage = @as(i32, @intCast(idx + 1));
-        const rect = questStageRect(stage);
-        const tint = if (stage == state.stage) rl.Color.white else if (hoveredQuestStage() != null and hoveredQuestStage().? == stage) rl.Color.init(255, 255, 255, 204) else rl.Color.init(179, 179, 179, 179);
-        window_ui.drawTextureFit(runtime_assets.texture(texture_id), rect, tint);
+        const icon_scale = if (stage == state.stage) @as(f32, 1.0) else quest_stage_icon_scale_unselected;
+        const tint = if (stage == state.stage) rl.Color.white else if (hovered_stage != null and hovered_stage.? == stage) rl.Color.init(255, 255, 255, 204) else rl.Color.init(179, 179, 179, 179);
+        const x = layout.icons_start_pos.x + @as(f32, @floatFromInt(stage - 1)) * quest_stage_icon_step;
+        window_ui.drawTextureFit(runtime_assets.texture(texture_id), rl.Rectangle.init(x, layout.icons_start_pos.y, quest_stage_icon_size * icon_scale, quest_stage_icon_size * icon_scale), tint);
     }
 
     if (hardcoreUnlocked(status)) {
         const check_tex = if (config.hardcore_flag != 0) runtime_assets.texture(.ui_check_on) else runtime_assets.texture(.ui_check_off);
-        const rect = hardcoreCheckRect();
+        const rect = hardcoreCheckRect(layout);
         window_ui.drawTextureFit(check_tex, rl.Rectangle.init(rect.x, rect.y, @floatFromInt(check_tex.width), @floatFromInt(check_tex.height)), rl.Color.white);
-        window_ui.drawSmallText(runtime_assets, "Hardcore", rect.x + @as(f32, @floatFromInt(check_tex.width)) + 6.0, rect.y + 1.0, muted_text);
+        window_ui.drawSmallText(runtime_assets, "Hardcore", rect.x + @as(f32, @floatFromInt(check_tex.width)) + 6.0, rect.y + 1.0, questRowColor(config.hardcore_flag != 0, false));
     }
 
-    var y = base_y + (if (hardcoreUnlocked(status)) @as(f32, 26.0) else @as(f32, 0.0));
-    const hovered_row = hoveredQuestRow(hardcoreUnlocked(status));
+    var y = questRowsY0(layout, hardcoreUnlocked(status));
     for (0..10) |row| {
         const level_minor = @as(i32, @intCast(row + 1));
         const unlocked = questUnlocked(status, config.hardcore_flag != 0, state.stage, level_minor);
         const hovered = hovered_row != null and hovered_row.? == row;
-        const color = if (hovered or row == state.row_selection) rl.Color.init(70, 180, 240, 255) else rl.Color.init(70, 180, 240, 153);
-        window_ui.drawSmallTextFmt("{d}.{d}", runtime_assets, .{ state.stage, level_minor }, base_x, y, color);
+        const color = questRowColor(config.hardcore_flag != 0, hovered);
+        window_ui.drawSmallTextFmt("{d}.{d}", runtime_assets, .{ state.stage, level_minor }, layout.list_pos.x, y, color);
         const title = if (unlocked) questTitle(state.stage, level_minor) else "???";
-        window_ui.drawSmallText(runtime_assets, title, base_x + 52.0, y, color);
-        y += 18.0;
+        window_ui.drawSmallText(runtime_assets, title, layout.list_pos.x + quest_list_name_x_offset, y, color);
+        if (unlocked) {
+            const title_w = window_ui.measureSmallText(runtime_assets, title);
+            rl.drawLine(
+                @intFromFloat(layout.list_pos.x),
+                @intFromFloat(y + 13.0),
+                @intFromFloat(layout.list_pos.x + title_w + quest_list_name_x_offset),
+                @intFromFloat(y + 13.0),
+                color,
+            );
+            if (show_counts) {
+                const counts = questCounts(status, state.stage, row);
+                var counts_buf: [32]u8 = undefined;
+                const counts_text = std.fmt.bufPrint(&counts_buf, "({d}/{d})", .{ counts.completed, counts.games }) catch "";
+                window_ui.drawSmallText(runtime_assets, counts_text, layout.list_pos.x + quest_list_name_x_offset + title_w + 12.0, y, color);
+            }
+        }
+        y += quest_list_row_step;
     }
 
-    const back = backOnlyButton()[0];
+    const back = questBackButton(layout);
     const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
     window_ui.drawButton(back, false, hovered, runtime_assets);
 }
@@ -609,7 +732,7 @@ fn questUnlocked(status: formats.game_cfg.Status, hardcore: bool, stage: i32, mi
 }
 
 fn hardcoreUnlocked(status: formats.game_cfg.Status) bool {
-    return status.quest_unlock_index >= 49;
+    return status.quest_unlock_index >= quest_hardcore_unlock_index;
 }
 
 fn questTitle(stage: i32, minor: i32) []const u8 {
@@ -617,31 +740,113 @@ fn questTitle(stage: i32, minor: i32) []const u8 {
     return quest_titles[@intCast(std.math.clamp(index, @as(i32, 0), @as(i32, @intCast(quest_titles.len - 1))))];
 }
 
-fn questStageRect(stage: i32) rl.Rectangle {
-    return rl.Rectangle.init(554.0 + @as(f32, @floatFromInt(stage - 1)) * 40.0, 170.0, 32.0, 32.0);
-}
-
-fn hoveredQuestStage() ?i32 {
+fn hoveredQuestStage(layout: QuestLayout) ?i32 {
     const mouse = rl.getMousePosition();
     for (1..6) |stage| {
-        if (rl.checkCollisionPointRec(mouse, questStageRect(@intCast(stage)))) return @intCast(stage);
+        const x = layout.icons_start_pos.x + @as(f32, @floatFromInt(stage - 1)) * quest_stage_icon_step;
+        if (rl.checkCollisionPointRec(mouse, rl.Rectangle.init(x, layout.title_pos.y, quest_stage_icon_size, quest_stage_icon_size))) return @intCast(stage);
     }
     return null;
 }
 
-fn hoveredQuestRow(show_hardcore_toggle: bool) ?usize {
+fn hoveredQuestRow(layout: QuestLayout, show_hardcore_toggle: bool) ?usize {
     const mouse = rl.getMousePosition();
-    var y: f32 = 182.0 + if (show_hardcore_toggle) @as(f32, 26.0) else @as(f32, 0.0);
+    var y: f32 = questRowsY0(layout, show_hardcore_toggle);
     for (0..10) |row| {
-        const rect = rl.Rectangle.init(382.0, y - 3.0, 340.0, 16.0);
+        const rect = rl.Rectangle.init(
+            layout.list_pos.x - quest_list_hover_left_pad,
+            y - quest_list_hover_top_pad,
+            quest_list_hover_left_pad + quest_list_hover_right_pad,
+            quest_list_hover_bottom_pad - quest_list_hover_top_pad,
+        );
         if (rl.checkCollisionPointRec(mouse, rect)) return row;
-        y += 18.0;
+        y += quest_list_row_step;
     }
     return null;
 }
 
-fn hardcoreCheckRect() rl.Rectangle {
-    return rl.Rectangle.init(390.0, 182.0, 90.0, 16.0);
+fn hardcoreCheckRect(layout: QuestLayout) rl.Rectangle {
+    return rl.Rectangle.init(layout.list_pos.x + 132.0, layout.list_pos.y - 12.0, 120.0, 16.0);
+}
+
+fn beginCloseQuestBack(state: *QuestState) void {
+    if (state.closing) return;
+    state.closing = true;
+    state.closing_back = true;
+}
+
+fn beginCloseQuestStart(state: *QuestState, level_key: i32) void {
+    if (state.closing) return;
+    state.closing = true;
+    state.closing_level_key = level_key;
+}
+
+fn tryStartQuest(state: *QuestState, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, stage: i32, row: usize) QuestResult {
+    const minor = @as(i32, @intCast(row + 1));
+    if (!questUnlocked(status, config.hardcore_flag != 0, stage, minor)) return .{};
+    const level_key = stage * 100 + minor;
+    config.game_mode = @intFromEnum(game_ids.GameModeId.quests);
+    beginCloseQuestStart(state, level_key);
+    return .{ .play_button_click = true, .config_dirty = true };
+}
+
+fn questDigitRowPressed() ?usize {
+    if (rl.isKeyPressed(.one)) return 0;
+    if (rl.isKeyPressed(.two)) return 1;
+    if (rl.isKeyPressed(.three)) return 2;
+    if (rl.isKeyPressed(.four)) return 3;
+    if (rl.isKeyPressed(.five)) return 4;
+    if (rl.isKeyPressed(.six)) return 5;
+    if (rl.isKeyPressed(.seven)) return 6;
+    if (rl.isKeyPressed(.eight)) return 7;
+    if (rl.isKeyPressed(.nine)) return 8;
+    if (rl.isKeyPressed(.zero)) return 9;
+    return null;
+}
+
+fn questLayout() QuestLayout {
+    return .{
+        .panel_rect = .{ .x = 390.0, .y = 168.0, .width = 510.0, .height = 378.0 },
+        .title_pos = .{ .x = 609.0, .y = 212.0 },
+        .icons_start_pos = .{ .x = 689.0, .y = 215.0 },
+        .list_pos = .{ .x = 641.0, .y = 262.0 },
+        .back_pos = .{ .x = 779.0, .y = 474.0 },
+    };
+}
+
+fn questRowsY0(layout: QuestLayout, show_hardcore_toggle: bool) f32 {
+    return layout.list_pos.y + if (show_hardcore_toggle) @as(f32, 10.0) else @as(f32, 0.0);
+}
+
+fn questBackButton(layout: QuestLayout) window_ui.UiButton {
+    return .{ .label = "Back", .rect = rl.Rectangle.init(layout.back_pos.x, layout.back_pos.y, 82.0, 32.0) };
+}
+
+fn questBackButtonActivated(layout: QuestLayout) bool {
+    const back = questBackButton(layout);
+    return rl.isMouseButtonPressed(.left) and rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
+}
+
+fn questRowColor(hardcore: bool, hovered: bool) rl.Color {
+    if (hardcore) {
+        return if (hovered) rl.Color.init(250, 70, 60, 255) else rl.Color.init(250, 70, 60, 153);
+    }
+    return if (hovered) rl.Color.init(70, 180, 240, 255) else rl.Color.init(70, 180, 240, 153);
+}
+
+const QuestCountPair = struct {
+    completed: u32,
+    games: u32,
+};
+
+fn questCounts(status: formats.game_cfg.Status, stage: i32, row: usize) QuestCountPair {
+    const global_index = @as(usize, @intCast((stage - 1) * 10 + @as(i32, @intCast(row))));
+    const games_idx = global_index;
+    const completed_idx = global_index + 40;
+    return .{
+        .completed = if (completed_idx < status.quest_play_counts.len) status.quest_play_counts[completed_idx] else 0,
+        .games = if (games_idx < status.quest_play_counts.len) status.quest_play_counts[games_idx] else 0,
+    };
 }
 
 pub const StatisticsState = struct {
@@ -776,8 +981,12 @@ fn infoLabelRow(kind: InfoKind) i32 {
     };
 }
 
+fn frameDeltaMs(frame_dt: f32) i32 {
+    return @intFromFloat(@min(frame_dt, 0.1) * 1000.0);
+}
+
 fn panelAdvance(panel: *PanelState, frame_dt: f32) i32 {
-    const dt_ms = @as(i32, @intFromFloat(@min(frame_dt, 0.1) * 1000.0));
+    const dt_ms = frameDeltaMs(frame_dt);
     if (dt_ms > 0) {
         panel.timeline_ms = @min(panel_timeline_max_ms, panel.timeline_ms + dt_ms);
     }
@@ -802,8 +1011,29 @@ fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.Run
     }
 }
 
+fn drawMenuPanelShellNoTitle(timeline_ms: i32, runtime_assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle) void {
+    window_menu.drawMenuBackdrop(runtime_assets);
+    window_menu.drawSign(timeline_ms, runtime_assets);
+
+    const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
+    const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
+    window_ui.drawTextureFit(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+}
+
 fn drawTextureLabel(runtime_assets: *const window_assets.RuntimeAssets, texture_id: window_assets.TextureId, x: f32, y: f32, w: f32, h: f32, tint: rl.Color) void {
     window_ui.drawTextureFit(runtime_assets.texture(texture_id), rl.Rectangle.init(x, y, w, h), tint);
+}
+
+fn drawAtlasLabelAt(runtime_assets: *const window_assets.RuntimeAssets, x: f32, y: f32, row: i32, tint: rl.Color) void {
+    const texture = runtime_assets.texture(.ui_item_texts);
+    rl.drawTexturePro(
+        texture,
+        rl.Rectangle.init(0.0, @as(f32, @floatFromInt(row)) * 32.0, 128.0, 32.0),
+        rl.Rectangle.init(x, y, 128.0, 32.0),
+        rl.Vector2.zero(),
+        0.0,
+        tint,
+    );
 }
 
 fn playGameButtons() [4]window_ui.UiButton {

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -341,7 +341,6 @@ fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const windo
     const show_counts = rl.isKeyDown(.f1);
 
     drawAtlasLabelAt(runtime_assets, layout.title_pos.x, layout.title_pos.y, window_menu.label_row_play_game, window_ui.colorWithAlpha(rl.Color.white, 0.96));
-    window_ui.drawSmallText(runtime_assets, "player count", layout.drop_x, layout.content_y - 12.0, muted_text);
     drawPlayerCountWidget(state, runtime_assets, player_count_raw);
 
     var y = layout.content_y + layout.y_start;
@@ -389,9 +388,8 @@ fn playGameLayoutFromPlayerCount(player_count_raw: u32, status: formats.game_cfg
     const tight_spacing = player_count == 1 and status.quest_unlock_index >= 40;
     const y_step: f32 = if (tight_spacing) 28.0 else 32.0;
     const y_start: f32 = if (tight_spacing) 42.0 else 48.0;
-    const panel_height = 206.0 + y_start + y_step * @as(f32, @floatFromInt(entries.len));
     return .{
-        .panel_rect = .{ .x = 352.0, .y = 150.0, .width = 510.0, .height = panel_height },
+        .panel_rect = .{ .x = 352.0, .y = 150.0, .width = 510.0, .height = 278.0 },
         .title_pos = .{ .x = 496.0, .y = 184.0 },
         .content_x = 470.0,
         .content_y = 206.0,
@@ -404,7 +402,7 @@ fn playGameLayoutFromPlayerCount(player_count_raw: u32, status: formats.game_cfg
 }
 
 fn playGameButton(label: [:0]const u8, center_x: f32, top_y: f32) window_ui.UiButton {
-    return .{ .label = label, .rect = window_ui.centeredRect(center_x, top_y, 220.0, 44.0) };
+    return window_ui.buttonAt(label, center_x, top_y, false);
 }
 
 fn hoveredPlayGameEntry(entries: []const PlayGameEntry, layout: PlayGameLayout) ?usize {
@@ -673,7 +671,7 @@ fn drawQuestContent(state: *const QuestState, runtime_assets: *const window_asse
         rl.Rectangle.init(layout.title_pos.x, layout.title_pos.y, quest_title_w, quest_title_h),
         rl.Vector2.zero(),
         0.0,
-        rl.Color.init(179, 179, 179, 179),
+        rl.Color.white,
     );
 
     const stage_textures = [_]window_assets.TextureId{ .ui_num1, .ui_num2, .ui_num3, .ui_num4, .ui_num5 };
@@ -718,6 +716,10 @@ fn drawQuestContent(state: *const QuestState, runtime_assets: *const window_asse
             }
         }
         y += quest_list_row_step;
+    }
+
+    if (show_counts) {
+        window_ui.drawSmallText(runtime_assets, "(completed/games)", layout.list_pos.x + 96.0, questRowsY0(layout, hardcoreUnlocked(status)) + quest_list_row_step * 10.0 - 2.0, questRowColor(config.hardcore_flag != 0, false));
     }
 
     const back = questBackButton(layout);
@@ -819,7 +821,7 @@ fn questRowsY0(layout: QuestLayout, show_hardcore_toggle: bool) f32 {
 }
 
 fn questBackButton(layout: QuestLayout) window_ui.UiButton {
-    return .{ .label = "Back", .rect = rl.Rectangle.init(layout.back_pos.x, layout.back_pos.y, 82.0, 32.0) };
+    return window_ui.buttonAt("Back", layout.back_pos.x, layout.back_pos.y, false);
 }
 
 fn questBackButtonActivated(layout: QuestLayout) bool {
@@ -1071,7 +1073,7 @@ fn statisticsButtons() [5]window_ui.UiButton {
 
 fn backOnlyButton() [1]window_ui.UiButton {
     return .{
-        .{ .label = "BACK", .rect = window_ui.centeredRect(@as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5, 562.0, 180.0, 44.0) },
+        window_ui.buttonAt("Back", @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5 - 41.0, 562.0, false),
     };
 }
 

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -333,7 +333,7 @@ fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const windo
     const entries = playGameEntriesFromPlayerCount(clamped_player_count, status);
     const show_counts = rl.isKeyDown(.f1);
 
-    drawAtlasLabelAt(runtime_assets, layout.title_pos.x, layout.title_pos.y, window_menu.label_row_play_game, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    drawAtlasLabelAt(runtime_assets, layout.title_pos.x, layout.title_pos.y, window_menu.label_row_play_game, rl.Color.white);
     drawPlayerCountWidget(state, runtime_assets, player_count_raw);
 
     var y = layout.content_y + layout.y_start;
@@ -976,13 +976,13 @@ fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.Run
 
     const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
     const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
-    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, rl.Color.white, false);
 
     const T = @TypeOf(title_row_or_texture);
     if (T == i32) {
-        window_menu.drawAtlasLabelCentered(runtime_assets, title_row_or_texture, rect.y + 42.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+        window_menu.drawAtlasLabelCentered(runtime_assets, title_row_or_texture, rect.y + 42.0, rl.Color.white);
     } else {
-        drawTextureLabel(runtime_assets, title_row_or_texture, rect.x + rect.width * 0.5 - 64.0, rect.y + 34.0, 128.0, 32.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+        drawTextureLabel(runtime_assets, title_row_or_texture, rect.x + rect.width * 0.5 - 64.0, rect.y + 34.0, 128.0, 32.0, rl.Color.white);
     }
 }
 
@@ -992,7 +992,7 @@ fn drawMenuPanelShellNoTitle(timeline_ms: i32, runtime_assets: *const window_ass
 
     const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
     const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
-    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, rl.Color.white, false);
 }
 
 fn drawTextureLabel(runtime_assets: *const window_assets.RuntimeAssets, texture_id: window_assets.TextureId, x: f32, y: f32, w: f32, h: f32, tint: rl.Color) void {

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -183,14 +183,13 @@ const PlayGameEntry = struct {
 
 const PlayGameLayout = struct {
     panel_rect: rl.Rectangle,
+    base_pos: rl.Vector2,
+    drop_pos: rl.Vector2,
     title_pos: rl.Vector2,
-    content_x: f32,
-    content_y: f32,
-    drop_x: f32,
     y_start: f32,
     y_step: f32,
     count_x: f32,
-    tooltip_y: f32,
+    tooltip_pos: rl.Vector2,
 };
 
 const QuestLayout = struct {
@@ -337,9 +336,9 @@ fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const windo
     drawAtlasLabelAt(runtime_assets, layout.title_pos.x, layout.title_pos.y, window_menu.label_row_play_game, rl.Color.white);
     drawPlayerCountWidget(state, runtime_assets, layout, player_count_raw);
 
-    var y = layout.content_y + layout.y_start;
+    var y = layout.base_pos.y + layout.y_start;
     for (entries) |entry| {
-        const button = playGameButton(entry.label, layout.content_x, y);
+        const button = playGameButton(entry.label, layout.base_pos.x, y);
         const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
         window_ui.drawButton(button, false, hovered, runtime_assets);
         if (show_counts and entry.show_count) {
@@ -378,16 +377,18 @@ fn playGameLayoutFromPlayerCount(player_count_raw: u32, status: formats.game_cfg
     const y_step: f32 = if (tight_spacing) 28.0 else 32.0;
     const y_start: f32 = if (tight_spacing) 42.0 else 48.0;
     const panel_rect = animatedPanelRect(.{ .x = 352.0, .y = 150.0, .width = 510.0, .height = 278.0 }, timeline_ms);
+    const base_pos = rl.Vector2.init(panel_rect.x + 266.0, panel_rect.y + 50.0);
+    const drop_pos = rl.Vector2.init(base_pos.x + 80.0, base_pos.y + 1.0);
+    const y_end = y_start + y_step * @as(f32, @floatFromInt(entries.len));
     return .{
         .panel_rect = panel_rect,
-        .title_pos = .{ .x = panel_rect.x + 144.0, .y = 184.0 },
-        .content_x = panel_rect.x + 118.0,
-        .content_y = 206.0,
-        .drop_x = panel_rect.x + 170.0,
-        .y_start = if (tight_spacing) 26.0 else 32.0,
+        .base_pos = base_pos,
+        .drop_pos = drop_pos,
+        .title_pos = .{ .x = base_pos.x - 64.0, .y = base_pos.y - 8.0 },
+        .y_start = y_start,
         .y_step = y_step,
-        .count_x = panel_rect.x + 392.0,
-        .tooltip_y = 222.0 + y_start + y_step * @as(f32, @floatFromInt(entries.len)),
+        .count_x = base_pos.x + 158.0,
+        .tooltip_pos = .{ .x = base_pos.x - 55.0, .y = base_pos.y + y_end + 16.0 },
     };
 }
 
@@ -397,9 +398,9 @@ fn playGameButton(label: [:0]const u8, center_x: f32, top_y: f32) window_ui.UiBu
 
 fn hoveredPlayGameEntry(entries: []const PlayGameEntry, layout: PlayGameLayout) ?usize {
     const mouse = rl.getMousePosition();
-    var y = layout.content_y + layout.y_start;
+    var y = layout.base_pos.y + layout.y_start;
     for (entries, 0..) |entry, idx| {
-        const button = playGameButton(entry.label, layout.content_x, y);
+        const button = playGameButton(entry.label, layout.base_pos.x, y);
         if (rl.checkCollisionPointRec(mouse, button.rect)) return idx;
         y += layout.y_step;
     }
@@ -445,15 +446,18 @@ fn updatePlayGameTooltipTimers(state: *PlayGameState, entries: []const PlayGameE
 }
 
 fn drawPlayGameTooltips(state: *const PlayGameState, runtime_assets: *const window_assets.RuntimeAssets, entries: []const PlayGameEntry, layout: PlayGameLayout) void {
-    const tooltip_x = layout.content_x - 55.0;
-    const tooltip_y = layout.tooltip_y + 16.0;
     for (entries) |entry| {
         const tooltip_idx = tooltipIndexForKey(entry.key);
         const ms = state.tooltip_ms[tooltip_idx];
         if (ms <= 0) continue;
         const alpha = @as(u8, @intFromFloat(@min(@as(f32, 1.0), @as(f32, @floatFromInt(ms)) * 0.0009) * 255.0));
         const offset = playGameTooltipOffset(entry.key);
-        window_ui.drawSmallText(runtime_assets, entry.tooltip, tooltip_x + offset.x, tooltip_y + offset.y, rl.Color.init(255, 255, 255, alpha));
+        var lines = std.mem.splitScalar(u8, entry.tooltip, '\n');
+        var y = layout.tooltip_pos.y + offset.y;
+        while (lines.next()) |line| {
+            window_ui.drawSmallText(runtime_assets, line, layout.tooltip_pos.x + offset.x, y, rl.Color.init(255, 255, 255, alpha));
+            y += 14.0;
+        }
     }
 }
 
@@ -596,8 +600,10 @@ pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_
     const layout = questLayout(state.panel.timeline_ms);
     const hovered_stage = hoveredQuestStage(layout);
     if (hovered_stage) |stage| {
-        state.stage = stage;
-        if (rl.isMouseButtonPressed(.left)) return .{ .play_button_click = true };
+        if (rl.isMouseButtonPressed(.left)) {
+            state.stage = stage;
+            return .{ .play_button_click = true };
+        }
     }
 
     if (questDigitRowPressed()) |row| {
@@ -1028,15 +1034,15 @@ fn playGameButtons() [4]window_ui.UiButton {
 }
 
 fn playerCountHeaderRect(layout: PlayGameLayout) rl.Rectangle {
-    return rl.Rectangle.init(layout.drop_x - 30.0, 258.0, 124.0, 16.0);
+    return rl.Rectangle.init(layout.drop_pos.x, layout.drop_pos.y, 102.0, 16.0);
 }
 
 fn playerCountListRect(layout: PlayGameLayout) rl.Rectangle {
-    return rl.Rectangle.init(layout.drop_x - 30.0, 258.0, 124.0, 80.0);
+    return rl.Rectangle.init(layout.drop_pos.x, layout.drop_pos.y, 102.0, 88.0);
 }
 
 fn playerCountRowRect(layout: PlayGameLayout, idx: usize) rl.Rectangle {
-    return rl.Rectangle.init(layout.drop_x - 30.0, 275.0 + @as(f32, @floatFromInt(idx)) * 16.0, 124.0, 16.0);
+    return rl.Rectangle.init(layout.drop_pos.x, layout.drop_pos.y + 17.0 + @as(f32, @floatFromInt(idx)) * 16.0, 102.0, 16.0);
 }
 
 fn statisticsButtons(timeline_ms: i32) [5]window_ui.UiButton {

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -268,10 +268,10 @@ pub fn updateControls(state: *ControlsState, frame_dt: f32, config: *formats.cri
             openDropdown(state, config, .player, 4);
         },
         1 => {
-            openDropdown(state, config, .movement, movement_items.len);
+            openDropdown(state, config, .aim, aimItemCount(config, currentPlayerIndex(state)));
         },
         2 => {
-            openDropdown(state, config, .aim, aimItemCount(config, currentPlayerIndex(state)));
+            openDropdown(state, config, .movement, movement_items.len);
         },
         3 => {
             formats.crimson_cfg.setPlayerShowDirectionArrow(config, currentPlayerIndex(state), !formats.crimson_cfg.playerShowDirectionArrow(config, currentPlayerIndex(state)));
@@ -294,7 +294,7 @@ pub fn drawControls(state: *const ControlsState, runtime_assets: ?*const window_
 
 fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
     const buttons = optionsButtons();
-    for (buttons, 0..) |button, idx| {
+    for (buttons[5..], 5..) |button, idx| {
         const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
         window_ui.drawButton(button, idx == state.panel.selection, hovered, runtime_assets);
     }
@@ -308,7 +308,9 @@ fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window
     };
     for (labels, 0..) |label, idx| {
         const y = 236.0 + @as(f32, @floatFromInt(idx)) * 36.0;
-        window_ui.drawSmallText(runtime_assets, label, 420.0, y, muted_text);
+        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), buttons[idx].rect);
+        const selected = idx == state.panel.selection;
+        window_ui.drawSmallText(runtime_assets, label, 420.0, y, if (selected or hovered) text_color else muted_text);
     }
 
     drawSlider(runtime_assets, rl.Vector2.init(625.0, 234.0), 10, if (config.sound_disable != 0) 0 else @intFromFloat(std.math.clamp(config.sfx_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5));
@@ -318,6 +320,7 @@ fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window
 
     const checkbox_tex: window_assets.TextureId = if (config.ui_info_texts != 0) .ui_check_on else .ui_check_off;
     window_ui.drawTextureFit(runtime_assets.texture(checkbox_tex), rl.Rectangle.init(625.0, 378.0, 16.0, 16.0), rl.Color.white);
+    window_ui.drawSmallText(runtime_assets, "UI Info texts", 647.0, 379.0, if (state.panel.selection == 4 or rl.checkCollisionPointRec(rl.getMousePosition(), buttons[4].rect)) text_color else muted_text);
 }
 
 fn drawControlsPanels(state: *const ControlsState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
@@ -328,17 +331,18 @@ fn drawControlsPanels(state: *const ControlsState, runtime_assets: *const window
 
     window_ui.drawTextureFit(runtime_assets.texture(.ui_text_controls), rl.Rectangle.init(322.0, 202.0, 128.0, 32.0), rl.Color.white);
     window_ui.drawSmallText(runtime_assets, "Configured controls", 746.0, 156.0, text_color);
+    rl.drawRectangle(746, 169, @intFromFloat(window_ui.measureSmallText(runtime_assets, "Configured controls")), 1, rl.Color.init(255, 255, 255, 204));
 
     const player_idx = currentPlayerIndex(state);
     drawDropdownLabel(runtime_assets, "Configure for:", 182.0, 244.0);
     drawDropdown(runtime_assets, dropdownRect(182.0, 262.0), player_items[0..], player_idx, state.open_dropdown == .player, state.dropdown_selection);
 
-    drawDropdownLabel(runtime_assets, "Movement:", 182.0, 300.0);
-    drawDropdown(runtime_assets, dropdownRect(182.0, 318.0), movement_items[0..], movementItemIndex(&config, player_idx), state.open_dropdown == .movement, state.dropdown_selection);
-
-    drawDropdownLabel(runtime_assets, "Aim:", 182.0, 356.0);
+    drawDropdownLabel(runtime_assets, "Aiming method:", 182.0, 300.0);
     const current_aim_items = aimItems(&config, player_idx);
-    drawDropdown(runtime_assets, dropdownRect(182.0, 374.0), current_aim_items, aimItemIndex(&config, player_idx), state.open_dropdown == .aim, state.dropdown_selection);
+    drawDropdown(runtime_assets, dropdownRect(182.0, 318.0), current_aim_items, aimItemIndex(&config, player_idx), state.open_dropdown == .aim, state.dropdown_selection);
+
+    drawDropdownLabel(runtime_assets, "Moving method:", 182.0, 356.0);
+    drawDropdown(runtime_assets, dropdownRect(182.0, 374.0), movement_items[0..], movementItemIndex(&config, player_idx), state.open_dropdown == .movement, state.dropdown_selection);
 
     const direction_checked: window_assets.TextureId = if (formats.crimson_cfg.playerShowDirectionArrow(&config, player_idx)) .ui_check_on else .ui_check_off;
     window_ui.drawTextureFit(runtime_assets.texture(direction_checked), rl.Rectangle.init(182.0, 418.0, 16.0, 16.0), rl.Color.white);
@@ -375,25 +379,26 @@ fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.Run
 
 fn optionsButtons() [7]OptionButton {
     return .{
-        .{ .label = "SFX", .rect = rl.Rectangle.init(404.0, 226.0, 320.0, 28.0) },
-        .{ .label = "MUSIC", .rect = rl.Rectangle.init(404.0, 262.0, 320.0, 28.0) },
-        .{ .label = "DETAIL", .rect = rl.Rectangle.init(404.0, 298.0, 320.0, 28.0) },
-        .{ .label = "MOUSE", .rect = rl.Rectangle.init(404.0, 334.0, 320.0, 28.0) },
-        .{ .label = "UIINFO", .rect = rl.Rectangle.init(404.0, 370.0, 320.0, 28.0) },
-        .{ .label = "CONTROLS", .rect = rl.Rectangle.init(404.0, 414.0, 240.0, 44.0) },
-        .{ .label = "BACK", .rect = rl.Rectangle.init(404.0, 470.0, 180.0, 44.0) },
+        .{ .label = "Sfx", .rect = rl.Rectangle.init(404.0, 226.0, 320.0, 28.0) },
+        .{ .label = "Music", .rect = rl.Rectangle.init(404.0, 262.0, 320.0, 28.0) },
+        .{ .label = "Detail", .rect = rl.Rectangle.init(404.0, 298.0, 320.0, 28.0) },
+        .{ .label = "Mouse", .rect = rl.Rectangle.init(404.0, 334.0, 320.0, 28.0) },
+        .{ .label = "UiInfo", .rect = rl.Rectangle.init(404.0, 370.0, 320.0, 28.0) },
+        .{ .label = "Controls", .rect = rl.Rectangle.init(404.0, 414.0, 240.0, 44.0) },
+        .{ .label = "Back", .rect = rl.Rectangle.init(404.0, 470.0, 180.0, 44.0) },
     };
 }
 
 fn controlsBackButton() OptionButton {
-    return .{ .label = "BACK", .rect = rl.Rectangle.init(182.0, 448.0, 180.0, 44.0) };
+    return .{ .label = "Back", .rect = rl.Rectangle.init(182.0, 448.0, 180.0, 44.0) };
 }
 
 fn drawSlider(runtime_assets: *const window_assets.RuntimeAssets, pos: rl.Vector2, count: i32, value: i32) void {
     var idx: i32 = 0;
     while (idx < count) : (idx += 1) {
         const id: window_assets.TextureId = if (idx < value) .ui_rect_on else .ui_rect_off;
-        window_ui.drawTextureFit(runtime_assets.texture(id), rl.Rectangle.init(pos.x + @as(f32, @floatFromInt(idx * 16)), pos.y, 16.0, 16.0), rl.Color.white);
+        const tint = if (idx < value) rl.Color.white else rl.Color.init(255, 255, 255, 128);
+        window_ui.drawTextureFit(runtime_assets.texture(id), rl.Rectangle.init(pos.x + @as(f32, @floatFromInt(idx * 16)), pos.y, 16.0, 16.0), tint);
     }
 }
 
@@ -445,8 +450,8 @@ fn updateControlsFocusFromPointer(state: *ControlsState, rows: []const RebindRow
     const mouse = rl.getMousePosition();
     const left_rects = [_]rl.Rectangle{
         dropdownRect(182.0, 262.0),
-        dropdownRect(182.0, 318.0),
         dropdownRect(182.0, 374.0),
+        dropdownRect(182.0, 318.0),
         rl.Rectangle.init(182.0, 416.0, 220.0, 20.0),
     };
     for (left_rects, 0..) |rect, idx| {
@@ -489,8 +494,8 @@ fn updateControlsDropdown(state: *ControlsState, config: *formats.crimson_cfg.Cr
     const mouse = rl.getMousePosition();
     const base_rect = switch (state.open_dropdown) {
         .player => dropdownRect(182.0, 262.0),
-        .movement => dropdownRect(182.0, 318.0),
-        .aim => dropdownRect(182.0, 374.0),
+        .movement => dropdownRect(182.0, 374.0),
+        .aim => dropdownRect(182.0, 318.0),
         .none => unreachable,
     };
     for (items, 0..) |item, idx| {

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -313,6 +313,16 @@ fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window
     const controls_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), controls.rect);
     window_ui.drawButton(controls, false, controls_hovered, runtime_assets);
 
+    const labels_tex = runtime_assets.texture(.ui_item_texts);
+    rl.drawTexturePro(
+        labels_tex,
+        rl.Rectangle.init(0.0, @as(f32, @floatFromInt(window_menu.label_row_options)) * 32.0, 128.0, 32.0),
+        rl.Rectangle.init(panel_rect.x + 212.0, panel_rect.y + 40.0, 128.0, 32.0),
+        rl.Vector2.zero(),
+        0.0,
+        rl.Color.white,
+    );
+
     const labels = [_][]const u8{
         "Sound volume:",
         "Music volume:",

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -17,6 +17,7 @@ const value_dim = rl.Color.init(70, 180, 240, 153);
 const active_color = rl.Color.init(255, 228, 170, 255);
 
 const panel_timeline_max_ms: i32 = 300;
+const options_panel_rect = rl.Rectangle.init(360.0, 148.0, 510.0, 364.0);
 const controls_left_panel_rect = rl.Rectangle.init(132.0, 174.0, 510.0, 254.0);
 const controls_right_panel_rect = rl.Rectangle.init(598.0, 118.0, 510.0, 378.0);
 
@@ -132,6 +133,7 @@ pub fn updateOptions(state: *OptionsState, frame_dt: f32, config: *formats.crims
     const mouse = rl.getMousePosition();
     const click = rl.isMouseButtonPressed(.left);
     const mouse_down = rl.isMouseButtonDown(.left);
+    const panel_rect = animatedLeftPanelRect(options_panel_rect, state.panel.timeline_ms);
     const back_hovered = if (runtime_assets) |assets|
         state.panel.timeline_ms >= panel_timeline_max_ms and rl.checkCollisionPointRec(mouse, window_menu.panelBackHitRect(assets, state.panel.timeline_ms))
     else
@@ -152,37 +154,37 @@ pub fn updateOptions(state: *OptionsState, frame_dt: f32, config: *formats.crims
         .play_panel_click = dt_ms > 0 and state.panel.timeline_ms >= panel_timeline_max_ms and !state.panel.panel_open_sfx_played,
     };
 
-    if (updateOptionSlider(state, .sfx, optionSliderRect(625.0, 234.0, 10), 10, mouse, click, mouse_down)) |value| {
+    if (updateOptionSlider(state, .sfx, optionSliderRect(panel_rect, 265.0, 86.0, 10), 10, mouse, click, mouse_down)) |value| {
         config.sfx_volume = @as(f32, @floatFromInt(value)) * 0.1;
         config.sound_disable = @intFromBool(value == 0);
         result.config_dirty = true;
         result.reload_audio = true;
         result.play_button_click = true;
     }
-    if (updateOptionSlider(state, .music, optionSliderRect(625.0, 270.0, 10), 10, mouse, click, mouse_down)) |value| {
+    if (updateOptionSlider(state, .music, optionSliderRect(panel_rect, 265.0, 122.0, 10), 10, mouse, click, mouse_down)) |value| {
         config.music_volume = @as(f32, @floatFromInt(value)) * 0.1;
         config.music_disable = @intFromBool(value == 0);
         result.config_dirty = true;
         result.reload_audio = true;
         result.play_button_click = true;
     }
-    if (updateOptionSlider(state, .detail, optionSliderRect(625.0, 306.0, 5), 5, mouse, click, mouse_down)) |value| {
+    if (updateOptionSlider(state, .detail, optionSliderRect(panel_rect, 265.0, 158.0, 5), 5, mouse, click, mouse_down)) |value| {
         config.detail_preset = @intCast(std.math.clamp(value, @as(i32, 1), @as(i32, 5)));
         result.config_dirty = true;
         result.play_button_click = true;
     }
-    if (updateOptionSlider(state, .mouse, optionSliderRect(625.0, 342.0, 10), 10, mouse, click, mouse_down)) |value| {
+    if (updateOptionSlider(state, .mouse, optionSliderRect(panel_rect, 265.0, 194.0, 10), 10, mouse, click, mouse_down)) |value| {
         config.mouse_sensitivity = std.math.clamp(@as(f32, @floatFromInt(value)) * 0.1, @as(f32, 0.1), @as(f32, 1.0));
         result.config_dirty = true;
         result.play_button_click = true;
     }
-    if (click and rectContains(optionCheckboxRect(), mouse)) {
+    if (click and rectContains(optionCheckboxRect(panel_rect), mouse)) {
         config.ui_info_texts = if (config.ui_info_texts == 0) 1 else 0;
         result.config_dirty = true;
         result.play_button_click = true;
     }
 
-    const controls = controlsButton();
+    const controls = controlsButton(panel_rect);
     if (click and rl.checkCollisionPointRec(mouse, controls.rect)) {
         result.action = .open_controls;
         result.play_button_click = true;
@@ -193,7 +195,7 @@ pub fn updateOptions(state: *OptionsState, frame_dt: f32, config: *formats.crims
 
 pub fn drawOptions(state: *const OptionsState, runtime_assets: ?*const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
     if (runtime_assets) |assets| {
-        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, .{ .x = 360.0, .y = 148.0, .width = 510.0, .height = 364.0 });
+        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, options_panel_rect);
         drawOptionsContents(state, assets, config);
         return;
     }
@@ -205,6 +207,8 @@ pub fn updateControls(state: *ControlsState, frame_dt: f32, config: *formats.cri
     if (dt_ms > 0) {
         state.timeline_ms = @min(panel_timeline_max_ms, state.timeline_ms + dt_ms);
     }
+    const left_rect = animatedLeftPanelRect(controls_left_panel_rect, state.timeline_ms);
+    const right_rect = animatedRightPanelRect(controls_right_panel_rect, state.timeline_ms);
     const mouse = rl.getMousePosition();
     const back_hovered = if (runtime_assets) |assets|
         state.timeline_ms >= panel_timeline_max_ms and rl.checkCollisionPointRec(mouse, window_menu.panelBackHitRect(assets, state.timeline_ms))
@@ -229,7 +233,7 @@ pub fn updateControls(state: *ControlsState, frame_dt: f32, config: *formats.cri
     }
 
     if (state.open_dropdown != .none) {
-        return updateControlsDropdown(state, config);
+        return updateControlsDropdown(state, config, left_rect);
     }
 
     const button_count = leftControlButtonCount();
@@ -240,7 +244,7 @@ pub fn updateControls(state: *ControlsState, frame_dt: f32, config: *formats.cri
         state.right_selection = rebind_rows.len - 1;
     }
 
-    updateControlsFocusFromPointer(state, rebind_rows[0..]);
+    updateControlsFocusFromPointer(state, rebind_rows[0..], left_rect, right_rect);
 
     if (rl.isKeyPressed(.tab)) {
         state.focus_right = !state.focus_right;
@@ -304,7 +308,8 @@ pub fn drawControls(state: *const ControlsState, runtime_assets: ?*const window_
 }
 
 fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
-    const controls = controlsButton();
+    const panel_rect = animatedLeftPanelRect(options_panel_rect, state.panel.timeline_ms);
+    const controls = controlsButton(panel_rect);
     const controls_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), controls.rect);
     window_ui.drawButton(controls, false, controls_hovered, runtime_assets);
 
@@ -316,32 +321,31 @@ fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window
         "UI Info texts",
     };
     for (labels, 0..) |label, idx| {
-        const y = 236.0 + @as(f32, @floatFromInt(idx)) * 36.0;
         const hovered = switch (idx) {
-            0 => rectContains(optionSliderRect(625.0, 234.0, 10), rl.getMousePosition()),
-            1 => rectContains(optionSliderRect(625.0, 270.0, 10), rl.getMousePosition()),
-            2 => rectContains(optionSliderRect(625.0, 306.0, 5), rl.getMousePosition()),
-            3 => rectContains(optionSliderRect(625.0, 342.0, 10), rl.getMousePosition()),
-            4 => rectContains(optionCheckboxRect(), rl.getMousePosition()),
+            0 => rectContains(optionSliderRect(panel_rect, 265.0, 86.0, 10), rl.getMousePosition()),
+            1 => rectContains(optionSliderRect(panel_rect, 265.0, 122.0, 10), rl.getMousePosition()),
+            2 => rectContains(optionSliderRect(panel_rect, 265.0, 158.0, 5), rl.getMousePosition()),
+            3 => rectContains(optionSliderRect(panel_rect, 265.0, 194.0, 10), rl.getMousePosition()),
+            4 => rectContains(optionCheckboxRect(panel_rect), rl.getMousePosition()),
             else => false,
         };
-        window_ui.drawSmallText(runtime_assets, label, 420.0, y, if (hovered) text_color else muted_text);
+        window_ui.drawSmallText(runtime_assets, label, panel_rect.x + 60.0, panel_rect.y + 88.0 + @as(f32, @floatFromInt(idx)) * 36.0, if (hovered) text_color else muted_text);
     }
 
-    drawSlider(runtime_assets, rl.Vector2.init(625.0, 234.0), 10, if (config.sound_disable != 0) 0 else @intFromFloat(std.math.clamp(config.sfx_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5));
-    drawSlider(runtime_assets, rl.Vector2.init(625.0, 270.0), 10, if (config.music_disable != 0) 0 else @intFromFloat(std.math.clamp(config.music_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5));
-    drawSlider(runtime_assets, rl.Vector2.init(625.0, 306.0), 5, @intCast(std.math.clamp(config.detail_preset, @as(u32, 1), @as(u32, 5))));
-    drawSlider(runtime_assets, rl.Vector2.init(625.0, 342.0), 10, @intFromFloat(std.math.clamp(config.mouse_sensitivity, @as(f32, 0.1), @as(f32, 1.0)) * 10.0 + 0.5));
+    drawSlider(runtime_assets, rl.Vector2.init(panel_rect.x + 265.0, panel_rect.y + 86.0), 10, if (config.sound_disable != 0) 0 else @intFromFloat(std.math.clamp(config.sfx_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5));
+    drawSlider(runtime_assets, rl.Vector2.init(panel_rect.x + 265.0, panel_rect.y + 122.0), 10, if (config.music_disable != 0) 0 else @intFromFloat(std.math.clamp(config.music_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5));
+    drawSlider(runtime_assets, rl.Vector2.init(panel_rect.x + 265.0, panel_rect.y + 158.0), 5, @intCast(std.math.clamp(config.detail_preset, @as(u32, 1), @as(u32, 5))));
+    drawSlider(runtime_assets, rl.Vector2.init(panel_rect.x + 265.0, panel_rect.y + 194.0), 10, @intFromFloat(std.math.clamp(config.mouse_sensitivity, @as(f32, 0.1), @as(f32, 1.0)) * 10.0 + 0.5));
 
     const checkbox_tex: window_assets.TextureId = if (config.ui_info_texts != 0) .ui_check_on else .ui_check_off;
-    window_ui.drawTextureFit(runtime_assets.texture(checkbox_tex), rl.Rectangle.init(625.0, 378.0, 16.0, 16.0), rl.Color.white);
-    window_ui.drawSmallText(runtime_assets, "UI Info texts", 647.0, 379.0, if (rectContains(optionCheckboxRect(), rl.getMousePosition())) text_color else muted_text);
+    window_ui.drawTextureFit(runtime_assets.texture(checkbox_tex), rl.Rectangle.init(panel_rect.x + 265.0, panel_rect.y + 230.0, 16.0, 16.0), rl.Color.white);
+    window_ui.drawSmallText(runtime_assets, "UI Info texts", panel_rect.x + 287.0, panel_rect.y + 231.0, if (rectContains(optionCheckboxRect(panel_rect), rl.getMousePosition())) text_color else muted_text);
     window_menu.drawPanelBackEntry(runtime_assets, state.panel.timeline_ms, state.back_hover_amount);
 }
 
 fn drawControlsPanels(state: *const ControlsState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
-    const left_rect = controls_left_panel_rect;
-    const right_rect = controls_right_panel_rect;
+    const left_rect = animatedLeftPanelRect(controls_left_panel_rect, state.timeline_ms);
+    const right_rect = animatedRightPanelRect(controls_right_panel_rect, state.timeline_ms);
     window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), left_rect, rl.Color.white, false);
     window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), right_rect, rl.Color.white, true);
 
@@ -378,7 +382,7 @@ fn drawControlsPanels(state: *const ControlsState, runtime_assets: *const window
     var y: f32 = right_rect.y + 82.0;
     for (rows, 0..) |row, idx| {
         const selected = state.focus_right and idx == state.right_selection;
-        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), rebindRect(y));
+        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), rebindRect(right_rect, y));
         const color = if (state.rebinding_row_index != null and state.rebinding_row_index.? == idx) active_color else if (selected or hovered) value_color else value_dim;
         window_ui.drawSmallText(runtime_assets, row.label, right_rect.x + 52.0, y, muted_text);
         window_ui.drawSmallText(runtime_assets, bindingValueText(row, &config, player_idx, state.rebinding_row_index != null and state.rebinding_row_index.? == idx), right_rect.x + 180.0, y, color);
@@ -406,20 +410,20 @@ fn drawMenuPanelShellNoTitle(timeline_ms: i32, runtime_assets: *const window_ass
     window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, rl.Color.white, false);
 }
 
-fn controlsButton() OptionButton {
-    return window_ui.buttonAt("Controls", 572.0, 343.0, true);
+fn controlsButton(panel_rect: rl.Rectangle) OptionButton {
+    return window_ui.buttonAt("Controls", panel_rect.x + 212.0, panel_rect.y + 195.0, true);
 }
 
 fn controlsBackButton() OptionButton {
     return window_ui.buttonAt("Back", 182.0, 448.0, false);
 }
 
-fn optionSliderRect(x: f32, y: f32, count: i32) rl.Rectangle {
-    return rl.Rectangle.init(x - 3.0, y - 1.0, @as(f32, @floatFromInt(count * 16)) + 6.0, 18.0);
+fn optionSliderRect(panel_rect: rl.Rectangle, rel_x: f32, rel_y: f32, count: i32) rl.Rectangle {
+    return rl.Rectangle.init(panel_rect.x + rel_x - 3.0, panel_rect.y + rel_y - 1.0, @as(f32, @floatFromInt(count * 16)) + 6.0, 18.0);
 }
 
-fn optionCheckboxRect() rl.Rectangle {
-    return rl.Rectangle.init(625.0, 378.0, 96.0, 16.0);
+fn optionCheckboxRect(panel_rect: rl.Rectangle) rl.Rectangle {
+    return rl.Rectangle.init(panel_rect.x + 265.0, panel_rect.y + 230.0, 96.0, 16.0);
 }
 
 fn updateOptionSlider(
@@ -529,17 +533,17 @@ fn leftControlButtonCount() usize {
     return 4;
 }
 
-fn rebindRect(y: f32) rl.Rectangle {
-    return rl.Rectangle.init(controls_right_panel_rect.x + 48.0, y - 2.0, 360.0, 18.0);
+fn rebindRect(right_rect: rl.Rectangle, y: f32) rl.Rectangle {
+    return rl.Rectangle.init(right_rect.x + 48.0, y - 2.0, 360.0, 18.0);
 }
 
-fn updateControlsFocusFromPointer(state: *ControlsState, rows: []const RebindRow) void {
+fn updateControlsFocusFromPointer(state: *ControlsState, rows: []const RebindRow, left_rect: rl.Rectangle, right_rect: rl.Rectangle) void {
     const mouse = rl.getMousePosition();
     const left_rects = [_]rl.Rectangle{
-        controlsDropdownRect(controls_left_panel_rect, 340.0, 56.0, dropdownWidth(player_items[0..], null)),
-        controlsDropdownRect(controls_left_panel_rect, 214.0, 102.0, dropdownWidth(aim_items_with_computer[0..], null)),
-        controlsDropdownRect(controls_left_panel_rect, 214.0, 144.0, dropdownWidth(movement_items[0..], null)),
-        rl.Rectangle.init(controls_left_panel_rect.x + 213.0, controls_left_panel_rect.y + 174.0, 220.0, 20.0),
+        controlsDropdownRect(left_rect, 340.0, 56.0, dropdownWidth(player_items[0..], null)),
+        controlsDropdownRect(left_rect, 214.0, 102.0, dropdownWidth(aim_items_with_computer[0..], null)),
+        controlsDropdownRect(left_rect, 214.0, 144.0, dropdownWidth(movement_items[0..], null)),
+        rl.Rectangle.init(left_rect.x + 213.0, left_rect.y + 174.0, 220.0, 20.0),
     };
     for (left_rects, 0..) |rect, idx| {
         if (rl.checkCollisionPointRec(mouse, rect)) {
@@ -550,7 +554,7 @@ fn updateControlsFocusFromPointer(state: *ControlsState, rows: []const RebindRow
     }
     for (rows, 0..) |row, row_idx| {
         _ = row;
-        if (rl.checkCollisionPointRec(mouse, rebindRect(controls_right_panel_rect.y + 82.0 + @as(f32, @floatFromInt(row_idx)) * 24.0))) {
+        if (rl.checkCollisionPointRec(mouse, rebindRect(right_rect, right_rect.y + 82.0 + @as(f32, @floatFromInt(row_idx)) * 24.0))) {
             state.focus_right = true;
             state.right_selection = row_idx;
             return;
@@ -558,7 +562,7 @@ fn updateControlsFocusFromPointer(state: *ControlsState, rows: []const RebindRow
     }
 }
 
-fn updateControlsDropdown(state: *ControlsState, config: *formats.crimson_cfg.CrimsonCfg) ControlsUpdate {
+fn updateControlsDropdown(state: *ControlsState, config: *formats.crimson_cfg.CrimsonCfg, left_rect: rl.Rectangle) ControlsUpdate {
     const items = switch (state.open_dropdown) {
         .player => player_items[0..],
         .movement => movement_items[0..],
@@ -575,9 +579,9 @@ fn updateControlsDropdown(state: *ControlsState, config: *formats.crimson_cfg.Cr
 
     const mouse = rl.getMousePosition();
     const base_rect = switch (state.open_dropdown) {
-        .player => controlsDropdownRect(controls_left_panel_rect, 340.0, 56.0, dropdownWidth(player_items[0..], null)),
-        .movement => controlsDropdownRect(controls_left_panel_rect, 214.0, 144.0, dropdownWidth(movement_items[0..], null)),
-        .aim => controlsDropdownRect(controls_left_panel_rect, 214.0, 102.0, dropdownWidth(items, null)),
+        .player => controlsDropdownRect(left_rect, 340.0, 56.0, dropdownWidth(player_items[0..], null)),
+        .movement => controlsDropdownRect(left_rect, 214.0, 144.0, dropdownWidth(movement_items[0..], null)),
+        .aim => controlsDropdownRect(left_rect, 214.0, 102.0, dropdownWidth(items, null)),
         .none => unreachable,
     };
     for (items, 0..) |item, idx| {
@@ -1018,4 +1022,14 @@ fn openDropdown(state: *ControlsState, config: *const formats.crimson_cfg.Crimso
     if (state.dropdown_selection >= item_count) {
         state.dropdown_selection = item_count - 1;
     }
+}
+
+fn animatedLeftPanelRect(rect: rl.Rectangle, timeline_ms: i32) rl.Rectangle {
+    const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
+    return rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
+}
+
+fn animatedRightPanelRect(rect: rl.Rectangle, timeline_ms: i32) rl.Rectangle {
+    const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
+    return rl.Rectangle.init(rect.x - anim.offset_x, rect.y, rect.width, rect.height);
 }

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -410,7 +410,7 @@ fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.Run
     const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
     const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
     window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, rl.Color.white, false);
-    window_menu.drawAtlasLabelCentered(runtime_assets, title_row, rect.y + 38.0, rl.Color.white);
+    window_menu.drawAtlasLabelCentered(runtime_assets, title_row, panel_rect.y + 38.0, rl.Color.white);
 }
 
 fn drawMenuPanelShellNoTitle(timeline_ms: i32, runtime_assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle) void {

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -47,6 +47,14 @@ const DropdownItem = struct {
     value: i32,
 };
 
+const OptionSlider = enum {
+    none,
+    sfx,
+    music,
+    detail,
+    mouse,
+};
+
 pub const OptionsAction = enum {
     none,
     open_controls,
@@ -89,6 +97,8 @@ const PanelState = struct {
 
 pub const OptionsState = struct {
     panel: PanelState = .{},
+    active_slider: OptionSlider = .none,
+    back_hover_amount: i32 = 0,
 
     pub fn reset(self: *OptionsState) void {
         self.* = .{};
@@ -106,6 +116,7 @@ pub const ControlsState = struct {
     dropdown_selection: usize = 0,
     rebinding_row_index: ?usize = null,
     rebinding_player_index: usize = 0,
+    back_hover_amount: i32 = 0,
 
     pub fn reset(self: *ControlsState) void {
         self.* = .{};
@@ -114,76 +125,65 @@ pub const ControlsState = struct {
 
 const OptionButton = window_ui.UiButton;
 
-pub fn updateOptions(state: *OptionsState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg) OptionsUpdate {
+pub fn updateOptions(state: *OptionsState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, runtime_assets: ?*const window_assets.RuntimeAssets) OptionsUpdate {
     const dt_ms = state.panel.advance(frame_dt);
-    const buttons = optionsButtons();
-    window_ui.updateSelectionFromPointer(&state.panel.selection, buttons[0..]);
+    const mouse = rl.getMousePosition();
+    const click = rl.isMouseButtonPressed(.left);
+    const mouse_down = rl.isMouseButtonDown(.left);
+    const back_hovered = if (runtime_assets) |assets|
+        state.panel.timeline_ms >= panel_timeline_max_ms and rl.checkCollisionPointRec(mouse, window_menu.panelBackHitRect(assets, state.panel.timeline_ms))
+    else
+        false;
 
-    if (rl.isKeyPressed(.escape)) {
+    if (back_hovered) {
+        state.back_hover_amount = std.math.clamp(state.back_hover_amount + dt_ms * 6, 0, 1000);
+    } else {
+        state.back_hover_amount = std.math.clamp(state.back_hover_amount - dt_ms * 2, 0, 1000);
+    }
+
+    if (rl.isKeyPressed(.escape) or rl.isKeyPressed(.enter) or rl.isKeyPressed(.space) or (back_hovered and click)) {
+        state.active_slider = .none;
         return .{ .action = .back_to_menu, .play_button_click = true };
     }
-    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
-        state.panel.selection = if (state.panel.selection == 0) buttons.len - 1 else state.panel.selection - 1;
+
+    var result: OptionsUpdate = .{
+        .play_panel_click = dt_ms > 0 and state.panel.timeline_ms >= panel_timeline_max_ms and !state.panel.panel_open_sfx_played,
+    };
+
+    if (updateOptionSlider(state, .sfx, optionSliderRect(625.0, 234.0, 10), 10, mouse, click, mouse_down)) |value| {
+        config.sfx_volume = @as(f32, @floatFromInt(value)) * 0.1;
+        config.sound_disable = @intFromBool(value == 0);
+        result.config_dirty = true;
+        result.reload_audio = true;
+        result.play_button_click = true;
     }
-    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
-        state.panel.selection = (state.panel.selection + 1) % buttons.len;
+    if (updateOptionSlider(state, .music, optionSliderRect(625.0, 270.0, 10), 10, mouse, click, mouse_down)) |value| {
+        config.music_volume = @as(f32, @floatFromInt(value)) * 0.1;
+        config.music_disable = @intFromBool(value == 0);
+        result.config_dirty = true;
+        result.reload_audio = true;
+        result.play_button_click = true;
+    }
+    if (updateOptionSlider(state, .detail, optionSliderRect(625.0, 306.0, 5), 5, mouse, click, mouse_down)) |value| {
+        config.detail_preset = @intCast(std.math.clamp(value, @as(i32, 1), @as(i32, 5)));
+        result.config_dirty = true;
+        result.play_button_click = true;
+    }
+    if (updateOptionSlider(state, .mouse, optionSliderRect(625.0, 342.0, 10), 10, mouse, click, mouse_down)) |value| {
+        config.mouse_sensitivity = std.math.clamp(@as(f32, @floatFromInt(value)) * 0.1, @as(f32, 0.1), @as(f32, 1.0));
+        result.config_dirty = true;
+        result.play_button_click = true;
+    }
+    if (click and rectContains(optionCheckboxRect(), mouse)) {
+        config.ui_info_texts = if (config.ui_info_texts == 0) 1 else 0;
+        result.config_dirty = true;
+        result.play_button_click = true;
     }
 
-    const adjust_left = rl.isKeyPressed(.left) or rl.isKeyPressed(.a);
-    const adjust_right = rl.isKeyPressed(.right) or rl.isKeyPressed(.d);
-    const activated = window_ui.buttonActivated(buttons[0..], state.panel.selection);
-    if (!(adjust_left or adjust_right or activated)) {
-        return .{
-            .play_panel_click = dt_ms > 0 and state.panel.timeline_ms >= panel_timeline_max_ms and !state.panel.panel_open_sfx_played,
-        };
-    }
-
-    var result: OptionsUpdate = .{ .play_button_click = true };
-    switch (state.panel.selection) {
-        0 => {
-            var value = if (config.sound_disable != 0) @as(i32, 0) else @as(i32, @intFromFloat(std.math.clamp(config.sfx_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5));
-            if (adjust_left or adjust_right) {
-                value = std.math.clamp(value + (if (adjust_left and !adjust_right) @as(i32, -1) else @as(i32, 1)), @as(i32, 0), @as(i32, 10));
-            } else {
-                value = if (value == 0) 10 else 0;
-            }
-            config.sfx_volume = @as(f32, @floatFromInt(value)) * 0.1;
-            config.sound_disable = @intFromBool(value == 0);
-            result.config_dirty = true;
-            result.reload_audio = true;
-        },
-        1 => {
-            var value = if (config.music_disable != 0) @as(i32, 0) else @as(i32, @intFromFloat(std.math.clamp(config.music_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5));
-            if (adjust_left or adjust_right) {
-                value = std.math.clamp(value + (if (adjust_left and !adjust_right) @as(i32, -1) else @as(i32, 1)), @as(i32, 0), @as(i32, 10));
-            } else {
-                value = if (value == 0) 10 else 0;
-            }
-            config.music_volume = @as(f32, @floatFromInt(value)) * 0.1;
-            config.music_disable = @intFromBool(value == 0);
-            result.config_dirty = true;
-            result.reload_audio = true;
-        },
-        2 => {
-            var value: i32 = @intCast(std.math.clamp(config.detail_preset, @as(u32, 1), @as(u32, 5)));
-            if (adjust_left and !adjust_right) value -= 1 else value += 1;
-            config.detail_preset = @intCast(std.math.clamp(value, @as(i32, 1), @as(i32, 5)));
-            result.config_dirty = true;
-        },
-        3 => {
-            var value = std.math.clamp(@as(i32, @intFromFloat(std.math.clamp(config.mouse_sensitivity, @as(f32, 0.1), @as(f32, 1.0)) * 10.0 + 0.5)), @as(i32, 1), @as(i32, 10));
-            if (adjust_left and !adjust_right) value -= 1 else value += 1;
-            value = std.math.clamp(value, @as(i32, 1), @as(i32, 10));
-            config.mouse_sensitivity = @as(f32, @floatFromInt(value)) * 0.1;
-            result.config_dirty = true;
-        },
-        4 => {
-            config.ui_info_texts = if (config.ui_info_texts == 0) 1 else 0;
-            result.config_dirty = true;
-        },
-        5 => result.action = .open_controls,
-        6 => result.action = .back_to_menu,
-        else => {},
+    const controls = controlsButton();
+    if (click and rl.checkCollisionPointRec(mouse, controls.rect)) {
+        result.action = .open_controls;
+        result.play_button_click = true;
     }
 
     return result;
@@ -198,17 +198,27 @@ pub fn drawOptions(state: *const OptionsState, runtime_assets: ?*const window_as
     rl.clearBackground(rl.Color.init(37, 24, 20, 255));
 }
 
-pub fn updateControls(state: *ControlsState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg) ControlsUpdate {
+pub fn updateControls(state: *ControlsState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, runtime_assets: ?*const window_assets.RuntimeAssets) ControlsUpdate {
     const dt_ms = @as(i32, @intFromFloat(@min(frame_dt, 0.1) * 1000.0));
     if (dt_ms > 0) {
         state.timeline_ms = @min(panel_timeline_max_ms, state.timeline_ms + dt_ms);
+    }
+    const mouse = rl.getMousePosition();
+    const back_hovered = if (runtime_assets) |assets|
+        state.timeline_ms >= panel_timeline_max_ms and rl.checkCollisionPointRec(mouse, window_menu.panelBackHitRect(assets, state.timeline_ms))
+    else
+        false;
+    if (back_hovered) {
+        state.back_hover_amount = std.math.clamp(state.back_hover_amount + dt_ms * 6, 0, 1000);
+    } else {
+        state.back_hover_amount = std.math.clamp(state.back_hover_amount - dt_ms * 2, 0, 1000);
     }
 
     if (state.rebinding_row_index != null) {
         return updateControlsRebinding(state, config);
     }
 
-    if (rl.isKeyPressed(.escape)) {
+    if (rl.isKeyPressed(.escape) or rl.isKeyPressed(.enter) or rl.isKeyPressed(.space) or (back_hovered and rl.isMouseButtonPressed(.left))) {
         if (state.open_dropdown != .none) {
             state.open_dropdown = .none;
             return .{};
@@ -277,7 +287,6 @@ pub fn updateControls(state: *ControlsState, frame_dt: f32, config: *formats.cri
             formats.crimson_cfg.setPlayerShowDirectionArrow(config, currentPlayerIndex(state), !formats.crimson_cfg.playerShowDirectionArrow(config, currentPlayerIndex(state)));
             result.config_dirty = true;
         },
-        4 => result.action = .back_to_options,
         else => {},
     }
     return result;
@@ -293,11 +302,9 @@ pub fn drawControls(state: *const ControlsState, runtime_assets: ?*const window_
 }
 
 fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
-    const buttons = optionsButtons();
-    for (buttons[5..], 5..) |button, idx| {
-        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
-        window_ui.drawButton(button, idx == state.panel.selection, hovered, runtime_assets);
-    }
+    const controls = controlsButton();
+    const controls_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), controls.rect);
+    window_ui.drawButton(controls, false, controls_hovered, runtime_assets);
 
     const labels = [_][]const u8{
         "Sound volume:",
@@ -308,9 +315,15 @@ fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window
     };
     for (labels, 0..) |label, idx| {
         const y = 236.0 + @as(f32, @floatFromInt(idx)) * 36.0;
-        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), buttons[idx].rect);
-        const selected = idx == state.panel.selection;
-        window_ui.drawSmallText(runtime_assets, label, 420.0, y, if (selected or hovered) text_color else muted_text);
+        const hovered = switch (idx) {
+            0 => rectContains(optionSliderRect(625.0, 234.0, 10), rl.getMousePosition()),
+            1 => rectContains(optionSliderRect(625.0, 270.0, 10), rl.getMousePosition()),
+            2 => rectContains(optionSliderRect(625.0, 306.0, 5), rl.getMousePosition()),
+            3 => rectContains(optionSliderRect(625.0, 342.0, 10), rl.getMousePosition()),
+            4 => rectContains(optionCheckboxRect(), rl.getMousePosition()),
+            else => false,
+        };
+        window_ui.drawSmallText(runtime_assets, label, 420.0, y, if (hovered) text_color else muted_text);
     }
 
     drawSlider(runtime_assets, rl.Vector2.init(625.0, 234.0), 10, if (config.sound_disable != 0) 0 else @intFromFloat(std.math.clamp(config.sfx_volume, @as(f32, 0.0), @as(f32, 1.0)) * 10.0 + 0.5));
@@ -320,7 +333,8 @@ fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window
 
     const checkbox_tex: window_assets.TextureId = if (config.ui_info_texts != 0) .ui_check_on else .ui_check_off;
     window_ui.drawTextureFit(runtime_assets.texture(checkbox_tex), rl.Rectangle.init(625.0, 378.0, 16.0, 16.0), rl.Color.white);
-    window_ui.drawSmallText(runtime_assets, "UI Info texts", 647.0, 379.0, if (state.panel.selection == 4 or rl.checkCollisionPointRec(rl.getMousePosition(), buttons[4].rect)) text_color else muted_text);
+    window_ui.drawSmallText(runtime_assets, "UI Info texts", 647.0, 379.0, if (rectContains(optionCheckboxRect(), rl.getMousePosition())) text_color else muted_text);
+    window_menu.drawPanelBackEntry(runtime_assets, state.panel.timeline_ms, state.back_hover_amount);
 }
 
 fn drawControlsPanels(state: *const ControlsState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
@@ -347,10 +361,7 @@ fn drawControlsPanels(state: *const ControlsState, runtime_assets: *const window
     const direction_checked: window_assets.TextureId = if (formats.crimson_cfg.playerShowDirectionArrow(&config, player_idx)) .ui_check_on else .ui_check_off;
     window_ui.drawTextureFit(runtime_assets.texture(direction_checked), rl.Rectangle.init(182.0, 418.0, 16.0, 16.0), rl.Color.white);
     window_ui.drawSmallText(runtime_assets, "Show direction arrow", 204.0, 418.0, if (state.left_selection == 3 and !state.focus_right) text_color else muted_text);
-
-    const back = controlsBackButton();
-    const back_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
-    window_ui.drawButton(back, state.left_selection == 4 and !state.focus_right, back_hovered, runtime_assets);
+    window_menu.drawPanelBackEntry(runtime_assets, state.timeline_ms, state.back_hover_amount);
 
     const rows = controlsRebindRows(&config, player_idx);
     var y: f32 = 198.0;
@@ -384,20 +395,45 @@ fn drawMenuPanelShellNoTitle(timeline_ms: i32, runtime_assets: *const window_ass
     window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
 }
 
-fn optionsButtons() [7]OptionButton {
-    return .{
-        .{ .label = "Sfx", .rect = rl.Rectangle.init(404.0, 226.0, 320.0, 28.0) },
-        .{ .label = "Music", .rect = rl.Rectangle.init(404.0, 262.0, 320.0, 28.0) },
-        .{ .label = "Detail", .rect = rl.Rectangle.init(404.0, 298.0, 320.0, 28.0) },
-        .{ .label = "Mouse", .rect = rl.Rectangle.init(404.0, 334.0, 320.0, 28.0) },
-        .{ .label = "UiInfo", .rect = rl.Rectangle.init(404.0, 370.0, 320.0, 28.0) },
-        window_ui.buttonAt("Controls", 572.0, 343.0, true),
-        window_ui.buttonAt("Back", 404.0, 470.0, false),
-    };
+fn controlsButton() OptionButton {
+    return window_ui.buttonAt("Controls", 572.0, 343.0, true);
 }
 
 fn controlsBackButton() OptionButton {
     return window_ui.buttonAt("Back", 182.0, 448.0, false);
+}
+
+fn optionSliderRect(x: f32, y: f32, count: i32) rl.Rectangle {
+    return rl.Rectangle.init(x - 3.0, y - 1.0, @as(f32, @floatFromInt(count * 16)) + 6.0, 18.0);
+}
+
+fn optionCheckboxRect() rl.Rectangle {
+    return rl.Rectangle.init(625.0, 378.0, 96.0, 16.0);
+}
+
+fn updateOptionSlider(
+    state: *OptionsState,
+    slider: OptionSlider,
+    rect: rl.Rectangle,
+    count: i32,
+    mouse: rl.Vector2,
+    click: bool,
+    mouse_down: bool,
+) ?i32 {
+    const hovered = rectContains(rect, mouse);
+    if (hovered and click) state.active_slider = slider;
+    if (state.active_slider == slider and mouse_down) {
+        const relative = mouse.x - (rect.x + 3.0);
+        var idx = @as(i32, @intFromFloat(@floor(relative / 16.0))) + 1;
+        idx = std.math.clamp(idx, @as(i32, 1), count);
+        return idx;
+    }
+    if (state.active_slider == slider and !mouse_down) state.active_slider = .none;
+    return null;
+}
+
+fn rectContains(rect: rl.Rectangle, point: rl.Vector2) bool {
+    return point.x >= rect.x and point.x <= rect.x + rect.width and point.y >= rect.y and point.y <= rect.y + rect.height;
 }
 
 fn drawSlider(runtime_assets: *const window_assets.RuntimeAssets, pos: rl.Vector2, count: i32, value: i32) void {
@@ -446,7 +482,7 @@ fn drawDropdown(
 }
 
 fn leftControlButtonCount() usize {
-    return 5;
+    return 4;
 }
 
 fn rebindRect(y: f32) rl.Rectangle {
@@ -467,11 +503,6 @@ fn updateControlsFocusFromPointer(state: *ControlsState, rows: []const RebindRow
             state.left_selection = idx;
             return;
         }
-    }
-    if (rl.checkCollisionPointRec(mouse, controlsBackButton().rect)) {
-        state.focus_right = false;
-        state.left_selection = 4;
-        return;
     }
     for (rows, 0..) |row, row_idx| {
         _ = row;

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -340,8 +340,8 @@ fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window
 fn drawControlsPanels(state: *const ControlsState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
     const left_rect = rl.Rectangle.init(132.0, 174.0, 510.0, 292.0);
     const right_rect = rl.Rectangle.init(598.0, 118.0, 510.0, 392.0);
-    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), left_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
-    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), right_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), true);
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), left_rect, rl.Color.white, false);
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), right_rect, rl.Color.white, true);
 
     window_ui.drawTextureFit(runtime_assets.texture(.ui_text_controls), rl.Rectangle.init(322.0, 202.0, 128.0, 32.0), rl.Color.white);
     window_ui.drawSmallText(runtime_assets, "Configured controls", 746.0, 156.0, text_color);
@@ -384,7 +384,7 @@ fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.Run
     drawMenuBackdropAndSign(timeline_ms, runtime_assets);
     const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
     const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
-    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, rl.Color.white, false);
     window_menu.drawAtlasLabelCentered(runtime_assets, title_row, rect.y + 38.0, rl.Color.white);
 }
 
@@ -392,7 +392,7 @@ fn drawMenuPanelShellNoTitle(timeline_ms: i32, runtime_assets: *const window_ass
     drawMenuBackdropAndSign(timeline_ms, runtime_assets);
     const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
     const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
-    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, rl.Color.white, false);
 }
 
 fn controlsButton() OptionButton {

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -191,7 +191,7 @@ pub fn updateOptions(state: *OptionsState, frame_dt: f32, config: *formats.crims
 
 pub fn drawOptions(state: *const OptionsState, runtime_assets: ?*const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
     if (runtime_assets) |assets| {
-        drawMenuPanelShell(state.panel.timeline_ms, assets, .{ .x = 360.0, .y = 148.0, .width = 510.0, .height = 364.0 }, window_menu.label_row_options);
+        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, .{ .x = 360.0, .y = 148.0, .width = 510.0, .height = 364.0 });
         drawOptionsContents(state, assets, config);
         return;
     }
@@ -377,6 +377,13 @@ fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.Run
     window_menu.drawAtlasLabelCentered(runtime_assets, title_row, rect.y + 38.0, rl.Color.white);
 }
 
+fn drawMenuPanelShellNoTitle(timeline_ms: i32, runtime_assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle) void {
+    drawMenuBackdropAndSign(timeline_ms, runtime_assets);
+    const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
+    const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
+}
+
 fn optionsButtons() [7]OptionButton {
     return .{
         .{ .label = "Sfx", .rect = rl.Rectangle.init(404.0, 226.0, 320.0, 28.0) },
@@ -384,13 +391,13 @@ fn optionsButtons() [7]OptionButton {
         .{ .label = "Detail", .rect = rl.Rectangle.init(404.0, 298.0, 320.0, 28.0) },
         .{ .label = "Mouse", .rect = rl.Rectangle.init(404.0, 334.0, 320.0, 28.0) },
         .{ .label = "UiInfo", .rect = rl.Rectangle.init(404.0, 370.0, 320.0, 28.0) },
-        .{ .label = "Controls", .rect = rl.Rectangle.init(404.0, 414.0, 240.0, 44.0) },
-        .{ .label = "Back", .rect = rl.Rectangle.init(404.0, 470.0, 180.0, 44.0) },
+        window_ui.buttonAt("Controls", 572.0, 343.0, true),
+        window_ui.buttonAt("Back", 404.0, 470.0, false),
     };
 }
 
 fn controlsBackButton() OptionButton {
-    return .{ .label = "Back", .rect = rl.Rectangle.init(182.0, 448.0, 180.0, 44.0) };
+    return window_ui.buttonAt("Back", 182.0, 448.0, false);
 }
 
 fn drawSlider(runtime_assets: *const window_assets.RuntimeAssets, pos: rl.Vector2, count: i32, value: i32) void {

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -326,8 +326,8 @@ fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window
 fn drawControlsPanels(state: *const ControlsState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
     const left_rect = rl.Rectangle.init(132.0, 174.0, 510.0, 292.0);
     const right_rect = rl.Rectangle.init(598.0, 118.0, 510.0, 392.0);
-    window_ui.drawTextureFit(runtime_assets.texture(.ui_menu_panel), left_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
-    window_ui.drawTextureFit(runtime_assets.texture(.ui_menu_panel), right_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), left_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), right_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), true);
 
     window_ui.drawTextureFit(runtime_assets.texture(.ui_text_controls), rl.Rectangle.init(322.0, 202.0, 128.0, 32.0), rl.Color.white);
     window_ui.drawSmallText(runtime_assets, "Configured controls", 746.0, 156.0, text_color);
@@ -373,7 +373,7 @@ fn drawMenuPanelShell(timeline_ms: i32, runtime_assets: *const window_assets.Run
     drawMenuBackdropAndSign(timeline_ms, runtime_assets);
     const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
     const panel_rect = rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
-    window_ui.drawTextureFit(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
     window_menu.drawAtlasLabelCentered(runtime_assets, title_row, rect.y + 38.0, rl.Color.white);
 }
 

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -17,6 +17,8 @@ const value_dim = rl.Color.init(70, 180, 240, 153);
 const active_color = rl.Color.init(255, 228, 170, 255);
 
 const panel_timeline_max_ms: i32 = 300;
+const controls_left_panel_rect = rl.Rectangle.init(132.0, 174.0, 510.0, 254.0);
+const controls_right_panel_rect = rl.Rectangle.init(598.0, 118.0, 510.0, 378.0);
 
 const DropdownKind = enum {
     none,
@@ -338,39 +340,48 @@ fn drawOptionsContents(state: *const OptionsState, runtime_assets: *const window
 }
 
 fn drawControlsPanels(state: *const ControlsState, runtime_assets: *const window_assets.RuntimeAssets, config: formats.crimson_cfg.CrimsonCfg) void {
-    const left_rect = rl.Rectangle.init(132.0, 174.0, 510.0, 292.0);
-    const right_rect = rl.Rectangle.init(598.0, 118.0, 510.0, 392.0);
+    const left_rect = controls_left_panel_rect;
+    const right_rect = controls_right_panel_rect;
     window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), left_rect, rl.Color.white, false);
     window_ui.drawClassicMenuPanel(runtime_assets.texture(.ui_menu_panel), right_rect, rl.Color.white, true);
 
-    window_ui.drawTextureFit(runtime_assets.texture(.ui_text_controls), rl.Rectangle.init(322.0, 202.0, 128.0, 32.0), rl.Color.white);
-    window_ui.drawSmallText(runtime_assets, "Configured controls", 746.0, 156.0, text_color);
-    rl.drawRectangle(746, 169, @intFromFloat(window_ui.measureSmallText(runtime_assets, "Configured controls")), 1, rl.Color.init(255, 255, 255, 204));
+    window_ui.drawTextureFit(runtime_assets.texture(.ui_text_controls), rl.Rectangle.init(left_rect.x + 206.0, left_rect.y + 44.0, 128.0, 32.0), rl.Color.white);
+    window_ui.drawSmallText(runtime_assets, "Configured controls", right_rect.x + 120.0, right_rect.y + 38.0, text_color);
+    rl.drawRectangle(
+        @intFromFloat(right_rect.x + 120.0),
+        @intFromFloat(right_rect.y + 51.0),
+        @intFromFloat(window_ui.measureSmallText(runtime_assets, "Configured controls")),
+        1,
+        rl.Color.init(255, 255, 255, 204),
+    );
 
     const player_idx = currentPlayerIndex(state);
-    drawDropdownLabel(runtime_assets, "Configure for:", 182.0, 244.0);
-    drawDropdown(runtime_assets, dropdownRect(182.0, 262.0), player_items[0..], player_idx, state.open_dropdown == .player, state.dropdown_selection);
+    const player_rect = controlsDropdownRect(left_rect, 340.0, 56.0, dropdownWidth(player_items[0..], runtime_assets));
+    drawDropdownLabel(runtime_assets, "Configure for:", left_rect.x + 339.0, left_rect.y + 41.0);
+    drawDropdown(runtime_assets, player_rect, player_items[0..], player_idx, state.open_dropdown == .player, state.dropdown_selection);
 
-    drawDropdownLabel(runtime_assets, "Aiming method:", 182.0, 300.0);
+    drawDropdownLabel(runtime_assets, "Aiming method:", left_rect.x + 213.0, left_rect.y + 86.0);
     const current_aim_items = aimItems(&config, player_idx);
-    drawDropdown(runtime_assets, dropdownRect(182.0, 318.0), current_aim_items, aimItemIndex(&config, player_idx), state.open_dropdown == .aim, state.dropdown_selection);
+    const aim_rect = controlsDropdownRect(left_rect, 214.0, 102.0, dropdownWidth(current_aim_items, runtime_assets));
+    drawDropdown(runtime_assets, aim_rect, current_aim_items, aimItemIndex(&config, player_idx), state.open_dropdown == .aim, state.dropdown_selection);
 
-    drawDropdownLabel(runtime_assets, "Moving method:", 182.0, 356.0);
-    drawDropdown(runtime_assets, dropdownRect(182.0, 374.0), movement_items[0..], movementItemIndex(&config, player_idx), state.open_dropdown == .movement, state.dropdown_selection);
+    drawDropdownLabel(runtime_assets, "Moving method:", left_rect.x + 213.0, left_rect.y + 128.0);
+    const move_rect = controlsDropdownRect(left_rect, 214.0, 144.0, dropdownWidth(movement_items[0..], runtime_assets));
+    drawDropdown(runtime_assets, move_rect, movement_items[0..], movementItemIndex(&config, player_idx), state.open_dropdown == .movement, state.dropdown_selection);
 
     const direction_checked: window_assets.TextureId = if (formats.crimson_cfg.playerShowDirectionArrow(&config, player_idx)) .ui_check_on else .ui_check_off;
-    window_ui.drawTextureFit(runtime_assets.texture(direction_checked), rl.Rectangle.init(182.0, 418.0, 16.0, 16.0), rl.Color.white);
-    window_ui.drawSmallText(runtime_assets, "Show direction arrow", 204.0, 418.0, if (state.left_selection == 3 and !state.focus_right) text_color else muted_text);
+    window_ui.drawTextureFit(runtime_assets.texture(direction_checked), rl.Rectangle.init(left_rect.x + 213.0, left_rect.y + 174.0, 16.0, 16.0), rl.Color.white);
+    window_ui.drawSmallText(runtime_assets, "Show direction arrow", left_rect.x + 235.0, left_rect.y + 175.0, if (state.left_selection == 3 and !state.focus_right) text_color else muted_text);
     window_menu.drawPanelBackEntry(runtime_assets, state.timeline_ms, state.back_hover_amount);
 
     const rows = controlsRebindRows(&config, player_idx);
-    var y: f32 = 198.0;
+    var y: f32 = right_rect.y + 82.0;
     for (rows, 0..) |row, idx| {
         const selected = state.focus_right and idx == state.right_selection;
         const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), rebindRect(y));
         const color = if (state.rebinding_row_index != null and state.rebinding_row_index.? == idx) active_color else if (selected or hovered) value_color else value_dim;
-        window_ui.drawSmallText(runtime_assets, row.label, 650.0, y, muted_text);
-        window_ui.drawSmallText(runtime_assets, bindingValueText(row, &config, player_idx, state.rebinding_row_index != null and state.rebinding_row_index.? == idx), 868.0, y, color);
+        window_ui.drawSmallText(runtime_assets, row.label, right_rect.x + 52.0, y, muted_text);
+        window_ui.drawSmallText(runtime_assets, bindingValueText(row, &config, player_idx, state.rebinding_row_index != null and state.rebinding_row_index.? == idx), right_rect.x + 180.0, y, color);
         y += 24.0;
     }
 }
@@ -453,6 +464,34 @@ fn dropdownRect(x: f32, y: f32) rl.Rectangle {
     return rl.Rectangle.init(x, y, 148.0, 16.0);
 }
 
+fn controlsDropdownRect(panel_rect: rl.Rectangle, rel_x: f32, rel_y: f32, width: f32) rl.Rectangle {
+    return rl.Rectangle.init(panel_rect.x + rel_x, panel_rect.y + rel_y, width, 16.0);
+}
+
+fn dropdownWidth(items: []const DropdownItem, runtime_assets: ?*const window_assets.RuntimeAssets) f32 {
+    var max_label_w: f32 = 0.0;
+    for (items) |item| {
+        const width = if (runtime_assets) |assets|
+            window_ui.measureSmallText(assets, item.label)
+        else
+            approxTextWidth(item.label);
+        max_label_w = @max(max_label_w, width);
+    }
+    return max_label_w + 48.0;
+}
+
+fn approxTextWidth(text: []const u8) f32 {
+    var width: f32 = 0.0;
+    for (text) |ch| {
+        width += switch (ch) {
+            'i', 'l', '!', '.', ',', '\'', ':' => 4.0,
+            ' ' => 5.0,
+            else => 8.0,
+        };
+    }
+    return width;
+}
+
 fn drawDropdown(
     runtime_assets: *const window_assets.RuntimeAssets,
     rect: rl.Rectangle,
@@ -486,16 +525,16 @@ fn leftControlButtonCount() usize {
 }
 
 fn rebindRect(y: f32) rl.Rectangle {
-    return rl.Rectangle.init(640.0, y - 2.0, 360.0, 18.0);
+    return rl.Rectangle.init(controls_right_panel_rect.x + 48.0, y - 2.0, 360.0, 18.0);
 }
 
 fn updateControlsFocusFromPointer(state: *ControlsState, rows: []const RebindRow) void {
     const mouse = rl.getMousePosition();
     const left_rects = [_]rl.Rectangle{
-        dropdownRect(182.0, 262.0),
-        dropdownRect(182.0, 374.0),
-        dropdownRect(182.0, 318.0),
-        rl.Rectangle.init(182.0, 416.0, 220.0, 20.0),
+        controlsDropdownRect(controls_left_panel_rect, 340.0, 56.0, dropdownWidth(player_items[0..], null)),
+        controlsDropdownRect(controls_left_panel_rect, 214.0, 102.0, dropdownWidth(aim_items_with_computer[0..], null)),
+        controlsDropdownRect(controls_left_panel_rect, 214.0, 144.0, dropdownWidth(movement_items[0..], null)),
+        rl.Rectangle.init(controls_left_panel_rect.x + 213.0, controls_left_panel_rect.y + 174.0, 220.0, 20.0),
     };
     for (left_rects, 0..) |rect, idx| {
         if (rl.checkCollisionPointRec(mouse, rect)) {
@@ -506,7 +545,7 @@ fn updateControlsFocusFromPointer(state: *ControlsState, rows: []const RebindRow
     }
     for (rows, 0..) |row, row_idx| {
         _ = row;
-        if (rl.checkCollisionPointRec(mouse, rebindRect(198.0 + @as(f32, @floatFromInt(row_idx)) * 24.0))) {
+        if (rl.checkCollisionPointRec(mouse, rebindRect(controls_right_panel_rect.y + 82.0 + @as(f32, @floatFromInt(row_idx)) * 24.0))) {
             state.focus_right = true;
             state.right_selection = row_idx;
             return;
@@ -531,9 +570,9 @@ fn updateControlsDropdown(state: *ControlsState, config: *formats.crimson_cfg.Cr
 
     const mouse = rl.getMousePosition();
     const base_rect = switch (state.open_dropdown) {
-        .player => dropdownRect(182.0, 262.0),
-        .movement => dropdownRect(182.0, 374.0),
-        .aim => dropdownRect(182.0, 318.0),
+        .player => controlsDropdownRect(controls_left_panel_rect, 340.0, 56.0, dropdownWidth(player_items[0..], null)),
+        .movement => controlsDropdownRect(controls_left_panel_rect, 214.0, 144.0, dropdownWidth(movement_items[0..], null)),
+        .aim => controlsDropdownRect(controls_left_panel_rect, 214.0, 102.0, dropdownWidth(items, null)),
         .none => unreachable,
     };
     for (items, 0..) |item, idx| {

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -501,11 +501,15 @@ fn drawDropdown(
     dropdown_selection: usize,
 ) void {
     const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), rect);
-    const texture = if (open or hovered) runtime_assets.texture(.ui_drop_on) else runtime_assets.texture(.ui_drop_off);
+    const active = open or hovered;
+    const texture = if (active) runtime_assets.texture(.ui_drop_on) else runtime_assets.texture(.ui_drop_off);
     rl.drawRectangleRec(rect, rl.Color.white);
     rl.drawRectangle(@intFromFloat(rect.x + 1.0), @intFromFloat(rect.y + 1.0), @intFromFloat(rect.width - 2.0), @intFromFloat(rect.height - 2.0), rl.Color.black);
+    if (active) {
+        rl.drawRectangle(@intFromFloat(rect.x), @intFromFloat(rect.y + 15.0), @intFromFloat(rect.width), 1, rl.Color.init(255, 255, 255, 128));
+    }
     const safe_index = @min(current_index, items.len - 1);
-    window_ui.drawSmallText(runtime_assets, items[safe_index].label, rect.x + 4.0, rect.y + 1.0, if (hovered or open) text_color else muted_text);
+    window_ui.drawSmallText(runtime_assets, items[safe_index].label, rect.x + 4.0, rect.y + 1.0, rl.Color.init(255, 255, 255, if (active) 242 else 191));
     rl.drawTexturePro(texture, rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height)), rl.Rectangle.init(rect.x + rect.width - 17.0, rect.y, 16.0, 16.0), rl.Vector2.zero(), 0.0, rl.Color.white);
 
     if (!open) return;
@@ -516,7 +520,8 @@ fn drawDropdown(
         const row_y = rect.y + 17.0 + @as(f32, @floatFromInt(idx)) * 16.0;
         const row_rect = rl.Rectangle.init(rect.x, row_y, rect.width, 16.0);
         const row_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), row_rect);
-        window_ui.drawSmallText(runtime_assets, item.label, rect.x + 4.0, row_y + 1.0, if (row_hovered or idx == dropdown_selection) text_color else muted_text);
+        const alpha: u8 = if (row_hovered) 242 else if (idx == dropdown_selection) 245 else 153;
+        window_ui.drawSmallText(runtime_assets, item.label, rect.x + 4.0, row_y + 1.0, rl.Color.init(255, 255, 255, alpha));
     }
 }
 

--- a/crimson-zig/src/window_statistics.zig
+++ b/crimson-zig/src/window_statistics.zig
@@ -121,7 +121,9 @@ const PerksScreen = struct {
 };
 
 const CreditsScreen = struct {
-    scroll: usize = 0,
+    scroll_time_s: f32 = 0.0,
+    line_start_index: i32 = 0,
+    line_end_index: i32 = 0,
 
     fn reset(self: *CreditsScreen) void {
         self.* = .{};
@@ -414,20 +416,14 @@ fn updatePerks(state: *State, frame_dt: f32, status: formats.game_cfg.Status) Up
 
 fn updateCredits(state: *State, frame_dt: f32) UpdateResult {
     _ = state.hub.panel.advance(frame_dt);
-    const max_scroll = if (window_statistics_data.credits_lines.len > 20) window_statistics_data.credits_lines.len - 20 else 0;
     if (rl.isKeyPressed(.escape) or backButtonActivated(backOnlyButton()[0])) {
         state.view = .hub;
         state.hub.reset();
         return .{ .play_button_click = true };
     }
-    if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
-        if (state.credits.scroll > 0) state.credits.scroll -= 1;
-    }
-    if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
-        state.credits.scroll = @min(state.credits.scroll + 1, max_scroll);
-    }
-    if (rl.getMouseWheelMove() > 0 and state.credits.scroll > 0) state.credits.scroll -= 1;
-    if (rl.getMouseWheelMove() < 0 and state.credits.scroll < max_scroll) state.credits.scroll += 1;
+    const dt_clamped = @min(frame_dt, 0.1);
+    state.credits.scroll_time_s += dt_clamped;
+    updateCreditsWindow(&state.credits);
     return .{};
 }
 
@@ -494,15 +490,24 @@ fn drawCredits(state: *const CreditsScreen, runtime_assets: ?*const window_asset
     if (runtime_assets) |assets| {
         drawPanelShellNoTitle(300, assets, credits_panel_rect);
         window_ui.drawSmallText(assets, "credits", credits_panel_rect.x + 202.0, credits_panel_rect.y + 46.0, text_color);
-        var y: f32 = credits_panel_rect.y + 60.0;
-        const start = state.scroll;
-        const end = @min(start + 16, window_statistics_data.credits_lines.len);
-        for (window_statistics_data.credits_lines[start..end]) |line| {
-            const color = if (line.heading) gold_color else text_color;
-            const line_width = window_ui.measureSmallText(assets, line.text);
-            const x = credits_panel_rect.x + 198.0 + 140.0 - line_width * 0.5;
-            window_ui.drawSmallText(assets, line.text, x, y, color);
-            y += 16.0;
+        const visible_count = state.line_end_index - state.line_start_index;
+        if (visible_count > 0) {
+            const base_y = credits_panel_rect.y + 60.0;
+            const frac_px = creditsScrollFractionPx(state.scroll_time_s);
+            const center_x = credits_panel_rect.x + 198.0 + 140.0;
+            var row: i32 = 0;
+            while (row < visible_count) : (row += 1) {
+                const index = state.line_start_index + row;
+                if (index < 0 or index >= window_statistics_data.credits_lines.len) continue;
+                const line = window_statistics_data.credits_lines[@intCast(index)];
+                const y = base_y + @as(f32, @floatFromInt(row)) * 16.0 - frac_px;
+                const alpha = creditsLineAlpha(y, base_y, visible_count);
+                if (alpha <= 0.0) continue;
+                const color = creditsLineColor(line.heading, alpha);
+                const line_width = window_ui.measureSmallText(assets, line.text);
+                const x = center_x - line_width * 0.5;
+                window_ui.drawSmallText(assets, line.text, x, y, color);
+            }
         }
         const back = backOnlyButton()[0];
         const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
@@ -813,6 +818,45 @@ fn drawListFrame(rect: rl.Rectangle) void {
 
 fn drawUnderline(x: f32, y: f32, width: f32) void {
     rl.drawRectangle(@intFromFloat(x), @intFromFloat(y), @intFromFloat(width), 1, rl.Color.init(255, 255, 255, 180));
+}
+
+fn creditsScrollFractionPx(scroll_time_s: f32) f32 {
+    var frac = scroll_time_s * 16.0;
+    while (frac > 16.0) frac -= 16.0;
+    return frac;
+}
+
+fn updateCreditsWindow(screen: *CreditsScreen) void {
+    const line_max_index: i32 = @intCast(window_statistics_data.credits_lines.len - 1);
+    if ((line_max_index + 2) < screen.line_start_index) {
+        screen.scroll_time_s = 0.0;
+        screen.line_start_index = 0;
+    }
+    const whole_scroll: i32 = @intFromFloat(screen.scroll_time_s);
+    screen.line_start_index = whole_scroll - 15;
+    screen.line_end_index = whole_scroll + 1;
+    if (line_max_index < screen.line_end_index) screen.line_end_index = line_max_index;
+}
+
+fn creditsLineColor(heading: bool, alpha: f32) rl.Color {
+    const rgb = if (heading)
+        [_]u8{ 255, 255, 255 }
+    else
+        [_]u8{ 102, 128, 178 };
+    return rl.Color.init(rgb[0], rgb[1], rgb[2], @intFromFloat(std.math.clamp(alpha, @as(f32, 0.0), @as(f32, 1.0)) * 255.0));
+}
+
+fn creditsLineAlpha(y: f32, base_y: f32, visible_count: i32) f32 {
+    const fade_px: f32 = 24.0;
+    const top = base_y + 8.0;
+    var alpha: f32 = 1.0;
+    if (y < top) {
+        alpha = 1.0 - ((top - y) / fade_px);
+    } else {
+        const bottom = base_y + @as(f32, @floatFromInt(visible_count - 1)) * 16.0 - fade_px;
+        if (y > bottom) alpha = ((bottom - y) / fade_px) + 1.0;
+    }
+    return std.math.clamp(alpha, @as(f32, 0.0), @as(f32, 1.0));
 }
 
 fn playerCountLabels() [4][]const u8 {

--- a/crimson-zig/src/window_statistics.zig
+++ b/crimson-zig/src/window_statistics.zig
@@ -13,6 +13,7 @@ const window_atlas = cz.window_atlas;
 
 const window_assets = @import("window_assets.zig");
 const window_menu = @import("window_menu.zig");
+const window_menu_panels = @import("window_menu_panels.zig");
 const window_ui = @import("window_ui.zig");
 const window_statistics_data = @import("window_statistics_data.zig");
 
@@ -88,6 +89,7 @@ const HighScoresScreen = struct {
     quest_level_key: i32 = 101,
     button_selection: usize = 0,
     dropdown_open: DropdownKind = .none,
+    scroll: usize = 0,
     records: []persistence.highscores.HighScoreRecord = &.{},
     records_owned: bool = false,
     load_error: ?[]const u8 = null,
@@ -300,6 +302,8 @@ fn updateHighScores(
     const hs = &state.high_scores;
     const buttons = highScoreButtons();
     window_ui.updateSelectionFromPointer(&hs.button_selection, buttons[0..]);
+    const rows: usize = 10;
+    const max_scroll = if (hs.records.len > rows) hs.records.len - rows else 0;
 
     if (rl.isKeyPressed(.escape)) {
         hs.dropdown_open = .none;
@@ -309,11 +313,29 @@ fn updateHighScores(
     }
 
     if (hs.dropdown_open == .none) {
+        const wheel = @as(i32, @intFromFloat(rl.getMouseWheelMove()));
+        if (wheel != 0) {
+            hs.scroll = @intCast(std.math.clamp(@as(i32, @intCast(hs.scroll)) - wheel, 0, @as(i32, @intCast(max_scroll))));
+        }
         if (rl.isKeyPressed(.up) or rl.isKeyPressed(.w)) {
             hs.button_selection = if (hs.button_selection == 0) buttons.len - 1 else hs.button_selection - 1;
+            hs.scroll = hs.scroll -| 1;
         }
         if (rl.isKeyPressed(.down) or rl.isKeyPressed(.s)) {
             hs.button_selection = (hs.button_selection + 1) % buttons.len;
+            hs.scroll = @min(hs.scroll + 1, max_scroll);
+        }
+        if (rl.isKeyPressed(.page_up)) {
+            hs.scroll = hs.scroll -| rows;
+        }
+        if (rl.isKeyPressed(.page_down)) {
+            hs.scroll = @min(hs.scroll + rows, max_scroll);
+        }
+        if (rl.isKeyPressed(.home)) {
+            hs.scroll = 0;
+        }
+        if (rl.isKeyPressed(.end)) {
+            hs.scroll = max_scroll;
         }
     }
 
@@ -550,23 +572,25 @@ fn drawHighScoreMainPanel(
     status: formats.game_cfg.Status,
 ) void {
     const title = highScoreTitle(state.mode);
-    window_ui.drawSmallText(assets, title, left_panel_rect.x + 158.0, left_panel_rect.y + 42.0, text_color);
-    drawUnderline(left_panel_rect.x + 158.0, left_panel_rect.y + 56.0, window_ui.measureSmallText(assets, title));
+    const title_x: f32 = if (state.mode == .survival) 266.0 else 269.0;
+    window_ui.drawSmallText(assets, title, left_panel_rect.x + title_x, left_panel_rect.y + 41.0, text_color);
+    drawUnderline(left_panel_rect.x + title_x, left_panel_rect.y + 55.0, window_ui.measureSmallText(assets, title));
 
     if (state.mode == .quests) {
         var quest_buf: [96]u8 = undefined;
+        const quest_title = questTitleForLevelKey(state.quest_level_key);
         const quest_label = std.fmt.bufPrint(&quest_buf, "{d}.{d}: {s}", .{
             @divTrunc(state.quest_level_key, 100),
             @mod(state.quest_level_key, 100),
-            if (config.hardcore_flag != 0) "Hardcore quest" else "Quest",
+            quest_title,
         }) catch "Quest";
-        window_ui.drawSmallText(assets, quest_label, left_panel_rect.x + 126.0, left_panel_rect.y + 64.0, if (config.hardcore_flag != 0) rl.Color.init(250, 70, 60, 180) else value_color);
+        window_ui.drawSmallText(assets, quest_label, left_panel_rect.x + 236.0, left_panel_rect.y + 63.0, if (config.hardcore_flag != 0) rl.Color.init(250, 70, 60, 180) else value_color);
         drawQuestArrows(assets, state.quest_level_key, config.hardcore_flag != 0, status);
     }
 
-    window_ui.drawSmallText(assets, "Rank", left_panel_rect.x + 102.0, left_panel_rect.y + 84.0, text_color);
-    window_ui.drawSmallText(assets, "Score", left_panel_rect.x + 138.0, left_panel_rect.y + 84.0, text_color);
-    window_ui.drawSmallText(assets, "Player", left_panel_rect.x + 194.0, left_panel_rect.y + 84.0, text_color);
+    window_ui.drawSmallText(assets, "Rank", left_panel_rect.x + 211.0, left_panel_rect.y + 84.0, text_color);
+    window_ui.drawSmallText(assets, "Score", left_panel_rect.x + 246.0, left_panel_rect.y + 84.0, text_color);
+    window_ui.drawSmallText(assets, "Player", left_panel_rect.x + 302.0, left_panel_rect.y + 84.0, text_color);
 
     const frame = scoreFrameRect();
     rl.drawRectangle(@intFromFloat(frame.x), @intFromFloat(frame.y), @intFromFloat(frame.width), @intFromFloat(frame.height), rl.Color.white);
@@ -575,17 +599,19 @@ fn drawHighScoreMainPanel(
     if (state.load_error) |load_error| {
         window_ui.drawSmallText(assets, load_error, frame.x + 8.0, frame.y + 8.0, rl.Color.orange);
     } else if (state.records.len == 0) {
-        window_ui.drawSmallText(assets, "No scores yet.", frame.x + 8.0, frame.y + 8.0, muted_text);
+        window_ui.drawSmallText(assets, "No scores yet.", left_panel_rect.x + 211.0, frame.y + 8.0, muted_text);
     } else {
-        const hovered_rank = hoveredHighScoreRank();
-        const row_count = @min(state.records.len, 10);
-        for (state.records[0..row_count], 0..) |record, idx| {
-            const row_y = frame.y + 8.0 + @as(f32, @floatFromInt(idx)) * 16.0;
+        const hovered_rank = hoveredHighScoreRank(state);
+        const start = @min(state.scroll, if (state.records.len > 10) state.records.len - 10 else 0);
+        const end = @min(start + 10, state.records.len);
+        for (state.records[start..end], 0..) |record, row| {
+            const idx = start + row;
             const color = if (hovered_rank != null and hovered_rank.? == idx) text_color else muted_text;
             var value_buf: [32]u8 = undefined;
-            window_ui.drawSmallTextFmt("{d}", assets, .{idx + 1}, frame.x + 6.0, row_y, color);
-            window_ui.drawSmallText(assets, formatHighScoreValue(&value_buf, record), frame.x + 36.0, row_y, color);
-            window_ui.drawSmallText(assets, clippedRecordName(record), frame.x + 94.0, row_y, color);
+            const y = frame.y + 8.0 + @as(f32, @floatFromInt(row)) * 16.0;
+            window_ui.drawSmallTextFmt("{d}", assets, .{idx + 1}, left_panel_rect.x + 216.0, y, color);
+            window_ui.drawSmallText(assets, formatHighScoreValue(&value_buf, record), left_panel_rect.x + 246.0, y, color);
+            window_ui.drawSmallText(assets, clippedRecordName(record), left_panel_rect.x + 304.0, y, color);
         }
     }
 
@@ -602,16 +628,16 @@ fn drawHighScoreRightPanel(
     config: formats.crimson_cfg.CrimsonCfg,
     status: formats.game_cfg.Status,
 ) void {
-    if (hoveredHighScoreRank()) |rank| {
+    if (hoveredHighScoreRank(state)) |rank| {
         if (rank < state.records.len) {
             drawHighScoreLocalDetails(assets, state.records[rank], rank);
             return;
         }
     }
 
-    const check_tex = if (config.hardcore_flag != 0) assets.texture(.ui_check_on) else assets.texture(.ui_check_off);
+    const check_tex = if (config.score_load_gate != 0) assets.texture(.ui_check_on) else assets.texture(.ui_check_off);
     window_ui.drawTextureFit(check_tex, rl.Rectangle.init(right_panel_rect.x + 44.0, right_panel_rect.y + 44.0, @floatFromInt(check_tex.width), @floatFromInt(check_tex.height)), rl.Color.white);
-    window_ui.drawSmallText(assets, "Hardcore", right_panel_rect.x + 66.0, right_panel_rect.y + 45.0, text_color);
+    window_ui.drawSmallText(assets, "Show internet scores", right_panel_rect.x + 66.0, right_panel_rect.y + 45.0, text_color);
     window_ui.drawSmallText(assets, "Number of players", right_panel_rect.x + 46.0, right_panel_rect.y + 64.0, text_color);
     window_ui.drawSmallText(assets, "Game mode", right_panel_rect.x + 174.0, right_panel_rect.y + 64.0, text_color);
     window_ui.drawSmallText(assets, "Show scores:", right_panel_rect.x + 44.0, right_panel_rect.y + 106.0, text_color);
@@ -661,13 +687,13 @@ fn drawWeaponsPanels(
     status: formats.game_cfg.Status,
 ) void {
     const title = "Unlocked Weapons Database";
-    window_ui.drawSmallText(assets, title, left_panel_rect.x + 150.0, left_panel_rect.y + 50.0, text_color);
-    drawUnderline(left_panel_rect.x + 150.0, left_panel_rect.y + 64.0, window_ui.measureSmallText(assets, title));
+    window_ui.drawSmallText(assets, title, left_panel_rect.x + 251.0, left_panel_rect.y + 50.0, text_color);
+    drawUnderline(left_panel_rect.x + 251.0, left_panel_rect.y + 63.0, window_ui.measureSmallText(assets, title));
 
     var weapon_ids: [state_mod.weapon_count_size]game_ids.WeaponId = undefined;
     const total = buildWeaponList(&weapon_ids, config, status);
-    window_ui.drawSmallTextFmt("{d} weapons in database", assets, .{total}, left_panel_rect.x + 102.0, left_panel_rect.y + 80.0, muted_text);
-    window_ui.drawSmallText(assets, "Weapon", left_panel_rect.x + 102.0, left_panel_rect.y + 108.0, text_color);
+    window_ui.drawSmallTextFmt("{d} weapons in database", assets, .{total}, left_panel_rect.x + 210.0, left_panel_rect.y + 80.0, muted_text);
+    window_ui.drawSmallText(assets, "Weapon", left_panel_rect.x + 210.0, left_panel_rect.y + 108.0, text_color);
     drawListFrame(weaponListRect());
 
     const start = @min(state.scroll, if (total > 10) total - 10 else 0);
@@ -675,7 +701,7 @@ fn drawWeaponsPanels(
     for (weapon_ids[start..end], 0..) |weapon_id, row| {
         const list_index = start + row;
         const color = if (list_index == state.selection) text_color else muted_text;
-        window_ui.drawSmallText(assets, game_ids.weaponDisplayName(weapon_id, false), weaponListRect().x + 6.0, weaponListRect().y + 6.0 + @as(f32, @floatFromInt(row)) * 16.0, color);
+        window_ui.drawSmallText(assets, game_ids.weaponDisplayName(weapon_id, false), left_panel_rect.x + 218.0, left_panel_rect.y + 130.0 + @as(f32, @floatFromInt(row)) * 16.0, color);
     }
 
     const back = backOnlyButton()[0];
@@ -684,17 +710,17 @@ fn drawWeaponsPanels(
 
     if (total == 0) return;
     const weapon_id = weapon_ids[@min(state.selection, total - 1)];
-    const detail_x = right_panel_rect.x + 46.0;
-    window_ui.drawSmallTextFmt("weapon #{d}", assets, .{@intFromEnum(weapon_id)}, detail_x + 146.0, right_panel_rect.y + 32.0, muted_text);
+    const detail_x = right_panel_rect.x;
+    window_ui.drawSmallTextFmt("weapon #{d}", assets, .{@intFromEnum(weapon_id)}, detail_x + 240.0, right_panel_rect.y + 32.0, muted_text);
     const name = game_ids.weaponDisplayName(weapon_id, false);
-    window_ui.drawSmallText(assets, name, detail_x, right_panel_rect.y + 50.0, text_color);
+    window_ui.drawSmallText(assets, name, detail_x + 50.0, right_panel_rect.y + 50.0, text_color);
     const icon_index = weapon_data.weaponIconIndex(weapon_id);
     if (icon_index >= 0) {
         const src_rect = window_atlas.weaponIconRect(assets.texture(.ui_wicons).width, assets.texture(.ui_wicons).height, icon_index);
         rl.drawTexturePro(
             assets.texture(.ui_wicons),
             rl.Rectangle.init(src_rect.x, src_rect.y, src_rect.width, src_rect.height),
-            rl.Rectangle.init(detail_x + 20.0, right_panel_rect.y + 82.0, 64.0, 32.0),
+            rl.Rectangle.init(detail_x + 82.0, right_panel_rect.y + 82.0, 64.0, 32.0),
             rl.Vector2.zero(),
             0.0,
             rl.Color.white,
@@ -707,11 +733,11 @@ fn drawWeaponsPanels(
         "Fire rate: n/a"
     else
         std.fmt.bufPrint(&fire_rate_buf, "Fire rate: {d} rpm", .{@as(i32, @intFromFloat(60.0 / stats_entry.shot_cooldown))}) catch "Fire rate: ?";
-    window_ui.drawSmallText(assets, fire_rate_text, detail_x + 16.0, right_panel_rect.y + 128.0, text_color);
+    window_ui.drawSmallText(assets, fire_rate_text, detail_x + 66.0, right_panel_rect.y + 128.0, text_color);
     var reload_buf: [64]u8 = undefined;
     const reload_text = std.fmt.bufPrint(&reload_buf, "Reload time: {d:.1} secs", .{stats_entry.reload_time}) catch "Reload time: ?";
-    window_ui.drawSmallText(assets, reload_text, detail_x + 16.0, right_panel_rect.y + 146.0, text_color);
-    window_ui.drawSmallTextFmt("Clip size: {d}", assets, .{stats_entry.clip_size}, detail_x + 16.0, right_panel_rect.y + 164.0, text_color);
+    window_ui.drawSmallText(assets, reload_text, detail_x + 66.0, right_panel_rect.y + 146.0, text_color);
+    window_ui.drawSmallTextFmt("Clip size: {d}", assets, .{stats_entry.clip_size}, detail_x + 66.0, right_panel_rect.y + 164.0, text_color);
 }
 
 fn drawPerksPanels(
@@ -724,13 +750,13 @@ fn drawPerksPanels(
 ) void {
     _ = hardcore;
     const title = "Unlocked Perks Database";
-    window_ui.drawSmallText(assets, title, left_panel_rect.x + 162.0, left_panel_rect.y + 50.0, text_color);
-    drawUnderline(left_panel_rect.x + 162.0, left_panel_rect.y + 64.0, window_ui.measureSmallText(assets, title));
+    window_ui.drawSmallText(assets, title, left_panel_rect.x + 261.0, left_panel_rect.y + 50.0, text_color);
+    drawUnderline(left_panel_rect.x + 261.0, left_panel_rect.y + 63.0, window_ui.measureSmallText(assets, title));
 
     var perk_ids: [state_mod.perk_count_size]game_ids.PerkId = undefined;
     const total = buildPerkList(&perk_ids, status);
-    window_ui.drawSmallTextFmt("{d} perks in database", assets, .{total}, left_panel_rect.x + 102.0, left_panel_rect.y + 78.0, muted_text);
-    window_ui.drawSmallText(assets, "Perks", left_panel_rect.x + 102.0, left_panel_rect.y + 106.0, text_color);
+    window_ui.drawSmallTextFmt("{d} perks in database", assets, .{total}, left_panel_rect.x + 210.0, left_panel_rect.y + 78.0, muted_text);
+    window_ui.drawSmallText(assets, "Perks", left_panel_rect.x + 210.0, left_panel_rect.y + 106.0, text_color);
     drawListFrame(perkListRect());
 
     const start = @min(state.scroll, if (total > 10) total - 10 else 0);
@@ -741,8 +767,8 @@ fn drawPerksPanels(
         window_ui.drawSmallText(
             assets,
             game_ids.perkDisplayName(perk_id, violence_disabled, preserve_bugs),
-            perkListRect().x + 6.0,
-            perkListRect().y + 6.0 + @as(f32, @floatFromInt(row)) * 16.0,
+            left_panel_rect.x + 218.0,
+            left_panel_rect.y + 128.0 + @as(f32, @floatFromInt(row)) * 16.0,
             color,
         );
     }
@@ -753,20 +779,22 @@ fn drawPerksPanels(
 
     if (total == 0) return;
     const perk_id = perk_ids[@min(state.selection, total - 1)];
-    const detail_x = right_panel_rect.x + 40.0;
-    window_ui.drawSmallTextFmt("perk #{d}", assets, .{@intFromEnum(perk_id)}, detail_x + 154.0, right_panel_rect.y + 32.0, muted_text);
+    const detail_x = right_panel_rect.x + 34.0;
+    window_ui.drawSmallTextFmt("perk #{d}", assets, .{@intFromEnum(perk_id)}, detail_x + 190.0, right_panel_rect.y + 32.0, muted_text);
     const name = game_ids.perkDisplayName(perk_id, violence_disabled, preserve_bugs);
-    window_ui.drawSmallText(assets, name, detail_x + 30.0, right_panel_rect.y + 50.0, text_color);
-    drawUnderline(detail_x + 30.0, right_panel_rect.y + 64.0, window_ui.measureSmallText(assets, name));
+    const name_width = window_ui.measureSmallText(assets, name);
+    const name_x = detail_x + 128.0 - name_width * 0.5;
+    window_ui.drawSmallText(assets, name, name_x, right_panel_rect.y + 50.0, text_color);
+    drawUnderline(name_x, right_panel_rect.y + 63.0, name_width);
 
-    var y = right_panel_rect.y + 92.0;
+    var y = right_panel_rect.y + 72.0;
     if (window_statistics_data.perkPrerequisite(perk_id)) |prereq| {
         var req_buf: [128]u8 = undefined;
         const req_text = std.fmt.bufPrint(&req_buf, "Requires: {s}", .{game_ids.perkDisplayName(prereq, violence_disabled, preserve_bugs)}) catch "Requires: ?";
-        window_ui.drawSmallText(assets, req_text, detail_x, y, rl.Color.init(255, 204, 204, 220));
+        window_ui.drawSmallText(assets, req_text, detail_x + 16.0, y, rl.Color.init(255, 204, 204, 220));
         y += 18.0;
     }
-    drawWrappedSmallText(assets, window_statistics_data.perkDescription(perk_id), detail_x, y, 256.0, muted_text);
+    drawWrappedSmallText(assets, window_statistics_data.perkDescription(perk_id), detail_x + 16.0, y, 256.0, muted_text);
 }
 
 fn drawSplitPanelShell(assets: *const window_assets.RuntimeAssets) void {
@@ -826,15 +854,15 @@ fn backOnlyButton() [1]window_ui.UiButton {
 }
 
 fn scoreFrameRect() rl.Rectangle {
-    return rl.Rectangle.init(left_panel_rect.x + 100.0, left_panel_rect.y + 101.0, 250.0, 164.0);
+    return rl.Rectangle.init(left_panel_rect.x + 210.0, left_panel_rect.y + 101.0, 250.0, 164.0);
 }
 
 fn weaponListRect() rl.Rectangle {
-    return rl.Rectangle.init(left_panel_rect.x + 102.0, left_panel_rect.y + 128.0, 250.0, 164.0);
+    return rl.Rectangle.init(left_panel_rect.x + 212.0, left_panel_rect.y + 128.0, 250.0, 164.0);
 }
 
 fn perkListRect() rl.Rectangle {
-    return rl.Rectangle.init(left_panel_rect.x + 102.0, left_panel_rect.y + 126.0, 250.0, 164.0);
+    return rl.Rectangle.init(left_panel_rect.x + 212.0, left_panel_rect.y + 126.0, 250.0, 164.0);
 }
 
 fn drawListFrame(rect: rl.Rectangle) void {
@@ -1109,24 +1137,27 @@ fn playerCountWidgetRect() rl.Rectangle {
 }
 
 fn gameModeWidgetRect() rl.Rectangle {
-    return rl.Rectangle.init(right_panel_rect.x + 174.0, right_panel_rect.y + 78.0, 118.0, 16.0);
+    return rl.Rectangle.init(right_panel_rect.x + 174.0, right_panel_rect.y + 78.0, 95.0, 16.0);
 }
 
 fn dateModeWidgetRect() rl.Rectangle {
-    return rl.Rectangle.init(right_panel_rect.x + 44.0, right_panel_rect.y + 120.0, 150.0, 16.0);
+    return rl.Rectangle.init(right_panel_rect.x + 44.0, right_panel_rect.y + 120.0, 134.0, 16.0);
 }
 
 fn scoreListWidgetRect() rl.Rectangle {
     return rl.Rectangle.init(right_panel_rect.x + 44.0, right_panel_rect.y + 164.0, 174.0, 16.0);
 }
 
-fn hoveredHighScoreRank() ?usize {
+fn hoveredHighScoreRank(state: *const HighScoresScreen) ?usize {
     const mouse = rl.getMousePosition();
     const frame = scoreFrameRect();
     if (!rectContains(frame, mouse)) return null;
     const row = @as(usize, @intFromFloat((mouse.y - (frame.y + 8.0)) / 16.0));
     if (row >= 10) return null;
-    return row;
+    const start = @min(state.scroll, if (state.records.len > 10) state.records.len - 10 else 0);
+    const rank = start + row;
+    if (rank >= state.records.len) return null;
+    return rank;
 }
 
 fn hoveredListRow(rect: rl.Rectangle, total: usize, scroll: usize) ?usize {
@@ -1139,22 +1170,48 @@ fn hoveredListRow(rect: rl.Rectangle, total: usize, scroll: usize) ?usize {
 
 fn drawHighScoreLocalDetails(assets: *const window_assets.RuntimeAssets, record: persistence.highscores.HighScoreRecord, rank: usize) void {
     const detail_x = right_panel_rect.x + 78.0;
-    window_ui.drawSmallText(assets, clippedRecordName(record), detail_x, right_panel_rect.y + 44.0, text_color);
-    window_ui.drawSmallText(assets, "Local score", detail_x, right_panel_rect.y + 58.0, muted_text);
+    const mode = record.gameModeId() orelse .survival;
+    const local_text = rl.Color.init(229, 229, 229, 204);
+    const value_text = rl.Color.init(229, 229, 255, 255);
+    const lower_text = rl.Color.init(229, 229, 229, 178);
+    const separator = rl.Color.init(149, 175, 198, 178);
+
+    window_ui.drawSmallText(assets, clippedRecordName(record), detail_x, right_panel_rect.y + 44.0, local_text);
+    window_ui.drawSmallText(assets, "Local score", detail_x, right_panel_rect.y + 58.0, local_text);
+    rl.drawLine(@intFromFloat(right_panel_rect.x + 78.0), @intFromFloat(right_panel_rect.y + 57.0), @intFromFloat(right_panel_rect.x + 117.0), @intFromFloat(right_panel_rect.y + 57.0), separator);
     var date_buf: [64]u8 = undefined;
     if (formatRecordDateBuf(&date_buf, record)) |date| {
-        window_ui.drawSmallText(assets, date, detail_x + 115.0, right_panel_rect.y + 72.0, muted_text);
+        const date_w = window_ui.measureSmallText(assets, date);
+        window_ui.drawSmallText(assets, date, right_panel_rect.x + 230.0 - date_w * 0.5, right_panel_rect.y + 72.0, local_text);
     }
-    window_ui.drawSmallText(assets, "Score", detail_x + 27.0, right_panel_rect.y + 90.0, muted_text);
-    window_ui.drawSmallText(assets, "Game time", detail_x + 114.0, right_panel_rect.y + 90.0, muted_text);
-    window_ui.drawSmallTextFmt("{d}", assets, .{record.scoreXp()}, detail_x + 27.0, right_panel_rect.y + 105.0, text_color);
-    var time_buf: [32]u8 = undefined;
-    window_ui.drawSmallText(assets, formatElapsedMmSsBuf(&time_buf, record.survivalElapsedMs()), detail_x + 148.0, right_panel_rect.y + 109.0, text_color);
+    rl.drawLine(@intFromFloat(right_panel_rect.x + 74.0), @intFromFloat(right_panel_rect.y + 72.0), @intFromFloat(right_panel_rect.x + 266.0), @intFromFloat(right_panel_rect.y + 72.0), separator);
+    window_ui.drawSmallText(assets, "Score", detail_x + 27.0, right_panel_rect.y + 90.0, local_text);
+    const time_label = if (mode == .quests) "Experience" else "Game time";
+    window_ui.drawSmallText(assets, time_label, detail_x + 114.0, right_panel_rect.y + 90.0, local_text);
+    rl.drawLine(@intFromFloat(right_panel_rect.x + 170.0), @intFromFloat(right_panel_rect.y + 90.0), @intFromFloat(right_panel_rect.x + 170.0), @intFromFloat(right_panel_rect.y + 138.0), separator);
+
+    switch (mode) {
+        .rush, .quests => {
+            var score_buf: [32]u8 = undefined;
+            const score_text = std.fmt.bufPrint(&score_buf, "{d:.2} secs", .{@as(f32, @floatFromInt(record.survivalElapsedMs())) * 0.001}) catch "0.00 secs";
+            const label_center_x = detail_x + 27.0 + window_ui.measureSmallText(assets, "Score") * 0.5;
+            const score_w = window_ui.measureSmallText(assets, score_text);
+            window_ui.drawSmallText(assets, score_text, label_center_x - score_w * 0.5, right_panel_rect.y + 105.0, value_text);
+            window_ui.drawSmallTextFmt("{d}", assets, .{record.scoreXp()}, detail_x + 148.0, right_panel_rect.y + 109.0, local_text);
+        },
+        .survival, .typo, .tutorial => {
+            window_ui.drawSmallTextFmt("{d}", assets, .{record.scoreXp()}, detail_x + 27.0, right_panel_rect.y + 105.0, value_text);
+            drawClockGauge(assets, record.survivalElapsedMs(), right_panel_rect.x + 194.0, right_panel_rect.y + 103.0);
+            var time_buf: [32]u8 = undefined;
+            window_ui.drawSmallText(assets, formatElapsedMmSsBuf(&time_buf, record.survivalElapsedMs()), detail_x + 148.0, right_panel_rect.y + 109.0, local_text);
+        },
+    }
     var rank_buf: [32]u8 = undefined;
     var ordinal_buf: [16]u8 = undefined;
     const rank_text = std.fmt.bufPrint(&rank_buf, "Rank: {s}", .{ordinalBuf(&ordinal_buf, rank + 1)}) catch "Rank: ?";
-    window_ui.drawSmallText(assets, rank_text, detail_x + 16.0, right_panel_rect.y + 120.0, muted_text);
+    window_ui.drawSmallText(assets, rank_text, detail_x + 16.0, right_panel_rect.y + 120.0, local_text);
     const icon_index = weapon_data.weaponIconIndex(record.mostUsedWeaponId());
+    rl.drawLine(@intFromFloat(right_panel_rect.x + 74.0), @intFromFloat(right_panel_rect.y + 142.0), @intFromFloat(right_panel_rect.x + 266.0), @intFromFloat(right_panel_rect.y + 142.0), separator);
     if (icon_index >= 0) {
         const src_rect = window_atlas.weaponIconRect(assets.texture(.ui_wicons).width, assets.texture(.ui_wicons).height, icon_index);
         rl.drawTexturePro(
@@ -1166,11 +1223,36 @@ fn drawHighScoreLocalDetails(assets: *const window_assets.RuntimeAssets, record:
             rl.Color.white,
         );
     }
-    window_ui.drawSmallTextFmt("Frags: {d}", assets, .{record.creatureKillCount()}, detail_x + 122.0, right_panel_rect.y + 147.0, muted_text);
+    window_ui.drawSmallTextFmt("Frags: {d}", assets, .{record.creatureKillCount()}, detail_x + 122.0, right_panel_rect.y + 147.0, lower_text);
     const shots_fired = record.shotsFired();
     const hit_pct: u32 = if (shots_fired == 0) 0 else @intCast(@divTrunc(record.shotsHit() * 100, shots_fired));
-    window_ui.drawSmallTextFmt("Hit %: {d}%", assets, .{hit_pct}, detail_x + 122.0, right_panel_rect.y + 161.0, muted_text);
-    window_ui.drawSmallText(assets, game_ids.weaponDisplayName(record.mostUsedWeaponId(), false), detail_x + 12.0, right_panel_rect.y + 178.0, text_color);
+    window_ui.drawSmallTextFmt("Hit %: {d}%", assets, .{hit_pct}, detail_x + 122.0, right_panel_rect.y + 161.0, lower_text);
+    const weapon_name = game_ids.weaponDisplayName(record.mostUsedWeaponId(), false);
+    const weapon_name_x = right_panel_rect.x + 90.0 + @max(@as(f32, 0.0), 32.0 - window_ui.measureSmallText(assets, weapon_name) * 0.5);
+    window_ui.drawSmallText(assets, weapon_name, weapon_name_x, right_panel_rect.y + 178.0, lower_text);
+    rl.drawLine(@intFromFloat(right_panel_rect.x + 74.0), @intFromFloat(right_panel_rect.y + 194.0), @intFromFloat(right_panel_rect.x + 266.0), @intFromFloat(right_panel_rect.y + 194.0), separator);
+}
+
+fn drawClockGauge(assets: *const window_assets.RuntimeAssets, elapsed_ms: u32, x: f32, y: f32) void {
+    const table = assets.texture(.ui_clock_table);
+    const pointer = assets.texture(.ui_clock_pointer);
+    rl.drawTexturePro(
+        table,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(table.width), @floatFromInt(table.height)),
+        rl.Rectangle.init(x, y, 32.0, 32.0),
+        rl.Vector2.zero(),
+        0.0,
+        rl.Color.white,
+    );
+    const seconds = @divTrunc(elapsed_ms, 1000);
+    rl.drawTexturePro(
+        pointer,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(pointer.width), @floatFromInt(pointer.height)),
+        rl.Rectangle.init(x + 16.0, y + 16.0, 32.0, 32.0),
+        rl.Vector2.init(16.0, 16.0),
+        @as(f32, @floatFromInt(seconds)) * 6.0,
+        rl.Color.white,
+    );
 }
 
 fn updateHighScoreWidgets(
@@ -1183,9 +1265,9 @@ fn updateHighScoreWidgets(
     const mouse = rl.getMousePosition();
     const click = rl.isMouseButtonPressed(.left);
 
-    const hardcore_rect = rl.Rectangle.init(right_panel_rect.x + 44.0, right_panel_rect.y + 44.0, 120.0, 16.0);
-    if (click and state.dropdown_open == .none and rectContains(hardcore_rect, mouse)) {
-        config.hardcore_flag = if (config.hardcore_flag == 0) 1 else 0;
+    const internet_rect = rl.Rectangle.init(right_panel_rect.x + 44.0, right_panel_rect.y + 44.0, 180.0, 16.0);
+    if (click and state.dropdown_open == .none and rectContains(internet_rect, mouse)) {
+        config.score_load_gate = if (config.score_load_gate == 0) 1 else 0;
         loadHighScores(state, allocator, base_dir, config.*, status);
         return .{ .config_dirty = true, .play_button_click = true };
     }
@@ -1417,6 +1499,7 @@ fn loadHighScores(
         return;
     };
     state.records_owned = true;
+    state.scroll = @min(state.scroll, if (state.records.len > 10) state.records.len - 10 else 0);
 }
 
 fn passesDateFilter(record: persistence.highscores.HighScoreRecord, date_mode_raw: u8) bool {
@@ -1537,6 +1620,12 @@ fn ordinalBuf(buf: []u8, rank: usize) []const u8 {
 fn questLevelKeyFromConfig(config: formats.crimson_cfg.CrimsonCfg) i32 {
     _ = config;
     return 101;
+}
+
+fn questTitleForLevelKey(level_key: i32) []const u8 {
+    const index = questLevelKeyToIndex(level_key);
+    if (index < 0 or index >= window_menu_panels.quest_titles.len) return "???";
+    return window_menu_panels.quest_titles[@intCast(index)];
 }
 
 fn questLevelKeyToIndex(level_key: i32) i32 {

--- a/crimson-zig/src/window_statistics.zig
+++ b/crimson-zig/src/window_statistics.zig
@@ -27,7 +27,8 @@ const panel_timeline_max_ms: i32 = 300;
 
 const left_panel_rect = rl.Rectangle.init(164.0, 156.0, 424.0, 402.0);
 const right_panel_rect = rl.Rectangle.init(678.0, 174.0, 424.0, 276.0);
-const credits_panel_rect = rl.Rectangle.init(250.0, 118.0, 780.0, 500.0);
+const stats_panel_rect = rl.Rectangle.init(390.0, 168.0, 510.0, 378.0);
+const credits_panel_rect = rl.Rectangle.init(360.0, 168.0, 510.0, 378.0);
 
 const HubAction = enum {
     high_scores,
@@ -432,9 +433,10 @@ fn updateCredits(state: *State, frame_dt: f32) UpdateResult {
 
 fn drawHub(state: *const HubState, runtime_assets: ?*const window_assets.RuntimeAssets, status: formats.game_cfg.Status) void {
     if (runtime_assets) |assets| {
-        drawPanelShell(state.panel.timeline_ms, assets, rl.Rectangle.init(390.0, 168.0, 500.0, 360.0), window_menu.label_row_statistics);
+        drawPanelShellNoTitle(state.panel.timeline_ms, assets, stats_panel_rect);
+        drawAtlasTitle(assets, stats_panel_rect, 290.0, 52.0, window_menu.label_row_statistics);
         var playtime_buf: [64]u8 = undefined;
-        window_ui.drawSmallText(assets, formatPlaytimeText(&playtime_buf, status.game_sequence_id), 492.0, 502.0, muted_text);
+        window_ui.drawSmallText(assets, formatPlaytimeText(&playtime_buf, status.game_sequence_id), stats_panel_rect.x + 204.0, stats_panel_rect.y + 334.0, muted_text);
         const buttons = hubButtons();
         for (buttons, 0..) |button, idx| {
             const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
@@ -490,13 +492,16 @@ fn drawPerks(
 
 fn drawCredits(state: *const CreditsScreen, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     if (runtime_assets) |assets| {
-        drawPanelShell(300, assets, credits_panel_rect, window_menu.label_row_statistics);
-        var y: f32 = 174.0;
+        drawPanelShellNoTitle(300, assets, credits_panel_rect);
+        drawAtlasTitle(assets, credits_panel_rect, 202.0, 46.0, window_menu.label_row_statistics);
+        var y: f32 = credits_panel_rect.y + 60.0;
         const start = state.scroll;
-        const end = @min(start + 20, window_statistics_data.credits_lines.len);
+        const end = @min(start + 16, window_statistics_data.credits_lines.len);
         for (window_statistics_data.credits_lines[start..end]) |line| {
             const color = if (line.heading) gold_color else text_color;
-            window_ui.drawSmallText(assets, line.text, 302.0, y, color);
+            const line_width = window_ui.measureSmallText(assets, line.text);
+            const x = credits_panel_rect.x + 198.0 + 140.0 - line_width * 0.5;
+            window_ui.drawSmallText(assets, line.text, x, y, color);
             y += 16.0;
         }
         const back = backOnlyButton()[0];
@@ -748,28 +753,45 @@ fn drawPanelShell(timeline_ms: i32, assets: *const window_assets.RuntimeAssets, 
     window_menu.drawAtlasLabelCentered(assets, label_row, rect.y + 42.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
 }
 
+fn drawPanelShellNoTitle(timeline_ms: i32, assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle) void {
+    window_menu.drawMenuBackdrop(assets);
+    window_menu.drawSign(timeline_ms, assets);
+    window_ui.drawTextureFit(assets.texture(.ui_menu_panel), rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+}
+
+fn drawAtlasTitle(assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle, rel_x: f32, rel_y: f32, row: i32) void {
+    const texture = assets.texture(.ui_item_texts);
+    rl.drawTexturePro(
+        texture,
+        rl.Rectangle.init(0.0, @as(f32, @floatFromInt(row)) * 32.0, 128.0, 32.0),
+        rl.Rectangle.init(rect.x + rel_x, rect.y + rel_y, 128.0, 32.0),
+        rl.Vector2.zero(),
+        0.0,
+        rl.Color.white,
+    );
+}
+
 fn hubButtons() [5]window_ui.UiButton {
-    const center_x = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
     return .{
-        .{ .label = "HIGH SCORES", .rect = window_ui.centeredRect(center_x, 250.0, 240.0, 44.0) },
-        .{ .label = "WEAPONS", .rect = window_ui.centeredRect(center_x, 304.0, 240.0, 44.0) },
-        .{ .label = "PERKS", .rect = window_ui.centeredRect(center_x, 358.0, 240.0, 44.0) },
-        .{ .label = "CREDITS", .rect = window_ui.centeredRect(center_x, 412.0, 240.0, 44.0) },
-        .{ .label = "BACK", .rect = window_ui.centeredRect(center_x, 478.0, 180.0, 44.0) },
+        .{ .label = "High scores", .rect = window_ui.centeredRect(stats_panel_rect.x + 270.0, stats_panel_rect.y + 104.0, 240.0, 44.0) },
+        .{ .label = "Weapons", .rect = window_ui.centeredRect(stats_panel_rect.x + 270.0, stats_panel_rect.y + 138.0, 240.0, 44.0) },
+        .{ .label = "Perks", .rect = window_ui.centeredRect(stats_panel_rect.x + 270.0, stats_panel_rect.y + 172.0, 240.0, 44.0) },
+        .{ .label = "Credits", .rect = window_ui.centeredRect(stats_panel_rect.x + 270.0, stats_panel_rect.y + 206.0, 240.0, 44.0) },
+        .{ .label = "Back", .rect = window_ui.centeredRect(stats_panel_rect.x + 394.0, stats_panel_rect.y + 290.0, 180.0, 44.0) },
     };
 }
 
 fn highScoreButtons() [3]window_ui.UiButton {
     return .{
-        .{ .label = "UPDATE SCORES", .rect = window_ui.centeredRect(left_panel_rect.x + 212.0, left_panel_rect.y + 268.0, 240.0, 44.0) },
-        .{ .label = "PLAY A GAME", .rect = window_ui.centeredRect(left_panel_rect.x + 212.0, left_panel_rect.y + 322.0, 240.0, 44.0) },
-        .{ .label = "BACK", .rect = window_ui.centeredRect(left_panel_rect.x + 340.0, left_panel_rect.y + 355.0, 150.0, 44.0) },
+        .{ .label = "Update scores", .rect = window_ui.centeredRect(left_panel_rect.x + 212.0, left_panel_rect.y + 268.0, 240.0, 44.0) },
+        .{ .label = "Play a game", .rect = window_ui.centeredRect(left_panel_rect.x + 212.0, left_panel_rect.y + 322.0, 240.0, 44.0) },
+        .{ .label = "Back", .rect = window_ui.centeredRect(left_panel_rect.x + 340.0, left_panel_rect.y + 355.0, 150.0, 44.0) },
     };
 }
 
 fn backOnlyButton() [1]window_ui.UiButton {
     return .{
-        .{ .label = "BACK", .rect = window_ui.centeredRect(@as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5, 562.0, 180.0, 44.0) },
+        .{ .label = "Back", .rect = window_ui.centeredRect(credits_panel_rect.x + 298.0, credits_panel_rect.y + 310.0, 180.0, 44.0) },
     };
 }
 
@@ -1234,7 +1256,9 @@ fn formatPlaytimeText(buf: []u8, game_sequence_ms: u32) []const u8 {
     const total_minutes = @divTrunc(@divTrunc(game_sequence_ms, 1000), 60);
     const hours = @divTrunc(total_minutes, 60);
     const minutes = @mod(total_minutes, 60);
-    return std.fmt.bufPrint(buf, "played for {d} hours {d} minutes", .{ hours, minutes }) catch "played for 0 hours 0 minutes";
+    const hour_label = if (hours == 1) "hour" else "hours";
+    const minute_label = if (minutes == 1) "minute" else "minutes";
+    return std.fmt.bufPrint(buf, "played for {d} {s} {d} {s}", .{ hours, hour_label, minutes, minute_label }) catch "played for 0 hours 0 minutes";
 }
 
 fn formatElapsedMmSsBuf(buf: []u8, elapsed_ms: u32) []const u8 {

--- a/crimson-zig/src/window_statistics.zig
+++ b/crimson-zig/src/window_statistics.zig
@@ -741,22 +741,22 @@ fn drawPerksPanels(
 fn drawSplitPanelShell(assets: *const window_assets.RuntimeAssets, label_row: i32) void {
     window_menu.drawMenuBackdrop(assets);
     window_menu.drawSign(panel_timeline_max_ms, assets);
-    window_ui.drawTextureFit(assets.texture(.ui_menu_panel), left_panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
-    window_ui.drawTextureFit(assets.texture(.ui_menu_panel), right_panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), left_panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), right_panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), true);
     window_menu.drawAtlasLabelCentered(assets, label_row, 146.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
 }
 
 fn drawPanelShell(timeline_ms: i32, assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle, label_row: i32) void {
     window_menu.drawMenuBackdrop(assets);
     window_menu.drawSign(timeline_ms, assets);
-    window_ui.drawTextureFit(assets.texture(.ui_menu_panel), rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
     window_menu.drawAtlasLabelCentered(assets, label_row, rect.y + 42.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
 }
 
 fn drawPanelShellNoTitle(timeline_ms: i32, assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle) void {
     window_menu.drawMenuBackdrop(assets);
     window_menu.drawSign(timeline_ms, assets);
-    window_ui.drawTextureFit(assets.texture(.ui_menu_panel), rect, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
 }
 
 fn drawAtlasTitle(assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle, rel_x: f32, rel_y: f32, row: i32) void {

--- a/crimson-zig/src/window_statistics.zig
+++ b/crimson-zig/src/window_statistics.zig
@@ -454,7 +454,7 @@ fn drawHighScores(
     status: formats.game_cfg.Status,
 ) void {
     if (runtime_assets) |assets| {
-        drawSplitPanelShell(assets, window_menu.label_row_statistics);
+        drawSplitPanelShell(assets);
         drawHighScoreMainPanel(state, assets, config, status);
         drawHighScoreRightPanel(state, assets, config, status);
         return;
@@ -469,7 +469,7 @@ fn drawWeapons(
     status: formats.game_cfg.Status,
 ) void {
     if (runtime_assets) |assets| {
-        drawSplitPanelShell(assets, window_menu.label_row_statistics);
+        drawSplitPanelShell(assets);
         drawWeaponsPanels(state, assets, config, status);
         return;
     }
@@ -483,7 +483,7 @@ fn drawPerks(
     status: formats.game_cfg.Status,
 ) void {
     if (runtime_assets) |assets| {
-        drawSplitPanelShell(assets, window_menu.label_row_statistics);
+        drawSplitPanelShell(assets);
         drawPerksPanels(state, assets, status, config.gore_disabled, config.hardcore_flag != 0, config.game_mode == @intFromEnum(game_ids.GameModeId.tutorial));
         return;
     }
@@ -493,7 +493,7 @@ fn drawPerks(
 fn drawCredits(state: *const CreditsScreen, runtime_assets: ?*const window_assets.RuntimeAssets) void {
     if (runtime_assets) |assets| {
         drawPanelShellNoTitle(300, assets, credits_panel_rect);
-        drawAtlasTitle(assets, credits_panel_rect, 202.0, 46.0, window_menu.label_row_statistics);
+        window_ui.drawSmallText(assets, "credits", credits_panel_rect.x + 202.0, credits_panel_rect.y + 46.0, text_color);
         var y: f32 = credits_panel_rect.y + 60.0;
         const start = state.scroll;
         const end = @min(start + 16, window_statistics_data.credits_lines.len);
@@ -738,12 +738,11 @@ fn drawPerksPanels(
     drawWrappedSmallText(assets, window_statistics_data.perkDescription(perk_id), detail_x, y, 256.0, muted_text);
 }
 
-fn drawSplitPanelShell(assets: *const window_assets.RuntimeAssets, label_row: i32) void {
+fn drawSplitPanelShell(assets: *const window_assets.RuntimeAssets) void {
     window_menu.drawMenuBackdrop(assets);
     window_menu.drawSign(panel_timeline_max_ms, assets);
     window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), left_panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
     window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), right_panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), true);
-    window_menu.drawAtlasLabelCentered(assets, label_row, 146.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
 }
 
 fn drawPanelShell(timeline_ms: i32, assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle, label_row: i32) void {
@@ -773,25 +772,25 @@ fn drawAtlasTitle(assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle
 
 fn hubButtons() [5]window_ui.UiButton {
     return .{
-        .{ .label = "High scores", .rect = window_ui.centeredRect(stats_panel_rect.x + 270.0, stats_panel_rect.y + 104.0, 240.0, 44.0) },
-        .{ .label = "Weapons", .rect = window_ui.centeredRect(stats_panel_rect.x + 270.0, stats_panel_rect.y + 138.0, 240.0, 44.0) },
-        .{ .label = "Perks", .rect = window_ui.centeredRect(stats_panel_rect.x + 270.0, stats_panel_rect.y + 172.0, 240.0, 44.0) },
-        .{ .label = "Credits", .rect = window_ui.centeredRect(stats_panel_rect.x + 270.0, stats_panel_rect.y + 206.0, 240.0, 44.0) },
-        .{ .label = "Back", .rect = window_ui.centeredRect(stats_panel_rect.x + 394.0, stats_panel_rect.y + 290.0, 180.0, 44.0) },
+        window_ui.buttonAt("High scores", stats_panel_rect.x + 270.0, stats_panel_rect.y + 104.0, true),
+        window_ui.buttonAt("Weapons", stats_panel_rect.x + 270.0, stats_panel_rect.y + 138.0, true),
+        window_ui.buttonAt("Perks", stats_panel_rect.x + 270.0, stats_panel_rect.y + 172.0, true),
+        window_ui.buttonAt("Credits", stats_panel_rect.x + 270.0, stats_panel_rect.y + 206.0, true),
+        window_ui.buttonAt("Back", stats_panel_rect.x + 394.0, stats_panel_rect.y + 290.0, false),
     };
 }
 
 fn highScoreButtons() [3]window_ui.UiButton {
     return .{
-        .{ .label = "Update scores", .rect = window_ui.centeredRect(left_panel_rect.x + 212.0, left_panel_rect.y + 268.0, 240.0, 44.0) },
-        .{ .label = "Play a game", .rect = window_ui.centeredRect(left_panel_rect.x + 212.0, left_panel_rect.y + 322.0, 240.0, 44.0) },
-        .{ .label = "Back", .rect = window_ui.centeredRect(left_panel_rect.x + 340.0, left_panel_rect.y + 355.0, 150.0, 44.0) },
+        window_ui.buttonAt("Update scores", left_panel_rect.x + 234.0, left_panel_rect.y + 268.0, true),
+        window_ui.buttonAt("Play a game", left_panel_rect.x + 234.0, left_panel_rect.y + 301.0, true),
+        window_ui.buttonAt("Back", left_panel_rect.x + 400.0, left_panel_rect.y + 301.0, false),
     };
 }
 
 fn backOnlyButton() [1]window_ui.UiButton {
     return .{
-        .{ .label = "Back", .rect = window_ui.centeredRect(credits_panel_rect.x + 298.0, credits_panel_rect.y + 310.0, 180.0, 44.0) },
+        window_ui.buttonAt("Back", credits_panel_rect.x + 298.0, credits_panel_rect.y + 310.0, false),
     };
 }
 

--- a/crimson-zig/src/window_statistics.zig
+++ b/crimson-zig/src/window_statistics.zig
@@ -24,6 +24,9 @@ const value_color = rl.Color.init(70, 180, 240, 255);
 const gold_color = rl.Color.init(255, 228, 170, 255);
 
 const panel_timeline_max_ms: i32 = 300;
+const credits_table_size: usize = 0x100;
+const credits_flag_heading: u8 = 0x1;
+const credits_flag_clicked: u8 = 0x4;
 
 const left_panel_rect = rl.Rectangle.init(164.0, 156.0, 424.0, 402.0);
 const right_panel_rect = rl.Rectangle.init(678.0, 174.0, 424.0, 276.0);
@@ -124,9 +127,27 @@ const CreditsScreen = struct {
     scroll_time_s: f32 = 0.0,
     line_start_index: i32 = 0,
     line_end_index: i32 = 0,
+    line_max_index: i32 = 0,
+    secret_line_base_index: usize = 0x54,
+    secret_unlock: bool = false,
+    lines: [credits_table_size]CreditLineState = [_]CreditLineState{.{}} ** credits_table_size,
 
     fn reset(self: *CreditsScreen) void {
         self.* = .{};
+        buildCreditsLines(self);
+    }
+};
+
+const CreditLineState = struct {
+    text: []const u8 = "",
+    flags: u8 = 0,
+
+    fn heading(self: CreditLineState) bool {
+        return (self.flags & credits_flag_heading) != 0;
+    }
+
+    fn clicked(self: CreditLineState) bool {
+        return (self.flags & credits_flag_clicked) != 0;
     }
 };
 
@@ -187,13 +208,14 @@ pub fn update(
     base_dir: []const u8,
     config: *formats.crimson_cfg.CrimsonCfg,
     status: formats.game_cfg.Status,
+    runtime_assets: ?*const window_assets.RuntimeAssets,
 ) UpdateResult {
     return switch (state.view) {
         .hub => updateHub(state, allocator, frame_dt, base_dir, config, status),
         .high_scores => updateHighScores(state, allocator, frame_dt, base_dir, config, status),
         .weapons => updateWeapons(state, frame_dt, config.*, status),
         .perks => updatePerks(state, frame_dt, status),
-        .credits => updateCredits(state, frame_dt),
+        .credits => updateCredits(state, frame_dt, runtime_assets),
     };
 }
 
@@ -414,7 +436,7 @@ fn updatePerks(state: *State, frame_dt: f32, status: formats.game_cfg.Status) Up
     return .{};
 }
 
-fn updateCredits(state: *State, frame_dt: f32) UpdateResult {
+fn updateCredits(state: *State, frame_dt: f32, runtime_assets: ?*const window_assets.RuntimeAssets) UpdateResult {
     _ = state.hub.panel.advance(frame_dt);
     if (rl.isKeyPressed(.escape) or backButtonActivated(backOnlyButton()[0])) {
         state.view = .hub;
@@ -424,6 +446,10 @@ fn updateCredits(state: *State, frame_dt: f32) UpdateResult {
     const dt_clamped = @min(frame_dt, 0.1);
     state.credits.scroll_time_s += dt_clamped;
     updateCreditsWindow(&state.credits);
+    if (runtime_assets) |assets| {
+        updateCreditsLineClicks(&state.credits, assets, rl.getMousePosition(), rl.isMouseButtonPressed(.left));
+        updateCreditsSecretUnlock(&state.credits);
+    }
     return .{};
 }
 
@@ -498,12 +524,12 @@ fn drawCredits(state: *const CreditsScreen, runtime_assets: ?*const window_asset
             var row: i32 = 0;
             while (row < visible_count) : (row += 1) {
                 const index = state.line_start_index + row;
-                if (index < 0 or index >= window_statistics_data.credits_lines.len) continue;
-                const line = window_statistics_data.credits_lines[@intCast(index)];
+                if (index < 0 or index >= credits_table_size) continue;
+                const line = state.lines[@intCast(index)];
                 const y = base_y + @as(f32, @floatFromInt(row)) * 16.0 - frac_px;
                 const alpha = creditsLineAlpha(y, base_y, visible_count);
                 if (alpha <= 0.0) continue;
-                const color = creditsLineColor(line.heading, alpha);
+                const color = creditsLineColor(line, alpha);
                 const line_width = window_ui.measureSmallText(assets, line.text);
                 const x = center_x - line_width * 0.5;
                 window_ui.drawSmallText(assets, line.text, x, y, color);
@@ -746,21 +772,21 @@ fn drawPerksPanels(
 fn drawSplitPanelShell(assets: *const window_assets.RuntimeAssets) void {
     window_menu.drawMenuBackdrop(assets);
     window_menu.drawSign(panel_timeline_max_ms, assets);
-    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), left_panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
-    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), right_panel_rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), true);
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), left_panel_rect, rl.Color.white, false);
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), right_panel_rect, rl.Color.white, true);
 }
 
 fn drawPanelShell(timeline_ms: i32, assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle, label_row: i32) void {
     window_menu.drawMenuBackdrop(assets);
     window_menu.drawSign(timeline_ms, assets);
-    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
-    window_menu.drawAtlasLabelCentered(assets, label_row, rect.y + 42.0, window_ui.colorWithAlpha(rl.Color.white, 0.96));
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), rect, rl.Color.white, false);
+    window_menu.drawAtlasLabelCentered(assets, label_row, rect.y + 42.0, rl.Color.white);
 }
 
 fn drawPanelShellNoTitle(timeline_ms: i32, assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle) void {
     window_menu.drawMenuBackdrop(assets);
     window_menu.drawSign(timeline_ms, assets);
-    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), rect, window_ui.colorWithAlpha(rl.Color.white, 0.96), false);
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), rect, rl.Color.white, false);
 }
 
 fn drawAtlasTitle(assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle, rel_x: f32, rel_y: f32, row: i32) void {
@@ -827,19 +853,20 @@ fn creditsScrollFractionPx(scroll_time_s: f32) f32 {
 }
 
 fn updateCreditsWindow(screen: *CreditsScreen) void {
-    const line_max_index: i32 = @intCast(window_statistics_data.credits_lines.len - 1);
-    if ((line_max_index + 2) < screen.line_start_index) {
+    if ((screen.line_max_index + 2) < screen.line_start_index) {
         screen.scroll_time_s = 0.0;
         screen.line_start_index = 0;
     }
     const whole_scroll: i32 = @intFromFloat(screen.scroll_time_s);
     screen.line_start_index = whole_scroll - 15;
     screen.line_end_index = whole_scroll + 1;
-    if (line_max_index < screen.line_end_index) screen.line_end_index = line_max_index;
+    if (screen.line_max_index < screen.line_end_index) screen.line_end_index = screen.line_max_index;
 }
 
-fn creditsLineColor(heading: bool, alpha: f32) rl.Color {
-    const rgb = if (heading)
+fn creditsLineColor(line: CreditLineState, alpha: f32) rl.Color {
+    const rgb = if (line.clicked())
+        if (line.heading()) [_]u8{ 230, 255, 230 } else [_]u8{ 102, 179, 179 }
+    else if (line.heading())
         [_]u8{ 255, 255, 255 }
     else
         [_]u8{ 102, 128, 178 };
@@ -857,6 +884,180 @@ fn creditsLineAlpha(y: f32, base_y: f32, visible_count: i32) f32 {
         if (y > bottom) alpha = ((bottom - y) / fade_px) + 1.0;
     }
     return std.math.clamp(alpha, @as(f32, 0.0), @as(f32, 1.0));
+}
+
+const credits_secret_lines = [_][]const u8{
+    "Inside Dead Let Mighty Blood",
+    "Do Firepower See Mark Of",
+    "The Sacrifice Old Center",
+    "Yourself Ground First For",
+    "Triangle Cube Last Not Flee",
+    "0001001110000010101110011",
+    "0101001011100010010101100",
+    "011111001000111",
+    "(4 bits for index) <- OOOPS I meant FIVE!",
+    "(4 bits for index)",
+};
+
+fn buildCreditsLines(screen: *CreditsScreen) void {
+    for (&screen.lines) |*line| line.* = .{};
+    screen.line_max_index = 0;
+    screen.secret_line_base_index = 0x54;
+    screen.secret_unlock = false;
+
+    const setLine = struct {
+        fn apply(screen_: *CreditsScreen, index: usize, text: []const u8, flags: u8) void {
+            screen_.lines[index] = .{ .text = text, .flags = flags };
+            screen_.line_max_index = @intCast(index);
+        }
+    }.apply;
+
+    setLine(screen, 0x00, "2026 Remake:", credits_flag_heading);
+    setLine(screen, 0x01, "banteg", 0);
+    setLine(screen, 0x02, "", 0);
+    setLine(screen, 0x03, "Crimsonland", credits_flag_heading);
+    setLine(screen, 0x04, "Game Design:", credits_flag_heading);
+    setLine(screen, 0x05, "Tero Alatalo", 0);
+    setLine(screen, 0x06, "", 0);
+    setLine(screen, 0x07, "Programming:", credits_flag_heading);
+    setLine(screen, 0x08, "Tero Alatalo", 0);
+    setLine(screen, 0x09, "", 0);
+    setLine(screen, 0x0A, "Producer:", credits_flag_heading);
+    setLine(screen, 0x0B, "Zach Young", 0);
+    setLine(screen, 0x0C, "", 0);
+    setLine(screen, 0x0D, "2D Art:", credits_flag_heading);
+    setLine(screen, 0x0E, "Tero Alatalo", 0);
+    setLine(screen, 0x0F, "", 0);
+    setLine(screen, 0x10, "3D Modelling:", credits_flag_heading);
+    setLine(screen, 0x11, "Tero Alatalo", 0);
+    setLine(screen, 0x12, "Timo Palonen", 0);
+    setLine(screen, 0x13, "", 0);
+    setLine(screen, 0x14, "Music:", credits_flag_heading);
+    setLine(screen, 0x15, "Valtteri Pihlajam", 0);
+    setLine(screen, 0x16, "Ville Eriksson", 0);
+    setLine(screen, 0x17, "", 0);
+    setLine(screen, 0x18, "Sound Effects:", credits_flag_heading);
+    setLine(screen, 0x19, "Ion Hardie", 0);
+    setLine(screen, 0x1A, "Tero Alatalo", 0);
+    setLine(screen, 0x1B, "Valtteri Pihlajam", 0);
+    setLine(screen, 0x1C, "Ville Eriksson", 0);
+    setLine(screen, 0x1D, "", 0);
+    setLine(screen, 0x1E, "Manual:", credits_flag_heading);
+    setLine(screen, 0x1F, "Miikka Kulmala", 0);
+    setLine(screen, 0x20, "Zach Young", 0);
+    setLine(screen, 0x21, "", 0);
+    setLine(screen, 0x22, "Special thanks to:", credits_flag_heading);
+    setLine(screen, 0x23, "Petri J", 0);
+    setLine(screen, 0x24, "Peter Hajba / Remedy", 0);
+    setLine(screen, 0x25, "", 0);
+    setLine(screen, 0x26, "Play testers:", credits_flag_heading);
+    setLine(screen, 0x27, "Avraham Petrosyan", 0);
+    setLine(screen, 0x28, "Bryce Baker", 0);
+    setLine(screen, 0x29, "Dan Ruskin", 0);
+    setLine(screen, 0x2A, "Dirk Bunk", 0);
+    setLine(screen, 0x2B, "Eric Dallaire", 0);
+    setLine(screen, 0x2C, "Erik Van Pelt", 0);
+    setLine(screen, 0x2D, "Ernie Ramirez", 0);
+    setLine(screen, 0x2E, "Ion Hardie", 0);
+    setLine(screen, 0x2F, "James C. Smith", 0);
+    setLine(screen, 0x30, "Jarkko Forsbacka", 0);
+    setLine(screen, 0x31, "Jeff McAteer", 0);
+    setLine(screen, 0x32, "Juha Alatalo", 0);
+    setLine(screen, 0x33, "Kalle Hahl", 0);
+    setLine(screen, 0x34, "Lars Brubaker", 0);
+    setLine(screen, 0x35, "Lee Cooper", 0);
+    setLine(screen, 0x36, "Markus Lassila", 0);
+    setLine(screen, 0x37, "Matti Alanen", 0);
+    setLine(screen, 0x38, "Miikka Kulmala", 0);
+    setLine(screen, 0x39, "Mika Alatalo", 0);
+    setLine(screen, 0x3A, "Mike Colonnese", 0);
+    setLine(screen, 0x3B, "Simon Hallam", 0);
+    setLine(screen, 0x3C, "Toni Nurminen", 0);
+    setLine(screen, 0x3D, "Valtteri Pihlajam", 0);
+    setLine(screen, 0x3E, "Ville Eriksson", 0);
+    setLine(screen, 0x3F, "Ville M", 0);
+    setLine(screen, 0x40, "Zach Young", 0);
+    setLine(screen, 0x41, "", 0);
+    setLine(screen, 0x42, "", 0);
+    setLine(screen, 0x43, "", 0);
+    setLine(screen, 0x44, "2003 (c) 10tons entertainment", 0);
+    setLine(screen, 0x45, "10tons logo by", 0);
+    setLine(screen, 0x46, "Pasi Heinonen", 0);
+    setLine(screen, 0x47, "", 0);
+    setLine(screen, 0x48, "", 0);
+    setLine(screen, 0x49, "", 0);
+    setLine(screen, 0x4A, "Uses Vorbis Audio Decompression", 0);
+    setLine(screen, 0x4B, "2003 (c) Xiph.Org Foundation", 0);
+    setLine(screen, 0x4C, "(see vorbis.txt)", 0);
+    var index: usize = 0x4D;
+    while (index < 0x54) : (index += 1) setLine(screen, index, "", 0);
+    setLine(screen, 0x54, "", 0);
+    setLine(screen, 0x55, "", 0);
+    setLine(screen, 0x56, "", 0);
+    setLine(screen, 0x57, "You can stop watching now.", 0);
+    index = 0x58;
+    while (index < 0x77) : (index += 1) setLine(screen, index, "", 0);
+    setLine(screen, 0x77, "Click the ones with the round ones!", 0);
+    setLine(screen, 0x78, "(and be patient!)", 0);
+    index = 0x79;
+    while (index < 0x7E) : (index += 1) setLine(screen, index, "", 0);
+}
+
+fn updateCreditsLineClicks(screen: *CreditsScreen, assets: *const window_assets.RuntimeAssets, mouse: rl.Vector2, click: bool) void {
+    if (!click) return;
+    const visible_count = screen.line_end_index - screen.line_start_index;
+    if (visible_count <= 0) return;
+
+    const base_y = credits_panel_rect.y + 60.0;
+    const frac_px = creditsScrollFractionPx(screen.scroll_time_s);
+    const center_x = credits_panel_rect.x + 198.0 + 140.0;
+    var row: i32 = 0;
+    while (row < visible_count) : (row += 1) {
+        const index = screen.line_start_index + row;
+        if (index < 0 or index >= credits_table_size) continue;
+        const line = screen.lines[@intCast(index)];
+        const text_w = window_ui.measureSmallText(assets, line.text);
+        const x = center_x - text_w * 0.5;
+        const y = base_y + @as(f32, @floatFromInt(row)) * 16.0 - frac_px;
+        if (!(mouse.x >= x and mouse.x <= x + text_w and mouse.y >= y and mouse.y <= y + 16.0)) continue;
+        if (std.mem.indexOfScalar(u8, line.text, 'o') != null) {
+            screen.lines[@intCast(index)].flags |= credits_flag_clicked;
+        } else {
+            _ = creditsLineClearFlag(screen, index);
+        }
+        return;
+    }
+}
+
+fn creditsLineClearFlag(screen: *CreditsScreen, start_index: i32) bool {
+    var index = start_index;
+    while (index >= 0) : (index -= 1) {
+        const slot: usize = @intCast(index);
+        if ((screen.lines[slot].flags & credits_flag_clicked) != 0) {
+            screen.lines[slot].flags &= ~credits_flag_clicked;
+            return true;
+        }
+    }
+    return false;
+}
+
+fn updateCreditsSecretUnlock(screen: *CreditsScreen) void {
+    if (screen.secret_unlock or !creditsAllRoundLinesFlagged(screen)) return;
+    screen.secret_unlock = true;
+    for (credits_secret_lines, 0..) |text, offset| {
+        const index = screen.secret_line_base_index + offset;
+        screen.lines[index].text = text;
+        screen.lines[index].flags |= credits_flag_clicked;
+    }
+}
+
+fn creditsAllRoundLinesFlagged(screen: *const CreditsScreen) bool {
+    var index: usize = 0;
+    while (index < credits_table_size) : (index += 1) {
+        const line = screen.lines[index];
+        if (line.text.len != 0 and std.mem.indexOfScalar(u8, line.text, 'o') != null and (line.flags & credits_flag_clicked) == 0) return false;
+    }
+    return true;
 }
 
 fn playerCountLabels() [4][]const u8 {

--- a/crimson-zig/src/window_statistics.zig
+++ b/crimson-zig/src/window_statistics.zig
@@ -119,6 +119,7 @@ const WeaponsScreen = struct {
 const PerksScreen = struct {
     selection: usize = 0,
     scroll: usize = 0,
+    hovered: ?usize = null,
 
     fn reset(self: *PerksScreen) void {
         self.* = .{};
@@ -379,7 +380,7 @@ fn updateWeapons(state: *State, frame_dt: f32, config: formats.crimson_cfg.Crims
         screen.selection = total - 1;
     }
 
-    if (rl.isKeyPressed(.escape) or backButtonActivated(backOnlyButton()[0])) {
+    if (rl.isKeyPressed(.escape) or backButtonActivated(weaponBackButton()[0])) {
         state.view = .hub;
         state.hub.reset();
         return .{ .play_button_click = true };
@@ -417,15 +418,17 @@ fn updatePerks(state: *State, frame_dt: f32, status: formats.game_cfg.Status) Up
     var perk_ids: [state_mod.perk_count_size]game_ids.PerkId = undefined;
     const total = buildPerkList(&perk_ids, status);
     const screen = &state.perks;
+    screen.hovered = null;
 
     if (total == 0) {
         screen.selection = 0;
         screen.scroll = 0;
+        screen.hovered = null;
     } else if (screen.selection >= total) {
         screen.selection = total - 1;
     }
 
-    if (rl.isKeyPressed(.escape) or backButtonActivated(backOnlyButton()[0])) {
+    if (rl.isKeyPressed(.escape) or backButtonActivated(perkBackButton()[0])) {
         state.view = .hub;
         state.hub.reset();
         return .{ .play_button_click = true };
@@ -452,7 +455,10 @@ fn updatePerks(state: *State, frame_dt: f32, status: formats.game_cfg.Status) Up
         if (screen.selection >= screen.scroll + 10) screen.scroll = screen.selection - 9;
     }
     if (hoveredListRow(perkListRect(), total, screen.scroll)) |row| {
-        screen.selection = row;
+        screen.hovered = row;
+        if (rl.isMouseButtonPressed(.left)) {
+            screen.selection = row;
+        }
     }
 
     return .{};
@@ -643,41 +649,49 @@ fn drawHighScoreRightPanel(
     window_ui.drawSmallText(assets, "Show scores:", right_panel_rect.x + 44.0, right_panel_rect.y + 106.0, text_color);
     window_ui.drawSmallText(assets, "Selected score list:", right_panel_rect.x + 44.0, right_panel_rect.y + 150.0, text_color);
 
-    drawDropdown(
-        assets,
-        playerCountWidgetRect(),
-        playerCountLabels()[0..],
-        @as(usize, @intCast(std.math.clamp(config.player_count, @as(u32, 1), @as(u32, 4)))) - 1,
-        state.dropdown_open == .player_count,
-    );
-
     var mode_labels_buf: [4][]const u8 = undefined;
     const mode_labels = highScoreModeLabels(&mode_labels_buf, status);
-    drawDropdown(
-        assets,
-        gameModeWidgetRect(),
-        mode_labels,
-        highScoreModeLabelIndex(state.mode, status),
-        state.dropdown_open == .game_mode,
-    );
-
-    drawDropdown(
-        assets,
-        dateModeWidgetRect(),
-        scoreDateModeLabels()[0..],
-        @min(config.highscore_date_mode, 3),
-        state.dropdown_open == .date_mode,
-    );
-
     var saved_names: [formats.crimson_cfg.saved_name_slot_count][]const u8 = undefined;
     for (0..saved_names.len) |idx| saved_names[idx] = formats.crimson_cfg.savedNameLabel(&config, idx);
-    drawDropdown(
-        assets,
-        scoreListWidgetRect(),
-        saved_names[0..],
-        formats.crimson_cfg.selectedSavedNameSlot(&config),
-        state.dropdown_open == .score_list,
-    );
+    const dropdowns = [_]struct {
+        kind: DropdownKind,
+        rect: rl.Rectangle,
+        items: []const []const u8,
+        selected: usize,
+    }{
+        .{
+            .kind = .player_count,
+            .rect = playerCountWidgetRect(),
+            .items = playerCountLabels()[0..],
+            .selected = @as(usize, @intCast(std.math.clamp(config.player_count, @as(u32, 1), @as(u32, 4)))) - 1,
+        },
+        .{
+            .kind = .game_mode,
+            .rect = gameModeWidgetRect(),
+            .items = mode_labels,
+            .selected = highScoreModeLabelIndex(state.mode, status),
+        },
+        .{
+            .kind = .date_mode,
+            .rect = dateModeWidgetRect(),
+            .items = scoreDateModeLabels()[0..],
+            .selected = @min(config.highscore_date_mode, 3),
+        },
+        .{
+            .kind = .score_list,
+            .rect = scoreListWidgetRect(),
+            .items = saved_names[0..],
+            .selected = formats.crimson_cfg.selectedSavedNameSlot(&config),
+        },
+    };
+    for (dropdowns) |dropdown| {
+        if (state.dropdown_open == dropdown.kind) continue;
+        drawDropdown(assets, dropdown.rect, dropdown.items, dropdown.selected, false);
+    }
+    for (dropdowns) |dropdown| {
+        if (state.dropdown_open != dropdown.kind) continue;
+        drawDropdown(assets, dropdown.rect, dropdown.items, dropdown.selected, true);
+    }
 }
 
 fn drawWeaponsPanels(
@@ -692,7 +706,8 @@ fn drawWeaponsPanels(
 
     var weapon_ids: [state_mod.weapon_count_size]game_ids.WeaponId = undefined;
     const total = buildWeaponList(&weapon_ids, config, status);
-    window_ui.drawSmallTextFmt("{d} weapons in database", assets, .{total}, left_panel_rect.x + 210.0, left_panel_rect.y + 80.0, muted_text);
+    const weapon_label = if (total == 1) "weapon" else "weapons";
+    window_ui.drawSmallTextFmt("{d} {s} in database", assets, .{ total, weapon_label }, left_panel_rect.x + 210.0, left_panel_rect.y + 80.0, muted_text);
     window_ui.drawSmallText(assets, "Weapon", left_panel_rect.x + 210.0, left_panel_rect.y + 108.0, text_color);
     drawListFrame(weaponListRect());
 
@@ -704,7 +719,7 @@ fn drawWeaponsPanels(
         window_ui.drawSmallText(assets, game_ids.weaponDisplayName(weapon_id, false), left_panel_rect.x + 218.0, left_panel_rect.y + 130.0 + @as(f32, @floatFromInt(row)) * 16.0, color);
     }
 
-    const back = backOnlyButton()[0];
+    const back = weaponBackButton()[0];
     const back_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
     window_ui.drawButton(back, false, back_hovered, assets);
 
@@ -755,7 +770,8 @@ fn drawPerksPanels(
 
     var perk_ids: [state_mod.perk_count_size]game_ids.PerkId = undefined;
     const total = buildPerkList(&perk_ids, status);
-    window_ui.drawSmallTextFmt("{d} perks in database", assets, .{total}, left_panel_rect.x + 210.0, left_panel_rect.y + 78.0, muted_text);
+    const perk_label = if (total == 1) "perk" else "perks";
+    window_ui.drawSmallTextFmt("{d} {s} in database", assets, .{ total, perk_label }, left_panel_rect.x + 210.0, left_panel_rect.y + 78.0, muted_text);
     window_ui.drawSmallText(assets, "Perks", left_panel_rect.x + 210.0, left_panel_rect.y + 106.0, text_color);
     drawListFrame(perkListRect());
 
@@ -763,22 +779,24 @@ fn drawPerksPanels(
     const end = @min(start + 10, total);
     for (perk_ids[start..end], 0..) |perk_id, row| {
         const list_index = start + row;
-        const color = if (list_index == state.selection) text_color else muted_text;
+        const alpha: f32 = if (state.hovered != null and state.hovered.? == list_index) 1.0 else if (list_index == state.selection) 0.9 else 0.7;
         window_ui.drawSmallText(
             assets,
             game_ids.perkDisplayName(perk_id, violence_disabled, preserve_bugs),
             left_panel_rect.x + 218.0,
             left_panel_rect.y + 128.0 + @as(f32, @floatFromInt(row)) * 16.0,
-            color,
+            rl.Color.init(255, 255, 255, @intFromFloat(255.0 * alpha)),
         );
     }
+    if (total > 10) drawPerkScrollbar(total, start);
 
-    const back = backOnlyButton()[0];
+    const back = perkBackButton()[0];
     const back_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
     window_ui.drawButton(back, false, back_hovered, assets);
 
     if (total == 0) return;
-    const perk_id = perk_ids[@min(state.selection, total - 1)];
+    const detail_index = @min(state.hovered orelse state.selection, total - 1);
+    const perk_id = perk_ids[detail_index];
     const detail_x = right_panel_rect.x + 34.0;
     window_ui.drawSmallTextFmt("perk #{d}", assets, .{@intFromEnum(perk_id)}, detail_x + 190.0, right_panel_rect.y + 32.0, muted_text);
     const name = game_ids.perkDisplayName(perk_id, violence_disabled, preserve_bugs);
@@ -853,6 +871,18 @@ fn backOnlyButton() [1]window_ui.UiButton {
     };
 }
 
+fn weaponBackButton() [1]window_ui.UiButton {
+    return .{
+        window_ui.buttonAt("Back", left_panel_rect.x + 368.0, left_panel_rect.y + 313.0, false),
+    };
+}
+
+fn perkBackButton() [1]window_ui.UiButton {
+    return .{
+        window_ui.buttonAt("Back", left_panel_rect.x + 356.0, left_panel_rect.y + 315.0, false),
+    };
+}
+
 fn scoreFrameRect() rl.Rectangle {
     return rl.Rectangle.init(left_panel_rect.x + 210.0, left_panel_rect.y + 101.0, 250.0, 164.0);
 }
@@ -868,6 +898,18 @@ fn perkListRect() rl.Rectangle {
 fn drawListFrame(rect: rl.Rectangle) void {
     rl.drawRectangle(@intFromFloat(rect.x), @intFromFloat(rect.y), @intFromFloat(rect.width), @intFromFloat(rect.height), rl.Color.white);
     rl.drawRectangle(@intFromFloat(rect.x + 1.0), @intFromFloat(rect.y + 1.0), @intFromFloat(rect.width - 2.0), @intFromFloat(rect.height - 2.0), rl.Color.black);
+}
+
+fn drawPerkScrollbar(total: usize, start: usize) void {
+    const track_x = left_panel_rect.x + 452.0;
+    const track_y = left_panel_rect.y + 126.0;
+    const track_h = 164.0;
+    const scroll_span = @max(total, 10) - 10;
+    const thumb_h = @min((10.0 / @as(f32, @floatFromInt(total))) * track_h, track_h - 3.0);
+    const thumb_top = track_y + 1.0 + ((track_h - 3.0 - thumb_h) / @as(f32, @floatFromInt(@max(scroll_span, 1)))) * @as(f32, @floatFromInt(start));
+    rl.drawRectangle(@intFromFloat(track_x), @intFromFloat(track_y), 1, @intFromFloat(track_h), rl.Color.white);
+    rl.drawRectangle(@intFromFloat(track_x + 1.0), @intFromFloat(thumb_top), 8, @intFromFloat(thumb_h + 1.0), rl.Color.init(255, 255, 255, 204));
+    rl.drawRectangle(@intFromFloat(track_x + 2.0), @intFromFloat(thumb_top + 1.0), 6, @intFromFloat(@max(1.0, thumb_h - 1.0)), rl.Color.init(51, 204, 255, 51));
 }
 
 fn drawUnderline(x: f32, y: f32, width: f32) void {
@@ -1105,12 +1147,16 @@ fn drawDropdown(
 ) void {
     const selected_index = @min(selected_index_raw, if (items.len == 0) @as(usize, 0) else items.len - 1);
     const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), rect);
-    const texture = if (is_open or hovered) assets.texture(.ui_drop_on) else assets.texture(.ui_drop_off);
+    const active = is_open or hovered;
+    const texture = if (active) assets.texture(.ui_drop_on) else assets.texture(.ui_drop_off);
 
     rl.drawRectangleRec(rect, rl.Color.white);
     rl.drawRectangle(@intFromFloat(rect.x + 1.0), @intFromFloat(rect.y + 1.0), @intFromFloat(rect.width - 2.0), @intFromFloat(rect.height - 2.0), rl.Color.black);
+    if (active) {
+        rl.drawRectangle(@intFromFloat(rect.x), @intFromFloat(rect.y + 15.0), @intFromFloat(rect.width), 1, rl.Color.init(255, 255, 255, 128));
+    }
     if (items.len != 0) {
-        window_ui.drawSmallText(assets, items[selected_index], rect.x + 4.0, rect.y + 1.0, if (hovered or is_open) text_color else muted_text);
+        window_ui.drawSmallText(assets, items[selected_index], rect.x + 4.0, rect.y + 1.0, rl.Color.init(255, 255, 255, if (active) 242 else 191));
     }
     rl.drawTexturePro(
         texture,
@@ -1128,7 +1174,8 @@ fn drawDropdown(
     for (items, 0..) |item, idx| {
         const row_rect = rl.Rectangle.init(rect.x, rect.y + 17.0 + @as(f32, @floatFromInt(idx)) * 16.0, rect.width, 16.0);
         const row_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), row_rect);
-        window_ui.drawSmallText(assets, item, row_rect.x + 4.0, row_rect.y + 1.0, if (row_hovered or idx == selected_index) text_color else muted_text);
+        const alpha: u8 = if (row_hovered) 242 else if (idx == selected_index) 245 else 153;
+        window_ui.drawSmallText(assets, item, row_rect.x + 4.0, row_rect.y + 1.0, rl.Color.init(255, 255, 255, alpha));
     }
 }
 

--- a/crimson-zig/src/window_statistics.zig
+++ b/crimson-zig/src/window_statistics.zig
@@ -230,10 +230,10 @@ pub fn draw(
 ) void {
     switch (state.view) {
         .hub => drawHub(&state.hub, runtime_assets, status),
-        .high_scores => drawHighScores(&state.high_scores, runtime_assets, config, status),
-        .weapons => drawWeapons(&state.weapons, runtime_assets, config, status),
-        .perks => drawPerks(&state.perks, runtime_assets, config, status),
-        .credits => drawCredits(&state.credits, runtime_assets),
+        .high_scores => drawHighScores(&state.high_scores, runtime_assets, config, status, state.hub.panel.timeline_ms),
+        .weapons => drawWeapons(&state.weapons, runtime_assets, config, status, state.hub.panel.timeline_ms),
+        .perks => drawPerks(&state.perks, runtime_assets, config, status, state.hub.panel.timeline_ms),
+        .credits => drawCredits(&state.credits, runtime_assets, state.hub.panel.timeline_ms),
     }
 }
 
@@ -246,7 +246,8 @@ fn updateHub(
     status: formats.game_cfg.Status,
 ) UpdateResult {
     const dt_ms = state.hub.panel.advance(frame_dt);
-    const buttons = hubButtons();
+    const panel_rect = animatedCenterPanelRect(stats_panel_rect, state.hub.panel.timeline_ms);
+    const buttons = hubButtons(panel_rect);
     window_ui.updateSelectionFromPointer(&state.hub.panel.selection, buttons[0..]);
 
     if (rl.isKeyPressed(.escape)) {
@@ -300,8 +301,10 @@ fn updateHighScores(
     status: formats.game_cfg.Status,
 ) UpdateResult {
     _ = state.hub.panel.advance(frame_dt);
+    const left_rect = animatedLeftPanelRect(left_panel_rect, state.hub.panel.timeline_ms);
+    const right_rect = animatedRightPanelRect(right_panel_rect, state.hub.panel.timeline_ms);
     const hs = &state.high_scores;
-    const buttons = highScoreButtons();
+    const buttons = highScoreButtons(left_rect);
     window_ui.updateSelectionFromPointer(&hs.button_selection, buttons[0..]);
     const rows: usize = 10;
     const max_scroll = if (hs.records.len > rows) hs.records.len - rows else 0;
@@ -340,12 +343,12 @@ fn updateHighScores(
         }
     }
 
-    if (updateHighScoreQuestArrows(hs, config, status)) {
+    if (updateHighScoreQuestArrows(hs, config, status, left_rect)) {
         loadHighScores(hs, allocator, base_dir, config.*, status);
         return .{ .config_dirty = true, .play_button_click = true };
     }
 
-    if (updateHighScoreWidgets(hs, allocator, base_dir, config, status)) |widget_result| {
+    if (updateHighScoreWidgets(hs, allocator, base_dir, config, status, right_rect)) |widget_result| {
         return widget_result;
     }
 
@@ -369,6 +372,7 @@ fn updateHighScores(
 
 fn updateWeapons(state: *State, frame_dt: f32, config: formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) UpdateResult {
     _ = state.hub.panel.advance(frame_dt);
+    const left_rect = animatedLeftPanelRect(left_panel_rect, state.hub.panel.timeline_ms);
     var weapon_ids: [state_mod.weapon_count_size]game_ids.WeaponId = undefined;
     const total = buildWeaponList(&weapon_ids, config, status);
     const screen = &state.weapons;
@@ -380,14 +384,14 @@ fn updateWeapons(state: *State, frame_dt: f32, config: formats.crimson_cfg.Crims
         screen.selection = total - 1;
     }
 
-    if (rl.isKeyPressed(.escape) or backButtonActivated(weaponBackButton()[0])) {
+    if (rl.isKeyPressed(.escape) or backButtonActivated(weaponBackButton(left_rect)[0])) {
         state.view = .hub;
         state.hub.reset();
         return .{ .play_button_click = true };
     }
 
     const mouse = rl.getMousePosition();
-    if (rl.getMouseWheelMove() != 0 and rectContains(weaponListRect(), mouse)) {
+    if (rl.getMouseWheelMove() != 0 and rectContains(weaponListRect(left_rect), mouse)) {
         const max_scroll = if (total > 10) total - 10 else 0;
         if (rl.getMouseWheelMove() > 0) {
             if (screen.scroll > 0) screen.scroll -= 1;
@@ -406,7 +410,7 @@ fn updateWeapons(state: *State, frame_dt: f32, config: formats.crimson_cfg.Crims
         if (screen.selection < screen.scroll) screen.scroll = screen.selection;
         if (screen.selection >= screen.scroll + 10) screen.scroll = screen.selection - 9;
     }
-    if (hoveredListRow(weaponListRect(), total, screen.scroll)) |row| {
+    if (hoveredListRow(weaponListRect(left_rect), total, screen.scroll)) |row| {
         screen.selection = row;
     }
 
@@ -415,6 +419,7 @@ fn updateWeapons(state: *State, frame_dt: f32, config: formats.crimson_cfg.Crims
 
 fn updatePerks(state: *State, frame_dt: f32, status: formats.game_cfg.Status) UpdateResult {
     _ = state.hub.panel.advance(frame_dt);
+    const left_rect = animatedLeftPanelRect(left_panel_rect, state.hub.panel.timeline_ms);
     var perk_ids: [state_mod.perk_count_size]game_ids.PerkId = undefined;
     const total = buildPerkList(&perk_ids, status);
     const screen = &state.perks;
@@ -428,14 +433,14 @@ fn updatePerks(state: *State, frame_dt: f32, status: formats.game_cfg.Status) Up
         screen.selection = total - 1;
     }
 
-    if (rl.isKeyPressed(.escape) or backButtonActivated(perkBackButton()[0])) {
+    if (rl.isKeyPressed(.escape) or backButtonActivated(perkBackButton(left_rect)[0])) {
         state.view = .hub;
         state.hub.reset();
         return .{ .play_button_click = true };
     }
 
     const mouse = rl.getMousePosition();
-    if (rl.getMouseWheelMove() != 0 and rectContains(perkListRect(), mouse)) {
+    if (rl.getMouseWheelMove() != 0 and rectContains(perkListRect(left_rect), mouse)) {
         const max_scroll = if (total > 10) total - 10 else 0;
         if (rl.getMouseWheelMove() > 0) {
             if (screen.scroll > 0) screen.scroll -= 1;
@@ -454,7 +459,7 @@ fn updatePerks(state: *State, frame_dt: f32, status: formats.game_cfg.Status) Up
         if (screen.selection < screen.scroll) screen.scroll = screen.selection;
         if (screen.selection >= screen.scroll + 10) screen.scroll = screen.selection - 9;
     }
-    if (hoveredListRow(perkListRect(), total, screen.scroll)) |row| {
+    if (hoveredListRow(perkListRect(left_rect), total, screen.scroll)) |row| {
         screen.hovered = row;
         if (rl.isMouseButtonPressed(.left)) {
             screen.selection = row;
@@ -466,7 +471,8 @@ fn updatePerks(state: *State, frame_dt: f32, status: formats.game_cfg.Status) Up
 
 fn updateCredits(state: *State, frame_dt: f32, runtime_assets: ?*const window_assets.RuntimeAssets) UpdateResult {
     _ = state.hub.panel.advance(frame_dt);
-    if (rl.isKeyPressed(.escape) or backButtonActivated(backOnlyButton()[0])) {
+    const panel_rect = animatedCenterPanelRect(credits_panel_rect, state.hub.panel.timeline_ms);
+    if (rl.isKeyPressed(.escape) or backButtonActivated(backOnlyButton(panel_rect)[0])) {
         state.view = .hub;
         state.hub.reset();
         return .{ .play_button_click = true };
@@ -475,7 +481,7 @@ fn updateCredits(state: *State, frame_dt: f32, runtime_assets: ?*const window_as
     state.credits.scroll_time_s += dt_clamped;
     updateCreditsWindow(&state.credits);
     if (runtime_assets) |assets| {
-        updateCreditsLineClicks(&state.credits, assets, rl.getMousePosition(), rl.isMouseButtonPressed(.left));
+        updateCreditsLineClicks(&state.credits, assets, panel_rect, rl.getMousePosition(), rl.isMouseButtonPressed(.left));
         updateCreditsSecretUnlock(&state.credits);
     }
     return .{};
@@ -483,11 +489,12 @@ fn updateCredits(state: *State, frame_dt: f32, runtime_assets: ?*const window_as
 
 fn drawHub(state: *const HubState, runtime_assets: ?*const window_assets.RuntimeAssets, status: formats.game_cfg.Status) void {
     if (runtime_assets) |assets| {
+        const panel_rect = animatedCenterPanelRect(stats_panel_rect, state.panel.timeline_ms);
         drawPanelShellNoTitle(state.panel.timeline_ms, assets, stats_panel_rect);
-        drawAtlasTitle(assets, stats_panel_rect, 290.0, 52.0, window_menu.label_row_statistics);
+        drawAtlasTitle(assets, panel_rect, 290.0, 52.0, window_menu.label_row_statistics);
         var playtime_buf: [64]u8 = undefined;
-        window_ui.drawSmallText(assets, formatPlaytimeText(&playtime_buf, status.game_sequence_id), stats_panel_rect.x + 204.0, stats_panel_rect.y + 334.0, muted_text);
-        const buttons = hubButtons();
+        window_ui.drawSmallText(assets, formatPlaytimeText(&playtime_buf, status.game_sequence_id), panel_rect.x + 204.0, panel_rect.y + 334.0, muted_text);
+        const buttons = hubButtons(panel_rect);
         for (buttons, 0..) |button, idx| {
             const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
             window_ui.drawButton(button, idx == state.panel.selection, hovered, assets);
@@ -502,11 +509,14 @@ fn drawHighScores(
     runtime_assets: ?*const window_assets.RuntimeAssets,
     config: formats.crimson_cfg.CrimsonCfg,
     status: formats.game_cfg.Status,
+    timeline_ms: i32,
 ) void {
     if (runtime_assets) |assets| {
-        drawSplitPanelShell(assets);
-        drawHighScoreMainPanel(state, assets, config, status);
-        drawHighScoreRightPanel(state, assets, config, status);
+        const left_rect = animatedLeftPanelRect(left_panel_rect, timeline_ms);
+        const right_rect = animatedRightPanelRect(right_panel_rect, timeline_ms);
+        drawSplitPanelShell(assets, timeline_ms);
+        drawHighScoreMainPanel(state, assets, config, status, left_rect);
+        drawHighScoreRightPanel(state, assets, config, status, left_rect, right_rect);
         return;
     }
     rl.clearBackground(panel_color);
@@ -517,10 +527,13 @@ fn drawWeapons(
     runtime_assets: ?*const window_assets.RuntimeAssets,
     config: formats.crimson_cfg.CrimsonCfg,
     status: formats.game_cfg.Status,
+    timeline_ms: i32,
 ) void {
     if (runtime_assets) |assets| {
-        drawSplitPanelShell(assets);
-        drawWeaponsPanels(state, assets, config, status);
+        const left_rect = animatedLeftPanelRect(left_panel_rect, timeline_ms);
+        const right_rect = animatedRightPanelRect(right_panel_rect, timeline_ms);
+        drawSplitPanelShell(assets, timeline_ms);
+        drawWeaponsPanels(state, assets, config, status, left_rect, right_rect);
         return;
     }
     rl.clearBackground(panel_color);
@@ -531,24 +544,28 @@ fn drawPerks(
     runtime_assets: ?*const window_assets.RuntimeAssets,
     config: formats.crimson_cfg.CrimsonCfg,
     status: formats.game_cfg.Status,
+    timeline_ms: i32,
 ) void {
     if (runtime_assets) |assets| {
-        drawSplitPanelShell(assets);
-        drawPerksPanels(state, assets, status, config.gore_disabled, config.hardcore_flag != 0, config.game_mode == @intFromEnum(game_ids.GameModeId.tutorial));
+        const left_rect = animatedLeftPanelRect(left_panel_rect, timeline_ms);
+        const right_rect = animatedRightPanelRect(right_panel_rect, timeline_ms);
+        drawSplitPanelShell(assets, timeline_ms);
+        drawPerksPanels(state, assets, status, config.gore_disabled, config.hardcore_flag != 0, config.game_mode == @intFromEnum(game_ids.GameModeId.tutorial), left_rect, right_rect);
         return;
     }
     rl.clearBackground(panel_color);
 }
 
-fn drawCredits(state: *const CreditsScreen, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+fn drawCredits(state: *const CreditsScreen, runtime_assets: ?*const window_assets.RuntimeAssets, timeline_ms: i32) void {
     if (runtime_assets) |assets| {
-        drawPanelShellNoTitle(300, assets, credits_panel_rect);
-        window_ui.drawSmallText(assets, "credits", credits_panel_rect.x + 202.0, credits_panel_rect.y + 46.0, text_color);
+        const panel_rect = animatedCenterPanelRect(credits_panel_rect, timeline_ms);
+        drawPanelShellNoTitle(timeline_ms, assets, credits_panel_rect);
+        window_ui.drawSmallText(assets, "credits", panel_rect.x + 202.0, panel_rect.y + 46.0, text_color);
         const visible_count = state.line_end_index - state.line_start_index;
         if (visible_count > 0) {
-            const base_y = credits_panel_rect.y + 60.0;
+            const base_y = panel_rect.y + 60.0;
             const frac_px = creditsScrollFractionPx(state.scroll_time_s);
-            const center_x = credits_panel_rect.x + 198.0 + 140.0;
+            const center_x = panel_rect.x + 198.0 + 140.0;
             var row: i32 = 0;
             while (row < visible_count) : (row += 1) {
                 const index = state.line_start_index + row;
@@ -563,7 +580,7 @@ fn drawCredits(state: *const CreditsScreen, runtime_assets: ?*const window_asset
                 window_ui.drawSmallText(assets, line.text, x, y, color);
             }
         }
-        const back = backOnlyButton()[0];
+        const back = backOnlyButton(panel_rect)[0];
         const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
         window_ui.drawButton(back, false, hovered, assets);
         return;
@@ -576,11 +593,12 @@ fn drawHighScoreMainPanel(
     assets: *const window_assets.RuntimeAssets,
     config: formats.crimson_cfg.CrimsonCfg,
     status: formats.game_cfg.Status,
+    left_rect: rl.Rectangle,
 ) void {
     const title = highScoreTitle(state.mode);
     const title_x: f32 = if (state.mode == .survival) 266.0 else 269.0;
-    window_ui.drawSmallText(assets, title, left_panel_rect.x + title_x, left_panel_rect.y + 41.0, text_color);
-    drawUnderline(left_panel_rect.x + title_x, left_panel_rect.y + 55.0, window_ui.measureSmallText(assets, title));
+    window_ui.drawSmallText(assets, title, left_rect.x + title_x, left_rect.y + 41.0, text_color);
+    drawUnderline(left_rect.x + title_x, left_rect.y + 55.0, window_ui.measureSmallText(assets, title));
 
     if (state.mode == .quests) {
         var quest_buf: [96]u8 = undefined;
@@ -590,24 +608,24 @@ fn drawHighScoreMainPanel(
             @mod(state.quest_level_key, 100),
             quest_title,
         }) catch "Quest";
-        window_ui.drawSmallText(assets, quest_label, left_panel_rect.x + 236.0, left_panel_rect.y + 63.0, if (config.hardcore_flag != 0) rl.Color.init(250, 70, 60, 180) else value_color);
-        drawQuestArrows(assets, state.quest_level_key, config.hardcore_flag != 0, status);
+        window_ui.drawSmallText(assets, quest_label, left_rect.x + 236.0, left_rect.y + 63.0, if (config.hardcore_flag != 0) rl.Color.init(250, 70, 60, 180) else value_color);
+        drawQuestArrows(assets, state.quest_level_key, config.hardcore_flag != 0, status, left_rect);
     }
 
-    window_ui.drawSmallText(assets, "Rank", left_panel_rect.x + 211.0, left_panel_rect.y + 84.0, text_color);
-    window_ui.drawSmallText(assets, "Score", left_panel_rect.x + 246.0, left_panel_rect.y + 84.0, text_color);
-    window_ui.drawSmallText(assets, "Player", left_panel_rect.x + 302.0, left_panel_rect.y + 84.0, text_color);
+    window_ui.drawSmallText(assets, "Rank", left_rect.x + 211.0, left_rect.y + 84.0, text_color);
+    window_ui.drawSmallText(assets, "Score", left_rect.x + 246.0, left_rect.y + 84.0, text_color);
+    window_ui.drawSmallText(assets, "Player", left_rect.x + 302.0, left_rect.y + 84.0, text_color);
 
-    const frame = scoreFrameRect();
+    const frame = scoreFrameRect(left_rect);
     rl.drawRectangle(@intFromFloat(frame.x), @intFromFloat(frame.y), @intFromFloat(frame.width), @intFromFloat(frame.height), rl.Color.white);
     rl.drawRectangle(@intFromFloat(frame.x + 1.0), @intFromFloat(frame.y + 1.0), @intFromFloat(frame.width - 2.0), @intFromFloat(frame.height - 2.0), rl.Color.black);
 
     if (state.load_error) |load_error| {
         window_ui.drawSmallText(assets, load_error, frame.x + 8.0, frame.y + 8.0, rl.Color.orange);
     } else if (state.records.len == 0) {
-        window_ui.drawSmallText(assets, "No scores yet.", left_panel_rect.x + 211.0, frame.y + 8.0, muted_text);
+        window_ui.drawSmallText(assets, "No scores yet.", left_rect.x + 211.0, frame.y + 8.0, muted_text);
     } else {
-        const hovered_rank = hoveredHighScoreRank(state);
+        const hovered_rank = hoveredHighScoreRank(state, left_rect);
         const start = @min(state.scroll, if (state.records.len > 10) state.records.len - 10 else 0);
         const end = @min(start + 10, state.records.len);
         for (state.records[start..end], 0..) |record, row| {
@@ -615,13 +633,13 @@ fn drawHighScoreMainPanel(
             const color = if (hovered_rank != null and hovered_rank.? == idx) text_color else muted_text;
             var value_buf: [32]u8 = undefined;
             const y = frame.y + 8.0 + @as(f32, @floatFromInt(row)) * 16.0;
-            window_ui.drawSmallTextFmt("{d}", assets, .{idx + 1}, left_panel_rect.x + 216.0, y, color);
-            window_ui.drawSmallText(assets, formatHighScoreValue(&value_buf, record), left_panel_rect.x + 246.0, y, color);
-            window_ui.drawSmallText(assets, clippedRecordName(record), left_panel_rect.x + 304.0, y, color);
+            window_ui.drawSmallTextFmt("{d}", assets, .{idx + 1}, left_rect.x + 216.0, y, color);
+            window_ui.drawSmallText(assets, formatHighScoreValue(&value_buf, record), left_rect.x + 246.0, y, color);
+            window_ui.drawSmallText(assets, clippedRecordName(record), left_rect.x + 304.0, y, color);
         }
     }
 
-    const buttons = highScoreButtons();
+    const buttons = highScoreButtons(left_rect);
     for (buttons, 0..) |button, idx| {
         const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
         window_ui.drawButton(button, idx == state.button_selection, hovered, assets);
@@ -633,21 +651,23 @@ fn drawHighScoreRightPanel(
     assets: *const window_assets.RuntimeAssets,
     config: formats.crimson_cfg.CrimsonCfg,
     status: formats.game_cfg.Status,
+    left_rect: rl.Rectangle,
+    right_rect: rl.Rectangle,
 ) void {
-    if (hoveredHighScoreRank(state)) |rank| {
+    if (hoveredHighScoreRank(state, left_rect)) |rank| {
         if (rank < state.records.len) {
-            drawHighScoreLocalDetails(assets, state.records[rank], rank);
+            drawHighScoreLocalDetails(assets, state.records[rank], rank, right_rect);
             return;
         }
     }
 
     const check_tex = if (config.score_load_gate != 0) assets.texture(.ui_check_on) else assets.texture(.ui_check_off);
-    window_ui.drawTextureFit(check_tex, rl.Rectangle.init(right_panel_rect.x + 44.0, right_panel_rect.y + 44.0, @floatFromInt(check_tex.width), @floatFromInt(check_tex.height)), rl.Color.white);
-    window_ui.drawSmallText(assets, "Show internet scores", right_panel_rect.x + 66.0, right_panel_rect.y + 45.0, text_color);
-    window_ui.drawSmallText(assets, "Number of players", right_panel_rect.x + 46.0, right_panel_rect.y + 64.0, text_color);
-    window_ui.drawSmallText(assets, "Game mode", right_panel_rect.x + 174.0, right_panel_rect.y + 64.0, text_color);
-    window_ui.drawSmallText(assets, "Show scores:", right_panel_rect.x + 44.0, right_panel_rect.y + 106.0, text_color);
-    window_ui.drawSmallText(assets, "Selected score list:", right_panel_rect.x + 44.0, right_panel_rect.y + 150.0, text_color);
+    window_ui.drawTextureFit(check_tex, rl.Rectangle.init(right_rect.x + 44.0, right_rect.y + 44.0, @floatFromInt(check_tex.width), @floatFromInt(check_tex.height)), rl.Color.white);
+    window_ui.drawSmallText(assets, "Show internet scores", right_rect.x + 66.0, right_rect.y + 45.0, text_color);
+    window_ui.drawSmallText(assets, "Number of players", right_rect.x + 46.0, right_rect.y + 64.0, text_color);
+    window_ui.drawSmallText(assets, "Game mode", right_rect.x + 174.0, right_rect.y + 64.0, text_color);
+    window_ui.drawSmallText(assets, "Show scores:", right_rect.x + 44.0, right_rect.y + 106.0, text_color);
+    window_ui.drawSmallText(assets, "Selected score list:", right_rect.x + 44.0, right_rect.y + 150.0, text_color);
 
     var mode_labels_buf: [4][]const u8 = undefined;
     const mode_labels = highScoreModeLabels(&mode_labels_buf, status);
@@ -661,25 +681,25 @@ fn drawHighScoreRightPanel(
     }{
         .{
             .kind = .player_count,
-            .rect = playerCountWidgetRect(),
+            .rect = playerCountWidgetRect(right_rect),
             .items = playerCountLabels()[0..],
             .selected = @as(usize, @intCast(std.math.clamp(config.player_count, @as(u32, 1), @as(u32, 4)))) - 1,
         },
         .{
             .kind = .game_mode,
-            .rect = gameModeWidgetRect(),
+            .rect = gameModeWidgetRect(right_rect),
             .items = mode_labels,
             .selected = highScoreModeLabelIndex(state.mode, status),
         },
         .{
             .kind = .date_mode,
-            .rect = dateModeWidgetRect(),
+            .rect = dateModeWidgetRect(right_rect),
             .items = scoreDateModeLabels()[0..],
             .selected = @min(config.highscore_date_mode, 3),
         },
         .{
             .kind = .score_list,
-            .rect = scoreListWidgetRect(),
+            .rect = scoreListWidgetRect(right_rect),
             .items = saved_names[0..],
             .selected = formats.crimson_cfg.selectedSavedNameSlot(&config),
         },
@@ -699,43 +719,45 @@ fn drawWeaponsPanels(
     assets: *const window_assets.RuntimeAssets,
     config: formats.crimson_cfg.CrimsonCfg,
     status: formats.game_cfg.Status,
+    left_rect: rl.Rectangle,
+    right_rect: rl.Rectangle,
 ) void {
     const title = "Unlocked Weapons Database";
-    window_ui.drawSmallText(assets, title, left_panel_rect.x + 251.0, left_panel_rect.y + 50.0, text_color);
-    drawUnderline(left_panel_rect.x + 251.0, left_panel_rect.y + 63.0, window_ui.measureSmallText(assets, title));
+    window_ui.drawSmallText(assets, title, left_rect.x + 251.0, left_rect.y + 50.0, text_color);
+    drawUnderline(left_rect.x + 251.0, left_rect.y + 63.0, window_ui.measureSmallText(assets, title));
 
     var weapon_ids: [state_mod.weapon_count_size]game_ids.WeaponId = undefined;
     const total = buildWeaponList(&weapon_ids, config, status);
     const weapon_label = if (total == 1) "weapon" else "weapons";
-    window_ui.drawSmallTextFmt("{d} {s} in database", assets, .{ total, weapon_label }, left_panel_rect.x + 210.0, left_panel_rect.y + 80.0, muted_text);
-    window_ui.drawSmallText(assets, "Weapon", left_panel_rect.x + 210.0, left_panel_rect.y + 108.0, text_color);
-    drawListFrame(weaponListRect());
+    window_ui.drawSmallTextFmt("{d} {s} in database", assets, .{ total, weapon_label }, left_rect.x + 210.0, left_rect.y + 80.0, muted_text);
+    window_ui.drawSmallText(assets, "Weapon", left_rect.x + 210.0, left_rect.y + 108.0, text_color);
+    drawListFrame(weaponListRect(left_rect));
 
     const start = @min(state.scroll, if (total > 10) total - 10 else 0);
     const end = @min(start + 10, total);
     for (weapon_ids[start..end], 0..) |weapon_id, row| {
         const list_index = start + row;
         const color = if (list_index == state.selection) text_color else muted_text;
-        window_ui.drawSmallText(assets, game_ids.weaponDisplayName(weapon_id, false), left_panel_rect.x + 218.0, left_panel_rect.y + 130.0 + @as(f32, @floatFromInt(row)) * 16.0, color);
+        window_ui.drawSmallText(assets, game_ids.weaponDisplayName(weapon_id, false), left_rect.x + 218.0, left_rect.y + 130.0 + @as(f32, @floatFromInt(row)) * 16.0, color);
     }
 
-    const back = weaponBackButton()[0];
+    const back = weaponBackButton(left_rect)[0];
     const back_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
     window_ui.drawButton(back, false, back_hovered, assets);
 
     if (total == 0) return;
     const weapon_id = weapon_ids[@min(state.selection, total - 1)];
-    const detail_x = right_panel_rect.x;
-    window_ui.drawSmallTextFmt("weapon #{d}", assets, .{@intFromEnum(weapon_id)}, detail_x + 240.0, right_panel_rect.y + 32.0, muted_text);
+    const detail_x = right_rect.x;
+    window_ui.drawSmallTextFmt("weapon #{d}", assets, .{@intFromEnum(weapon_id)}, detail_x + 240.0, right_rect.y + 32.0, muted_text);
     const name = game_ids.weaponDisplayName(weapon_id, false);
-    window_ui.drawSmallText(assets, name, detail_x + 50.0, right_panel_rect.y + 50.0, text_color);
+    window_ui.drawSmallText(assets, name, detail_x + 50.0, right_rect.y + 50.0, text_color);
     const icon_index = weapon_data.weaponIconIndex(weapon_id);
     if (icon_index >= 0) {
         const src_rect = window_atlas.weaponIconRect(assets.texture(.ui_wicons).width, assets.texture(.ui_wicons).height, icon_index);
         rl.drawTexturePro(
             assets.texture(.ui_wicons),
             rl.Rectangle.init(src_rect.x, src_rect.y, src_rect.width, src_rect.height),
-            rl.Rectangle.init(detail_x + 82.0, right_panel_rect.y + 82.0, 64.0, 32.0),
+            rl.Rectangle.init(detail_x + 82.0, right_rect.y + 82.0, 64.0, 32.0),
             rl.Vector2.zero(),
             0.0,
             rl.Color.white,
@@ -748,11 +770,11 @@ fn drawWeaponsPanels(
         "Fire rate: n/a"
     else
         std.fmt.bufPrint(&fire_rate_buf, "Fire rate: {d} rpm", .{@as(i32, @intFromFloat(60.0 / stats_entry.shot_cooldown))}) catch "Fire rate: ?";
-    window_ui.drawSmallText(assets, fire_rate_text, detail_x + 66.0, right_panel_rect.y + 128.0, text_color);
+    window_ui.drawSmallText(assets, fire_rate_text, detail_x + 66.0, right_rect.y + 128.0, text_color);
     var reload_buf: [64]u8 = undefined;
     const reload_text = std.fmt.bufPrint(&reload_buf, "Reload time: {d:.1} secs", .{stats_entry.reload_time}) catch "Reload time: ?";
-    window_ui.drawSmallText(assets, reload_text, detail_x + 66.0, right_panel_rect.y + 146.0, text_color);
-    window_ui.drawSmallTextFmt("Clip size: {d}", assets, .{stats_entry.clip_size}, detail_x + 66.0, right_panel_rect.y + 164.0, text_color);
+    window_ui.drawSmallText(assets, reload_text, detail_x + 66.0, right_rect.y + 146.0, text_color);
+    window_ui.drawSmallTextFmt("Clip size: {d}", assets, .{stats_entry.clip_size}, detail_x + 66.0, right_rect.y + 164.0, text_color);
 }
 
 fn drawPerksPanels(
@@ -762,18 +784,20 @@ fn drawPerksPanels(
     violence_disabled: u8,
     hardcore: bool,
     preserve_bugs: bool,
+    left_rect: rl.Rectangle,
+    right_rect: rl.Rectangle,
 ) void {
     _ = hardcore;
     const title = "Unlocked Perks Database";
-    window_ui.drawSmallText(assets, title, left_panel_rect.x + 261.0, left_panel_rect.y + 50.0, text_color);
-    drawUnderline(left_panel_rect.x + 261.0, left_panel_rect.y + 63.0, window_ui.measureSmallText(assets, title));
+    window_ui.drawSmallText(assets, title, left_rect.x + 261.0, left_rect.y + 50.0, text_color);
+    drawUnderline(left_rect.x + 261.0, left_rect.y + 63.0, window_ui.measureSmallText(assets, title));
 
     var perk_ids: [state_mod.perk_count_size]game_ids.PerkId = undefined;
     const total = buildPerkList(&perk_ids, status);
     const perk_label = if (total == 1) "perk" else "perks";
-    window_ui.drawSmallTextFmt("{d} {s} in database", assets, .{ total, perk_label }, left_panel_rect.x + 210.0, left_panel_rect.y + 78.0, muted_text);
-    window_ui.drawSmallText(assets, "Perks", left_panel_rect.x + 210.0, left_panel_rect.y + 106.0, text_color);
-    drawListFrame(perkListRect());
+    window_ui.drawSmallTextFmt("{d} {s} in database", assets, .{ total, perk_label }, left_rect.x + 210.0, left_rect.y + 78.0, muted_text);
+    window_ui.drawSmallText(assets, "Perks", left_rect.x + 210.0, left_rect.y + 106.0, text_color);
+    drawListFrame(perkListRect(left_rect));
 
     const start = @min(state.scroll, if (total > 10) total - 10 else 0);
     const end = @min(start + 10, total);
@@ -783,29 +807,29 @@ fn drawPerksPanels(
         window_ui.drawSmallText(
             assets,
             game_ids.perkDisplayName(perk_id, violence_disabled, preserve_bugs),
-            left_panel_rect.x + 218.0,
-            left_panel_rect.y + 128.0 + @as(f32, @floatFromInt(row)) * 16.0,
+            left_rect.x + 218.0,
+            left_rect.y + 128.0 + @as(f32, @floatFromInt(row)) * 16.0,
             rl.Color.init(255, 255, 255, @intFromFloat(255.0 * alpha)),
         );
     }
-    if (total > 10) drawPerkScrollbar(total, start);
+    if (total > 10) drawPerkScrollbar(total, start, left_rect);
 
-    const back = perkBackButton()[0];
+    const back = perkBackButton(left_rect)[0];
     const back_hovered = rl.checkCollisionPointRec(rl.getMousePosition(), back.rect);
     window_ui.drawButton(back, false, back_hovered, assets);
 
     if (total == 0) return;
     const detail_index = @min(state.hovered orelse state.selection, total - 1);
     const perk_id = perk_ids[detail_index];
-    const detail_x = right_panel_rect.x + 34.0;
-    window_ui.drawSmallTextFmt("perk #{d}", assets, .{@intFromEnum(perk_id)}, detail_x + 190.0, right_panel_rect.y + 32.0, muted_text);
+    const detail_x = right_rect.x + 34.0;
+    window_ui.drawSmallTextFmt("perk #{d}", assets, .{@intFromEnum(perk_id)}, detail_x + 190.0, right_rect.y + 32.0, muted_text);
     const name = game_ids.perkDisplayName(perk_id, violence_disabled, preserve_bugs);
     const name_width = window_ui.measureSmallText(assets, name);
     const name_x = detail_x + 128.0 - name_width * 0.5;
-    window_ui.drawSmallText(assets, name, name_x, right_panel_rect.y + 50.0, text_color);
-    drawUnderline(name_x, right_panel_rect.y + 63.0, name_width);
+    window_ui.drawSmallText(assets, name, name_x, right_rect.y + 50.0, text_color);
+    drawUnderline(name_x, right_rect.y + 63.0, name_width);
 
-    var y = right_panel_rect.y + 72.0;
+    var y = right_rect.y + 72.0;
     if (window_statistics_data.perkPrerequisite(perk_id)) |prereq| {
         var req_buf: [128]u8 = undefined;
         const req_text = std.fmt.bufPrint(&req_buf, "Requires: {s}", .{game_ids.perkDisplayName(prereq, violence_disabled, preserve_bugs)}) catch "Requires: ?";
@@ -815,24 +839,40 @@ fn drawPerksPanels(
     drawWrappedSmallText(assets, window_statistics_data.perkDescription(perk_id), detail_x + 16.0, y, 256.0, muted_text);
 }
 
-fn drawSplitPanelShell(assets: *const window_assets.RuntimeAssets) void {
+fn animatedCenterPanelRect(rect: rl.Rectangle, timeline_ms: i32) rl.Rectangle {
+    const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
+    return rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
+}
+
+fn animatedLeftPanelRect(rect: rl.Rectangle, timeline_ms: i32) rl.Rectangle {
+    const anim = window_menu.uiElementAnim(1, panel_timeline_max_ms, 0, rect.width, timeline_ms);
+    return rl.Rectangle.init(rect.x + anim.offset_x, rect.y, rect.width, rect.height);
+}
+
+fn animatedRightPanelRect(rect: rl.Rectangle, timeline_ms: i32) rl.Rectangle {
+    const anim = window_menu.uiElementAnim(2, panel_timeline_max_ms, 0, rect.width, timeline_ms);
+    return rl.Rectangle.init(rect.x - anim.offset_x, rect.y, rect.width, rect.height);
+}
+
+fn drawSplitPanelShell(assets: *const window_assets.RuntimeAssets, timeline_ms: i32) void {
     window_menu.drawMenuBackdrop(assets);
-    window_menu.drawSign(panel_timeline_max_ms, assets);
-    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), left_panel_rect, rl.Color.white, false);
-    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), right_panel_rect, rl.Color.white, true);
+    window_menu.drawSign(timeline_ms, assets);
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), animatedLeftPanelRect(left_panel_rect, timeline_ms), rl.Color.white, false);
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), animatedRightPanelRect(right_panel_rect, timeline_ms), rl.Color.white, true);
 }
 
 fn drawPanelShell(timeline_ms: i32, assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle, label_row: i32) void {
     window_menu.drawMenuBackdrop(assets);
     window_menu.drawSign(timeline_ms, assets);
-    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), rect, rl.Color.white, false);
-    window_menu.drawAtlasLabelCentered(assets, label_row, rect.y + 42.0, rl.Color.white);
+    const panel_rect = animatedCenterPanelRect(rect, timeline_ms);
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), panel_rect, rl.Color.white, false);
+    window_menu.drawAtlasLabelCentered(assets, label_row, panel_rect.y + 42.0, rl.Color.white);
 }
 
 fn drawPanelShellNoTitle(timeline_ms: i32, assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle) void {
     window_menu.drawMenuBackdrop(assets);
     window_menu.drawSign(timeline_ms, assets);
-    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), rect, rl.Color.white, false);
+    window_ui.drawClassicMenuPanel(assets.texture(.ui_menu_panel), animatedCenterPanelRect(rect, timeline_ms), rl.Color.white, false);
 }
 
 fn drawAtlasTitle(assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle, rel_x: f32, rel_y: f32, row: i32) void {
@@ -847,52 +887,52 @@ fn drawAtlasTitle(assets: *const window_assets.RuntimeAssets, rect: rl.Rectangle
     );
 }
 
-fn hubButtons() [5]window_ui.UiButton {
+fn hubButtons(panel_rect: rl.Rectangle) [5]window_ui.UiButton {
     return .{
-        window_ui.buttonAt("High scores", stats_panel_rect.x + 270.0, stats_panel_rect.y + 104.0, true),
-        window_ui.buttonAt("Weapons", stats_panel_rect.x + 270.0, stats_panel_rect.y + 138.0, true),
-        window_ui.buttonAt("Perks", stats_panel_rect.x + 270.0, stats_panel_rect.y + 172.0, true),
-        window_ui.buttonAt("Credits", stats_panel_rect.x + 270.0, stats_panel_rect.y + 206.0, true),
-        window_ui.buttonAt("Back", stats_panel_rect.x + 394.0, stats_panel_rect.y + 290.0, false),
+        window_ui.buttonAt("High scores", panel_rect.x + 270.0, panel_rect.y + 104.0, true),
+        window_ui.buttonAt("Weapons", panel_rect.x + 270.0, panel_rect.y + 138.0, true),
+        window_ui.buttonAt("Perks", panel_rect.x + 270.0, panel_rect.y + 172.0, true),
+        window_ui.buttonAt("Credits", panel_rect.x + 270.0, panel_rect.y + 206.0, true),
+        window_ui.buttonAt("Back", panel_rect.x + 394.0, panel_rect.y + 290.0, false),
     };
 }
 
-fn highScoreButtons() [3]window_ui.UiButton {
+fn highScoreButtons(left_rect: rl.Rectangle) [3]window_ui.UiButton {
     return .{
-        window_ui.buttonAt("Update scores", left_panel_rect.x + 234.0, left_panel_rect.y + 268.0, true),
-        window_ui.buttonAt("Play a game", left_panel_rect.x + 234.0, left_panel_rect.y + 301.0, true),
-        window_ui.buttonAt("Back", left_panel_rect.x + 400.0, left_panel_rect.y + 301.0, false),
+        window_ui.buttonAt("Update scores", left_rect.x + 234.0, left_rect.y + 268.0, true),
+        window_ui.buttonAt("Play a game", left_rect.x + 234.0, left_rect.y + 301.0, true),
+        window_ui.buttonAt("Back", left_rect.x + 400.0, left_rect.y + 301.0, false),
     };
 }
 
-fn backOnlyButton() [1]window_ui.UiButton {
+fn backOnlyButton(panel_rect: rl.Rectangle) [1]window_ui.UiButton {
     return .{
-        window_ui.buttonAt("Back", credits_panel_rect.x + 298.0, credits_panel_rect.y + 310.0, false),
+        window_ui.buttonAt("Back", panel_rect.x + 298.0, panel_rect.y + 310.0, false),
     };
 }
 
-fn weaponBackButton() [1]window_ui.UiButton {
+fn weaponBackButton(left_rect: rl.Rectangle) [1]window_ui.UiButton {
     return .{
-        window_ui.buttonAt("Back", left_panel_rect.x + 368.0, left_panel_rect.y + 313.0, false),
+        window_ui.buttonAt("Back", left_rect.x + 368.0, left_rect.y + 313.0, false),
     };
 }
 
-fn perkBackButton() [1]window_ui.UiButton {
+fn perkBackButton(left_rect: rl.Rectangle) [1]window_ui.UiButton {
     return .{
-        window_ui.buttonAt("Back", left_panel_rect.x + 356.0, left_panel_rect.y + 315.0, false),
+        window_ui.buttonAt("Back", left_rect.x + 356.0, left_rect.y + 315.0, false),
     };
 }
 
-fn scoreFrameRect() rl.Rectangle {
-    return rl.Rectangle.init(left_panel_rect.x + 210.0, left_panel_rect.y + 101.0, 250.0, 164.0);
+fn scoreFrameRect(left_rect: rl.Rectangle) rl.Rectangle {
+    return rl.Rectangle.init(left_rect.x + 210.0, left_rect.y + 101.0, 250.0, 164.0);
 }
 
-fn weaponListRect() rl.Rectangle {
-    return rl.Rectangle.init(left_panel_rect.x + 212.0, left_panel_rect.y + 128.0, 250.0, 164.0);
+fn weaponListRect(left_rect: rl.Rectangle) rl.Rectangle {
+    return rl.Rectangle.init(left_rect.x + 212.0, left_rect.y + 128.0, 250.0, 164.0);
 }
 
-fn perkListRect() rl.Rectangle {
-    return rl.Rectangle.init(left_panel_rect.x + 212.0, left_panel_rect.y + 126.0, 250.0, 164.0);
+fn perkListRect(left_rect: rl.Rectangle) rl.Rectangle {
+    return rl.Rectangle.init(left_rect.x + 212.0, left_rect.y + 126.0, 250.0, 164.0);
 }
 
 fn drawListFrame(rect: rl.Rectangle) void {
@@ -900,9 +940,9 @@ fn drawListFrame(rect: rl.Rectangle) void {
     rl.drawRectangle(@intFromFloat(rect.x + 1.0), @intFromFloat(rect.y + 1.0), @intFromFloat(rect.width - 2.0), @intFromFloat(rect.height - 2.0), rl.Color.black);
 }
 
-fn drawPerkScrollbar(total: usize, start: usize) void {
-    const track_x = left_panel_rect.x + 452.0;
-    const track_y = left_panel_rect.y + 126.0;
+fn drawPerkScrollbar(total: usize, start: usize, left_rect: rl.Rectangle) void {
+    const track_x = left_rect.x + 452.0;
+    const track_y = left_rect.y + 126.0;
     const track_h = 164.0;
     const scroll_span = @max(total, 10) - 10;
     const thumb_h = @min((10.0 / @as(f32, @floatFromInt(total))) * track_h, track_h - 3.0);
@@ -1073,14 +1113,14 @@ fn buildCreditsLines(screen: *CreditsScreen) void {
     while (index < 0x7E) : (index += 1) setLine(screen, index, "", 0);
 }
 
-fn updateCreditsLineClicks(screen: *CreditsScreen, assets: *const window_assets.RuntimeAssets, mouse: rl.Vector2, click: bool) void {
+fn updateCreditsLineClicks(screen: *CreditsScreen, assets: *const window_assets.RuntimeAssets, panel_rect: rl.Rectangle, mouse: rl.Vector2, click: bool) void {
     if (!click) return;
     const visible_count = screen.line_end_index - screen.line_start_index;
     if (visible_count <= 0) return;
 
-    const base_y = credits_panel_rect.y + 60.0;
+    const base_y = panel_rect.y + 60.0;
     const frac_px = creditsScrollFractionPx(screen.scroll_time_s);
-    const center_x = credits_panel_rect.x + 198.0 + 140.0;
+    const center_x = panel_rect.x + 198.0 + 140.0;
     var row: i32 = 0;
     while (row < visible_count) : (row += 1) {
         const index = screen.line_start_index + row;
@@ -1179,25 +1219,25 @@ fn drawDropdown(
     }
 }
 
-fn playerCountWidgetRect() rl.Rectangle {
-    return rl.Rectangle.init(right_panel_rect.x + 46.0, right_panel_rect.y + 78.0, 102.0, 16.0);
+fn playerCountWidgetRect(right_rect: rl.Rectangle) rl.Rectangle {
+    return rl.Rectangle.init(right_rect.x + 46.0, right_rect.y + 78.0, 102.0, 16.0);
 }
 
-fn gameModeWidgetRect() rl.Rectangle {
-    return rl.Rectangle.init(right_panel_rect.x + 174.0, right_panel_rect.y + 78.0, 95.0, 16.0);
+fn gameModeWidgetRect(right_rect: rl.Rectangle) rl.Rectangle {
+    return rl.Rectangle.init(right_rect.x + 174.0, right_rect.y + 78.0, 95.0, 16.0);
 }
 
-fn dateModeWidgetRect() rl.Rectangle {
-    return rl.Rectangle.init(right_panel_rect.x + 44.0, right_panel_rect.y + 120.0, 134.0, 16.0);
+fn dateModeWidgetRect(right_rect: rl.Rectangle) rl.Rectangle {
+    return rl.Rectangle.init(right_rect.x + 44.0, right_rect.y + 120.0, 134.0, 16.0);
 }
 
-fn scoreListWidgetRect() rl.Rectangle {
-    return rl.Rectangle.init(right_panel_rect.x + 44.0, right_panel_rect.y + 164.0, 174.0, 16.0);
+fn scoreListWidgetRect(right_rect: rl.Rectangle) rl.Rectangle {
+    return rl.Rectangle.init(right_rect.x + 44.0, right_rect.y + 164.0, 174.0, 16.0);
 }
 
-fn hoveredHighScoreRank(state: *const HighScoresScreen) ?usize {
+fn hoveredHighScoreRank(state: *const HighScoresScreen, left_rect: rl.Rectangle) ?usize {
     const mouse = rl.getMousePosition();
-    const frame = scoreFrameRect();
+    const frame = scoreFrameRect(left_rect);
     if (!rectContains(frame, mouse)) return null;
     const row = @as(usize, @intFromFloat((mouse.y - (frame.y + 8.0)) / 16.0));
     if (row >= 10) return null;
@@ -1215,27 +1255,27 @@ fn hoveredListRow(rect: rl.Rectangle, total: usize, scroll: usize) ?usize {
     return scroll + row;
 }
 
-fn drawHighScoreLocalDetails(assets: *const window_assets.RuntimeAssets, record: persistence.highscores.HighScoreRecord, rank: usize) void {
-    const detail_x = right_panel_rect.x + 78.0;
+fn drawHighScoreLocalDetails(assets: *const window_assets.RuntimeAssets, record: persistence.highscores.HighScoreRecord, rank: usize, right_rect: rl.Rectangle) void {
+    const detail_x = right_rect.x + 78.0;
     const mode = record.gameModeId() orelse .survival;
     const local_text = rl.Color.init(229, 229, 229, 204);
     const value_text = rl.Color.init(229, 229, 255, 255);
     const lower_text = rl.Color.init(229, 229, 229, 178);
     const separator = rl.Color.init(149, 175, 198, 178);
 
-    window_ui.drawSmallText(assets, clippedRecordName(record), detail_x, right_panel_rect.y + 44.0, local_text);
-    window_ui.drawSmallText(assets, "Local score", detail_x, right_panel_rect.y + 58.0, local_text);
-    rl.drawLine(@intFromFloat(right_panel_rect.x + 78.0), @intFromFloat(right_panel_rect.y + 57.0), @intFromFloat(right_panel_rect.x + 117.0), @intFromFloat(right_panel_rect.y + 57.0), separator);
+    window_ui.drawSmallText(assets, clippedRecordName(record), detail_x, right_rect.y + 44.0, local_text);
+    window_ui.drawSmallText(assets, "Local score", detail_x, right_rect.y + 58.0, local_text);
+    rl.drawLine(@intFromFloat(right_rect.x + 78.0), @intFromFloat(right_rect.y + 57.0), @intFromFloat(right_rect.x + 117.0), @intFromFloat(right_rect.y + 57.0), separator);
     var date_buf: [64]u8 = undefined;
     if (formatRecordDateBuf(&date_buf, record)) |date| {
         const date_w = window_ui.measureSmallText(assets, date);
-        window_ui.drawSmallText(assets, date, right_panel_rect.x + 230.0 - date_w * 0.5, right_panel_rect.y + 72.0, local_text);
+        window_ui.drawSmallText(assets, date, right_rect.x + 230.0 - date_w * 0.5, right_rect.y + 72.0, local_text);
     }
-    rl.drawLine(@intFromFloat(right_panel_rect.x + 74.0), @intFromFloat(right_panel_rect.y + 72.0), @intFromFloat(right_panel_rect.x + 266.0), @intFromFloat(right_panel_rect.y + 72.0), separator);
-    window_ui.drawSmallText(assets, "Score", detail_x + 27.0, right_panel_rect.y + 90.0, local_text);
+    rl.drawLine(@intFromFloat(right_rect.x + 74.0), @intFromFloat(right_rect.y + 72.0), @intFromFloat(right_rect.x + 266.0), @intFromFloat(right_rect.y + 72.0), separator);
+    window_ui.drawSmallText(assets, "Score", detail_x + 27.0, right_rect.y + 90.0, local_text);
     const time_label = if (mode == .quests) "Experience" else "Game time";
-    window_ui.drawSmallText(assets, time_label, detail_x + 114.0, right_panel_rect.y + 90.0, local_text);
-    rl.drawLine(@intFromFloat(right_panel_rect.x + 170.0), @intFromFloat(right_panel_rect.y + 90.0), @intFromFloat(right_panel_rect.x + 170.0), @intFromFloat(right_panel_rect.y + 138.0), separator);
+    window_ui.drawSmallText(assets, time_label, detail_x + 114.0, right_rect.y + 90.0, local_text);
+    rl.drawLine(@intFromFloat(right_rect.x + 170.0), @intFromFloat(right_rect.y + 90.0), @intFromFloat(right_rect.x + 170.0), @intFromFloat(right_rect.y + 138.0), separator);
 
     switch (mode) {
         .rush, .quests => {
@@ -1243,41 +1283,41 @@ fn drawHighScoreLocalDetails(assets: *const window_assets.RuntimeAssets, record:
             const score_text = std.fmt.bufPrint(&score_buf, "{d:.2} secs", .{@as(f32, @floatFromInt(record.survivalElapsedMs())) * 0.001}) catch "0.00 secs";
             const label_center_x = detail_x + 27.0 + window_ui.measureSmallText(assets, "Score") * 0.5;
             const score_w = window_ui.measureSmallText(assets, score_text);
-            window_ui.drawSmallText(assets, score_text, label_center_x - score_w * 0.5, right_panel_rect.y + 105.0, value_text);
-            window_ui.drawSmallTextFmt("{d}", assets, .{record.scoreXp()}, detail_x + 148.0, right_panel_rect.y + 109.0, local_text);
+            window_ui.drawSmallText(assets, score_text, label_center_x - score_w * 0.5, right_rect.y + 105.0, value_text);
+            window_ui.drawSmallTextFmt("{d}", assets, .{record.scoreXp()}, detail_x + 148.0, right_rect.y + 109.0, local_text);
         },
         .survival, .typo, .tutorial => {
-            window_ui.drawSmallTextFmt("{d}", assets, .{record.scoreXp()}, detail_x + 27.0, right_panel_rect.y + 105.0, value_text);
-            drawClockGauge(assets, record.survivalElapsedMs(), right_panel_rect.x + 194.0, right_panel_rect.y + 103.0);
+            window_ui.drawSmallTextFmt("{d}", assets, .{record.scoreXp()}, detail_x + 27.0, right_rect.y + 105.0, value_text);
+            drawClockGauge(assets, record.survivalElapsedMs(), right_rect.x + 194.0, right_rect.y + 103.0);
             var time_buf: [32]u8 = undefined;
-            window_ui.drawSmallText(assets, formatElapsedMmSsBuf(&time_buf, record.survivalElapsedMs()), detail_x + 148.0, right_panel_rect.y + 109.0, local_text);
+            window_ui.drawSmallText(assets, formatElapsedMmSsBuf(&time_buf, record.survivalElapsedMs()), detail_x + 148.0, right_rect.y + 109.0, local_text);
         },
     }
     var rank_buf: [32]u8 = undefined;
     var ordinal_buf: [16]u8 = undefined;
     const rank_text = std.fmt.bufPrint(&rank_buf, "Rank: {s}", .{ordinalBuf(&ordinal_buf, rank + 1)}) catch "Rank: ?";
-    window_ui.drawSmallText(assets, rank_text, detail_x + 16.0, right_panel_rect.y + 120.0, local_text);
+    window_ui.drawSmallText(assets, rank_text, detail_x + 16.0, right_rect.y + 120.0, local_text);
     const icon_index = weapon_data.weaponIconIndex(record.mostUsedWeaponId());
-    rl.drawLine(@intFromFloat(right_panel_rect.x + 74.0), @intFromFloat(right_panel_rect.y + 142.0), @intFromFloat(right_panel_rect.x + 266.0), @intFromFloat(right_panel_rect.y + 142.0), separator);
+    rl.drawLine(@intFromFloat(right_rect.x + 74.0), @intFromFloat(right_rect.y + 142.0), @intFromFloat(right_rect.x + 266.0), @intFromFloat(right_rect.y + 142.0), separator);
     if (icon_index >= 0) {
         const src_rect = window_atlas.weaponIconRect(assets.texture(.ui_wicons).width, assets.texture(.ui_wicons).height, icon_index);
         rl.drawTexturePro(
             assets.texture(.ui_wicons),
             rl.Rectangle.init(src_rect.x, src_rect.y, src_rect.width, src_rect.height),
-            rl.Rectangle.init(detail_x + 12.0, right_panel_rect.y + 146.0, 64.0, 32.0),
+            rl.Rectangle.init(detail_x + 12.0, right_rect.y + 146.0, 64.0, 32.0),
             rl.Vector2.zero(),
             0.0,
             rl.Color.white,
         );
     }
-    window_ui.drawSmallTextFmt("Frags: {d}", assets, .{record.creatureKillCount()}, detail_x + 122.0, right_panel_rect.y + 147.0, lower_text);
+    window_ui.drawSmallTextFmt("Frags: {d}", assets, .{record.creatureKillCount()}, detail_x + 122.0, right_rect.y + 147.0, lower_text);
     const shots_fired = record.shotsFired();
     const hit_pct: u32 = if (shots_fired == 0) 0 else @intCast(@divTrunc(record.shotsHit() * 100, shots_fired));
-    window_ui.drawSmallTextFmt("Hit %: {d}%", assets, .{hit_pct}, detail_x + 122.0, right_panel_rect.y + 161.0, lower_text);
+    window_ui.drawSmallTextFmt("Hit %: {d}%", assets, .{hit_pct}, detail_x + 122.0, right_rect.y + 161.0, lower_text);
     const weapon_name = game_ids.weaponDisplayName(record.mostUsedWeaponId(), false);
-    const weapon_name_x = right_panel_rect.x + 90.0 + @max(@as(f32, 0.0), 32.0 - window_ui.measureSmallText(assets, weapon_name) * 0.5);
-    window_ui.drawSmallText(assets, weapon_name, weapon_name_x, right_panel_rect.y + 178.0, lower_text);
-    rl.drawLine(@intFromFloat(right_panel_rect.x + 74.0), @intFromFloat(right_panel_rect.y + 194.0), @intFromFloat(right_panel_rect.x + 266.0), @intFromFloat(right_panel_rect.y + 194.0), separator);
+    const weapon_name_x = right_rect.x + 90.0 + @max(@as(f32, 0.0), 32.0 - window_ui.measureSmallText(assets, weapon_name) * 0.5);
+    window_ui.drawSmallText(assets, weapon_name, weapon_name_x, right_rect.y + 178.0, lower_text);
+    rl.drawLine(@intFromFloat(right_rect.x + 74.0), @intFromFloat(right_rect.y + 194.0), @intFromFloat(right_rect.x + 266.0), @intFromFloat(right_rect.y + 194.0), separator);
 }
 
 fn drawClockGauge(assets: *const window_assets.RuntimeAssets, elapsed_ms: u32, x: f32, y: f32) void {
@@ -1308,25 +1348,26 @@ fn updateHighScoreWidgets(
     base_dir: []const u8,
     config: *formats.crimson_cfg.CrimsonCfg,
     status: formats.game_cfg.Status,
+    right_rect: rl.Rectangle,
 ) ?UpdateResult {
     const mouse = rl.getMousePosition();
     const click = rl.isMouseButtonPressed(.left);
 
-    const internet_rect = rl.Rectangle.init(right_panel_rect.x + 44.0, right_panel_rect.y + 44.0, 180.0, 16.0);
+    const internet_rect = rl.Rectangle.init(right_rect.x + 44.0, right_rect.y + 44.0, 180.0, 16.0);
     if (click and state.dropdown_open == .none and rectContains(internet_rect, mouse)) {
         config.score_load_gate = if (config.score_load_gate == 0) 1 else 0;
         loadHighScores(state, allocator, base_dir, config.*, status);
         return .{ .config_dirty = true, .play_button_click = true };
     }
 
-    if (updateDropdownSelection(&state.dropdown_open, .player_count, playerCountWidgetRect(), playerCountLabels()[0..], click, mouse)) |selected| {
+    if (updateDropdownSelection(&state.dropdown_open, .player_count, playerCountWidgetRect(right_rect), playerCountLabels()[0..], click, mouse)) |selected| {
         config.player_count = @intCast(selected + 1);
         loadHighScores(state, allocator, base_dir, config.*, status);
         return .{ .config_dirty = true, .play_button_click = true };
     }
     var mode_labels_buf: [4][]const u8 = undefined;
     const mode_labels = highScoreModeLabels(&mode_labels_buf, status);
-    if (updateDropdownSelection(&state.dropdown_open, .game_mode, gameModeWidgetRect(), mode_labels, click, mouse)) |selected| {
+    if (updateDropdownSelection(&state.dropdown_open, .game_mode, gameModeWidgetRect(right_rect), mode_labels, click, mouse)) |selected| {
         const mode = highScoreModeFromIndex(selected, status);
         state.mode = mode;
         config.game_mode = @intCast(@intFromEnum(mode));
@@ -1335,14 +1376,14 @@ fn updateHighScoreWidgets(
         loadHighScores(state, allocator, base_dir, config.*, status);
         return .{ .config_dirty = true, .play_button_click = true };
     }
-    if (updateDropdownSelection(&state.dropdown_open, .date_mode, dateModeWidgetRect(), scoreDateModeLabels()[0..], click, mouse)) |selected| {
+    if (updateDropdownSelection(&state.dropdown_open, .date_mode, dateModeWidgetRect(right_rect), scoreDateModeLabels()[0..], click, mouse)) |selected| {
         config.highscore_date_mode = @intCast(selected);
         loadHighScores(state, allocator, base_dir, config.*, status);
         return .{ .config_dirty = true, .play_button_click = true };
     }
     var saved_names: [formats.crimson_cfg.saved_name_slot_count][]const u8 = undefined;
     for (0..saved_names.len) |idx| saved_names[idx] = formats.crimson_cfg.savedNameLabel(config, idx);
-    if (updateDropdownSelection(&state.dropdown_open, .score_list, scoreListWidgetRect(), saved_names[0..], click, mouse)) |selected| {
+    if (updateDropdownSelection(&state.dropdown_open, .score_list, scoreListWidgetRect(right_rect), saved_names[0..], click, mouse)) |selected| {
         formats.crimson_cfg.setSelectedSavedNameSlot(config, selected);
         return .{ .config_dirty = true, .play_button_click = true };
     }
@@ -1388,6 +1429,7 @@ fn updateHighScoreQuestArrows(
     state: *HighScoresScreen,
     config: *formats.crimson_cfg.CrimsonCfg,
     status: formats.game_cfg.Status,
+    left_rect: rl.Rectangle,
 ) bool {
     if (state.mode != .quests) return false;
     const click = rl.isMouseButtonPressed(.left);
@@ -1397,11 +1439,11 @@ fn updateHighScoreQuestArrows(
     const max_index = std.math.clamp(unlock, @as(i32, 0), @as(i32, 49));
     const current_index = questLevelKeyToIndex(state.quest_level_key);
     const mouse = rl.getMousePosition();
-    if (current_index > 0 and rectContains(questPrevArrowRect(), mouse)) {
+    if (current_index > 0 and rectContains(questPrevArrowRect(left_rect), mouse)) {
         state.quest_level_key = questIndexToLevelKey(current_index - 1);
         return true;
     }
-    if (current_index < max_index and rectContains(questNextArrowRect(), mouse)) {
+    if (current_index < max_index and rectContains(questNextArrowRect(left_rect), mouse)) {
         state.quest_level_key = questIndexToLevelKey(current_index + 1);
         return true;
     }
@@ -1413,6 +1455,7 @@ fn drawQuestArrows(
     quest_level_key: i32,
     hardcore: bool,
     status: formats.game_cfg.Status,
+    left_rect: rl.Rectangle,
 ) void {
     const arrow = assets.texture(.ui_arrow);
     const unlock = if (hardcore) status.quest_unlock_index_full else status.quest_unlock_index;
@@ -1423,7 +1466,7 @@ fn drawQuestArrows(
         rl.drawTexturePro(
             arrow,
             rl.Rectangle.init(0.0, 0.0, @floatFromInt(arrow.width), @floatFromInt(arrow.height)),
-            questPrevArrowRect(),
+            questPrevArrowRect(left_rect),
             rl.Vector2.zero(),
             0.0,
             tint,
@@ -1433,7 +1476,7 @@ fn drawQuestArrows(
         rl.drawTexturePro(
             arrow,
             rl.Rectangle.init(0.0, 0.0, -@as(f32, @floatFromInt(arrow.width)), @floatFromInt(arrow.height)),
-            questNextArrowRect(),
+            questNextArrowRect(left_rect),
             rl.Vector2.zero(),
             0.0,
             tint,
@@ -1441,12 +1484,12 @@ fn drawQuestArrows(
     }
 }
 
-fn questPrevArrowRect() rl.Rectangle {
-    return rl.Rectangle.init(left_panel_rect.x + 96.0, left_panel_rect.y + 62.0, 32.0, 16.0);
+fn questPrevArrowRect(left_rect: rl.Rectangle) rl.Rectangle {
+    return rl.Rectangle.init(left_rect.x + 96.0, left_rect.y + 62.0, 32.0, 16.0);
 }
 
-fn questNextArrowRect() rl.Rectangle {
-    return rl.Rectangle.init(left_panel_rect.x + 352.0, left_panel_rect.y + 62.0, 32.0, 16.0);
+fn questNextArrowRect(left_rect: rl.Rectangle) rl.Rectangle {
+    return rl.Rectangle.init(left_rect.x + 352.0, left_rect.y + 62.0, 32.0, 16.0);
 }
 
 fn highScoreTitle(mode: game_ids.GameModeId) []const u8 {

--- a/crimson-zig/src/window_ui.zig
+++ b/crimson-zig/src/window_ui.zig
@@ -20,7 +20,7 @@ pub fn centeredRect(center_x: f32, top_y: f32, width: f32, height: f32) rl.Recta
 pub fn updateSelectionFromPointer(selection: *usize, buttons: []const UiButton) void {
     const mouse = rl.getMousePosition();
     for (buttons, 0..) |button, idx| {
-        if (rl.checkCollisionPointRec(mouse, button.rect)) {
+        if (rl.checkCollisionPointRec(mouse, buttonHitRect(button))) {
             selection.* = idx;
             return;
         }
@@ -33,7 +33,7 @@ pub fn buttonActivated(buttons: []const UiButton, selection: usize) bool {
     if (!rl.isMouseButtonPressed(.left)) return false;
     const mouse = rl.getMousePosition();
     for (buttons, 0..) |button, idx| {
-        if (idx == selection and rl.checkCollisionPointRec(mouse, button.rect)) {
+        if (idx == selection and rl.checkCollisionPointRec(mouse, buttonHitRect(button))) {
             return true;
         }
     }
@@ -47,38 +47,33 @@ pub fn drawButton(
     runtime_assets: ?*const window_assets.RuntimeAssets,
 ) void {
     if (runtime_assets) |assets| {
-        const scale = button.rect.height / 32.0;
+        const scale: f32 = 1.0;
         const texture = if (button.rect.width > 120.0) assets.texture(.ui_button_md) else assets.texture(.ui_button_sm);
-        const glow_alpha: f32 = if (selected or hovered) 0.92 else 0.72;
+        const plate_rect = rl.Rectangle.init(button.rect.x, button.rect.y, button.rect.width, 32.0 * scale);
         if (selected or hovered) {
-            rl.drawRectangleRounded(
-                .{
-                    .x = button.rect.x + 12.0 * scale,
-                    .y = button.rect.y + 5.0 * scale,
-                    .width = button.rect.width - 24.0 * scale,
-                    .height = button.rect.height - 10.0 * scale,
-                },
-                0.18,
-                8,
-                rl.Color.init(128, 128, 178, @intFromFloat(glow_alpha * 120.0)),
+            rl.drawRectangle(
+                @intFromFloat(plate_rect.x + 12.0 * scale),
+                @intFromFloat(plate_rect.y + 5.0 * scale),
+                @intFromFloat(plate_rect.width - 24.0 * scale),
+                @intFromFloat(22.0 * scale),
+                rl.Color.init(128, 128, 178, 255),
             );
         }
-        const plate_alpha: f32 = if (selected or hovered) 255.0 else 230.0;
         rl.drawTexturePro(
             texture,
             rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height)),
-            button.rect,
+            plate_rect,
             rl.Vector2.zero(),
             0.0,
-            rl.Color.init(255, 255, 255, @intFromFloat(plate_alpha)),
+            rl.Color.white,
         );
 
         const label_width = measureSmallText(assets, button.label);
         drawSmallText(
             assets,
             button.label,
-            button.rect.x + (button.rect.width - label_width) * 0.5 + 1.0,
-            button.rect.y + 10.0,
+            plate_rect.x + (plate_rect.width - label_width) * 0.5 + 1.0 * scale,
+            plate_rect.y + 10.0 * scale,
             colorWithAlpha(rl.Color.white, if (selected or hovered) 1.0 else 0.7),
         );
         return;
@@ -95,6 +90,10 @@ pub fn drawButton(
     rl.drawText(button.label, label_x, label_y, 24, rl.Color.init(245, 236, 225, 255));
 }
 
+fn buttonHitRect(button: UiButton) rl.Rectangle {
+    return rl.Rectangle.init(button.rect.x, button.rect.y + 2.0, button.rect.width, 28.0);
+}
+
 pub fn colorWithAlpha(color: rl.Color, alpha: f32) rl.Color {
     return rl.Color.init(
         color.r,
@@ -107,6 +106,58 @@ pub fn colorWithAlpha(color: rl.Color, alpha: f32) rl.Color {
 pub fn drawTextureFit(texture: rl.Texture2D, dest: rl.Rectangle, tint: rl.Color) void {
     const src = rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height));
     rl.drawTexturePro(texture, src, dest, rl.Vector2.zero(), 0.0, tint);
+}
+
+const menu_panel_inset: f32 = 1.0;
+const menu_panel_src_slice_y1: f32 = 130.0;
+const menu_panel_src_slice_y2: f32 = 150.0;
+const menu_panel_dst_top_h: f32 = 138.0;
+const menu_panel_dst_bottom_h: f32 = 116.0;
+
+pub fn drawClassicMenuPanel(texture: rl.Texture2D, dst: rl.Rectangle, tint: rl.Color, flip_x: bool) void {
+    const tex_w = @as(f32, @floatFromInt(texture.width));
+    const tex_h = @as(f32, @floatFromInt(texture.height));
+    if (tex_w <= 0.0 or tex_h <= 0.0) return;
+
+    const src_x = menu_panel_inset;
+    const src_y = menu_panel_inset;
+    const src_w = @max(0.0, tex_w - menu_panel_inset * 2.0);
+    const src_h = @max(0.0, tex_h - menu_panel_inset * 2.0);
+    const scale = if (dst.width != 0.0) dst.width / 510.0 else 1.0;
+    const top_h = menu_panel_dst_top_h * scale;
+    const bottom_h = menu_panel_dst_bottom_h * scale;
+    const mid_h = dst.height - top_h - bottom_h;
+
+    const srcRect = struct {
+        fn make(rect: rl.Rectangle, use_flip_x: bool) rl.Rectangle {
+            if (!use_flip_x) return rect;
+            return rl.Rectangle.init(rect.x, rect.y, -rect.width, rect.height);
+        }
+    }.make;
+
+    if (mid_h <= 0.0) {
+        rl.drawTexturePro(
+            texture,
+            srcRect(rl.Rectangle.init(src_x, src_y, src_w, src_h), flip_x),
+            dst,
+            rl.Vector2.zero(),
+            0.0,
+            tint,
+        );
+        return;
+    }
+
+    const src_top = srcRect(rl.Rectangle.init(src_x, src_y, src_w, @max(0.0, menu_panel_src_slice_y1 - menu_panel_inset)), flip_x);
+    const src_mid = srcRect(rl.Rectangle.init(src_x, menu_panel_src_slice_y1, src_w, @max(0.0, menu_panel_src_slice_y2 - menu_panel_src_slice_y1)), flip_x);
+    const src_bot = srcRect(rl.Rectangle.init(src_x, menu_panel_src_slice_y2, src_w, @max(0.0, (tex_h - menu_panel_inset) - menu_panel_src_slice_y2)), flip_x);
+
+    const dst_top = rl.Rectangle.init(dst.x, dst.y, dst.width, top_h);
+    const dst_mid = rl.Rectangle.init(dst.x, dst.y + top_h, dst.width, mid_h);
+    const dst_bot = rl.Rectangle.init(dst.x, dst.y + top_h + mid_h, dst.width, bottom_h);
+
+    rl.drawTexturePro(texture, src_top, dst_top, rl.Vector2.zero(), 0.0, tint);
+    rl.drawTexturePro(texture, src_mid, dst_mid, rl.Vector2.zero(), 0.0, tint);
+    rl.drawTexturePro(texture, src_bot, dst_bot, rl.Vector2.zero(), 0.0, tint);
 }
 
 pub fn drawSmallText(

--- a/crimson-zig/src/window_ui.zig
+++ b/crimson-zig/src/window_ui.zig
@@ -55,12 +55,13 @@ pub fn drawButton(
         const texture = if (button.rect.width > 120.0) assets.texture(.ui_button_md) else assets.texture(.ui_button_sm);
         const plate_rect = rl.Rectangle.init(button.rect.x, button.rect.y, button.rect.width, button_plate_height * scale);
         if (selected or hovered) {
+            const highlight_alpha: u8 = if (hovered) 255 else 170;
             rl.drawRectangle(
                 @intFromFloat(plate_rect.x + 12.0 * scale),
                 @intFromFloat(plate_rect.y + 5.0 * scale),
                 @intFromFloat(plate_rect.width - 24.0 * scale),
                 @intFromFloat(22.0 * scale),
-                rl.Color.init(128, 128, 178, 255),
+                rl.Color.init(128, 128, 178, highlight_alpha),
             );
         }
         rl.drawTexturePro(

--- a/crimson-zig/src/window_ui.zig
+++ b/crimson-zig/src/window_ui.zig
@@ -8,6 +8,10 @@ pub const UiButton = struct {
     rect: rl.Rectangle,
 };
 
+pub const ui_shadow_offset: f32 = 7.0;
+pub const ui_shadow_tint = rl.Color.init(0x44, 0x44, 0x44, 0x44);
+pub const button_plate_height: f32 = 32.0;
+
 pub fn centeredRect(center_x: f32, top_y: f32, width: f32, height: f32) rl.Rectangle {
     return .{
         .x = center_x - width * 0.5,
@@ -49,7 +53,7 @@ pub fn drawButton(
     if (runtime_assets) |assets| {
         const scale: f32 = 1.0;
         const texture = if (button.rect.width > 120.0) assets.texture(.ui_button_md) else assets.texture(.ui_button_sm);
-        const plate_rect = rl.Rectangle.init(button.rect.x, button.rect.y, button.rect.width, 32.0 * scale);
+        const plate_rect = rl.Rectangle.init(button.rect.x, button.rect.y, button.rect.width, button_plate_height * scale);
         if (selected or hovered) {
             rl.drawRectangle(
                 @intFromFloat(plate_rect.x + 12.0 * scale),
@@ -94,6 +98,31 @@ fn buttonHitRect(button: UiButton) rl.Rectangle {
     return rl.Rectangle.init(button.rect.x, button.rect.y + 2.0, button.rect.width, 28.0);
 }
 
+pub fn buttonWidth(label: []const u8, force_wide: bool) f32 {
+    if (force_wide) return 145.0;
+    if (approxButtonTextWidth(label) < 40.0) return 82.0;
+    return 145.0;
+}
+
+pub fn buttonAt(label: [:0]const u8, x: f32, y: f32, force_wide: bool) UiButton {
+    return .{
+        .label = label,
+        .rect = rl.Rectangle.init(x, y, buttonWidth(label, force_wide), button_plate_height),
+    };
+}
+
+fn approxButtonTextWidth(label: []const u8) f32 {
+    var width: f32 = 0.0;
+    for (label) |ch| {
+        width += switch (ch) {
+            'i', 'l', '!', '.', ',', '\'', ':' => 4.0,
+            ' ' => 5.0,
+            else => 8.0,
+        };
+    }
+    return width;
+}
+
 pub fn colorWithAlpha(color: rl.Color, alpha: f32) rl.Color {
     return rl.Color.init(
         color.r,
@@ -136,6 +165,7 @@ pub fn drawClassicMenuPanel(texture: rl.Texture2D, dst: rl.Rectangle, tint: rl.C
     }.make;
 
     if (mid_h <= 0.0) {
+        drawPanelShadow(texture, srcRect(rl.Rectangle.init(src_x, src_y, src_w, src_h), flip_x), dst);
         rl.drawTexturePro(
             texture,
             srcRect(rl.Rectangle.init(src_x, src_y, src_w, src_h), flip_x),
@@ -155,9 +185,29 @@ pub fn drawClassicMenuPanel(texture: rl.Texture2D, dst: rl.Rectangle, tint: rl.C
     const dst_mid = rl.Rectangle.init(dst.x, dst.y + top_h, dst.width, mid_h);
     const dst_bot = rl.Rectangle.init(dst.x, dst.y + top_h + mid_h, dst.width, bottom_h);
 
+    drawPanelShadow(texture, src_top, dst_top);
+    drawPanelShadow(texture, src_mid, dst_mid);
+    drawPanelShadow(texture, src_bot, dst_bot);
+
     rl.drawTexturePro(texture, src_top, dst_top, rl.Vector2.zero(), 0.0, tint);
     rl.drawTexturePro(texture, src_mid, dst_mid, rl.Vector2.zero(), 0.0, tint);
     rl.drawTexturePro(texture, src_bot, dst_bot, rl.Vector2.zero(), 0.0, tint);
+}
+
+fn drawPanelShadow(texture: rl.Texture2D, src: rl.Rectangle, dst: rl.Rectangle) void {
+    rl.gl.rlSetBlendFactors(rl.gl.rl_zero, rl.gl.rl_one_minus_src_alpha, rl.gl.rl_func_add);
+    rl.beginBlendMode(.custom);
+    rl.gl.rlSetBlendFactors(rl.gl.rl_zero, rl.gl.rl_one_minus_src_alpha, rl.gl.rl_func_add);
+    defer rl.endBlendMode();
+
+    rl.drawTexturePro(
+        texture,
+        src,
+        rl.Rectangle.init(dst.x + ui_shadow_offset, dst.y + ui_shadow_offset, dst.width, dst.height),
+        rl.Vector2.zero(),
+        0.0,
+        ui_shadow_tint,
+    );
 }
 
 pub fn drawSmallText(

--- a/tests/contracts/test_zig_port_guard.py
+++ b/tests/contracts/test_zig_port_guard.py
@@ -16,7 +16,7 @@ from crimson.weapons import WeaponId
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ZIG_CREATURES = REPO_ROOT / "crimson-zig" / "src" / "runtime" / "creatures.zig"
-ZIG_WEAPONS = REPO_ROOT / "crimson-zig" / "src" / "runtime" / "weapons.zig"
+ZIG_FIRE_RECIPES = REPO_ROOT / "crimson-zig" / "src" / "runtime" / "fire_recipes.zig"
 ZIG_WEAPON_DATA = REPO_ROOT / "crimson-zig" / "src" / "runtime" / "weapon_data.zig"
 
 
@@ -54,10 +54,10 @@ def _python_supported_fire_weapons() -> set[str]:
 
 
 def _zig_supported_fire_weapons() -> set[str]:
-    weapons_source = ZIG_WEAPONS.read_text()
+    fire_recipes_source = ZIG_FIRE_RECIPES.read_text()
     weapon_data_source = ZIG_WEAPON_DATA.read_text()
 
-    supported = set(re.findall(r"\n\s*\.([a-z0-9_]+)\s*=>\s*\{", weapons_source))
+    supported = set(re.findall(r"\n\s*\.([a-z0-9_]+)\s*=>\s*\.?\{", fire_recipes_source))
     switch_match = re.search(
         r"pub fn projectileTypeIdFromWeaponId\(weapon_id: WeaponId\) \?ProjectileTypeId \{\n\s*return switch \(weapon_id\) \{(.*?)\n\s*\};\n\}",
         weapon_data_source,


### PR DESCRIPTION
## Summary
- tighten the Zig play-game and quest panels to follow the Python menu flow more closely
- remove fake options slider button chrome and realign controls ordering/layout to the Python shell
- move statistics and credits back toward the smaller classic panel geometry and text placement

## What Changed
- added close-transition and tooltip timing to the play-game panel so actions resolve after the panel slides out
- switched play-game labels, tooltip offsets, and F1-only mode counts to the Python-style behavior
- replaced the old quest row-selection scaffold with quest-specific layout helpers, row hitboxes, hardcore gating, and panel-local title/icon placement
- fixed quest hardcore unlock gating to use unlock index 40
- stopped drawing option slider rows as regular buttons and restored the checkbox label/slider tint behavior
- reordered controls to `Configure for -> Aiming method -> Moving method` and aligned the left-panel draw order with the Python screen
- restored the statistics hub to the smaller classic panel layout, corrected playtime grammar, and moved credits back to the classic centered panel treatment

## Verification
- `cd crimson-zig && zig build window`
- `cd crimson-zig && zig build test`
- `cd crimson-zig && zig build wasm`
- `cd crimson-zig && zig build run-window` smoke launch
