### PR TITLE
feat(zig): port transient world fx runtime

### DIFF
--- a/crimson-zig/src/root.zig
+++ b/crimson-zig/src/root.zig
@@ -14,6 +14,7 @@ pub const lifecycle = @import("runtime/lifecycle.zig");
 pub const perks = @import("runtime/perks.zig");
 pub const weapon_data = @import("runtime/weapon_data.zig");
 pub const particles = @import("runtime/particles.zig");
+pub const effects = @import("runtime/effects.zig");
 pub const secondary_projectiles = @import("runtime/secondary_projectiles.zig");
 pub const state = @import("runtime/state.zig");
 pub const weapons = @import("runtime/weapons.zig");

--- a/crimson-zig/src/runtime/bonuses.zig
+++ b/crimson-zig/src/runtime/bonuses.zig
@@ -4,6 +4,7 @@ const native_math = @import("native_math.zig");
 
 const creature_lifecycle = @import("lifecycle.zig").CreatureLifecycle;
 const creatures_mod = @import("creatures.zig");
+const effects_mod = @import("effects.zig");
 const owner_ref = @import("owner_ref.zig");
 const perks = @import("perks.zig");
 const player_runtime = @import("player.zig");
@@ -23,6 +24,7 @@ pub const BonusPickupRecord = struct {
     bonus_id: BonusId = .unused,
     amount: i32 = 0,
     player_index: i32 = -1,
+    pos: state_mod.Vec2 = .{},
 };
 pub const BonusPickupBuffer = struct {
     items: [bonus_pool_size]BonusPickupRecord = [_]BonusPickupRecord{.{}} ** bonus_pool_size,
@@ -227,6 +229,7 @@ pub const BonusPool = struct {
                     .bonus_id = entry.bonus_id,
                     .amount = entry.amount,
                     .player_index = player.index,
+                    .pos = entry.pos,
                 });
                 entry.picked = true;
                 entry.time_left = narrowF32(bonus_pickup_linger);
@@ -293,10 +296,6 @@ pub fn bonusUpdate(
             state.bonuses.freeze -= dt;
         }
     }
-
-    for (pickup_bonus_ids[0..pickup_count]) |bonus_id| {
-        consumeBonusPickupEffectsRng(state, bonus_id);
-    }
 }
 
 pub fn applyPendingBonusEffects(
@@ -305,6 +304,31 @@ pub fn applyPendingBonusEffects(
     projectiles: *projectiles_mod.ProjectilePool,
     creatures: *creatures_mod.CreaturePool,
     bonuses: *BonusPool,
+    dt: f32,
+    world_size: f32,
+    tick_index: usize,
+) void {
+    var effects: effects_mod.EffectPool = .{};
+    applyPendingBonusEffectsWithEffects(
+        state,
+        players,
+        projectiles,
+        creatures,
+        bonuses,
+        &effects,
+        dt,
+        world_size,
+        tick_index,
+    );
+}
+
+pub fn applyPendingBonusEffectsWithEffects(
+    state: *state_mod.GameplayState,
+    players: []state_mod.PlayerState,
+    projectiles: *projectiles_mod.ProjectilePool,
+    creatures: *creatures_mod.CreaturePool,
+    bonuses: *BonusPool,
+    effects: *effects_mod.EffectPool,
     dt: f32,
     world_size: f32,
     tick_index: usize,
@@ -339,6 +363,7 @@ pub fn applyPendingBonusEffects(
             projectiles,
             creatures,
             bonuses,
+            effects,
             origin,
             dt,
             world_size,
@@ -346,6 +371,44 @@ pub fn applyPendingBonusEffects(
         );
     }
     state.pending_nuke_count = 0;
+}
+
+pub fn emitBonusPickupEffects(
+    state: *state_mod.GameplayState,
+    pickups: []const BonusPickupRecord,
+    effects: *effects_mod.EffectPool,
+    detail_preset: i32,
+) void {
+    for (pickups) |pickup| {
+        if (pickup.bonus_id != .nuke) {
+            effects.spawnBurst(
+                state,
+                pickup.pos,
+                12,
+                detail_preset,
+                0.4,
+                0.1,
+                .{ .r = 0.4, .g = 0.5, .b = 1.0, .a = 0.5 },
+            );
+        }
+        switch (pickup.bonus_id) {
+            .reflex_boost => effects.spawnRing(
+                pickup.pos,
+                detail_preset,
+                .{ .r = 0.6, .g = 0.6, .b = 1.0, .a = 1.0 },
+                1.0,
+                45.0,
+            ),
+            .freeze => effects.spawnRing(
+                pickup.pos,
+                detail_preset,
+                .{ .r = 0.3, .g = 0.5, .b = 0.8, .a = 1.0 },
+                1.0,
+                45.0,
+            ),
+            else => {},
+        }
+    }
 }
 
 pub fn applyPendingCreatureProjectiles(
@@ -447,6 +510,7 @@ fn bonusTelekineticUpdate(
             .bonus_id = entry.bonus_id,
             .amount = entry.amount,
             .player_index = player.index,
+            .pos = entry.pos,
         });
         entry.picked = true;
         entry.time_left = narrowF32(bonus_pickup_linger);
@@ -518,6 +582,7 @@ fn applyNukeBonus(
     projectiles: *projectiles_mod.ProjectilePool,
     creatures: *creatures_mod.CreaturePool,
     bonuses: *BonusPool,
+    effects: *effects_mod.EffectPool,
     origin: state_mod.Vec2,
     dt: f32,
     world_size: f32,
@@ -552,7 +617,7 @@ fn applyNukeBonus(
         _ = projectiles.spawn(origin, narrowF32(angle), type_id, projectile_owner, meta, false);
     }
 
-    consumeSpawnBurstRng(state, 5);
+    effects.spawnExplosionBurst(state, origin, 1.0, 5);
 
     const prev_spawn_guard = state.bonus_spawn_guard;
     state.bonus_spawn_guard = true;

--- a/crimson-zig/src/runtime/creatures.zig
+++ b/crimson-zig/src/runtime/creatures.zig
@@ -5,6 +5,7 @@ const native_math = @import("native_math.zig");
 const runtime_anim = @import("anim.zig");
 const bonus_runtime = @import("bonuses.zig");
 const creature_lifecycle = @import("lifecycle.zig").CreatureLifecycle;
+const effects_mod = @import("effects.zig");
 const owner_ref = @import("owner_ref.zig");
 const perks = @import("perks.zig");
 const runtime_helpers = @import("helpers.zig");
@@ -80,6 +81,7 @@ pub const CreaturePool = struct {
     entries: [max_creatures]CreatureState = [_]CreatureState{CreatureState{}} ** max_creatures,
     kill_count: i32 = 0,
     capture_spawn_events_authoritative: bool = false,
+    effects: ?*effects_mod.EffectPool = null,
     spawn_slots: [max_creatures]spawn_mod.SpawnSlotInit = [_]spawn_mod.SpawnSlotInit{
         .{
             .owner_creature = 0,
@@ -96,6 +98,7 @@ pub const CreaturePool = struct {
         self.entries = [_]CreatureState{CreatureState{}} ** max_creatures;
         self.kill_count = 0;
         self.capture_spawn_events_authoritative = false;
+        self.effects = null;
         self.spawn_slot_count = 0;
     }
 
@@ -1798,7 +1801,19 @@ pub const CreaturePool = struct {
                 call_pos_x > 0.0 and call_pos_x < terrain_size and
                 call_pos_y > 0.0 and call_pos_y < terrain_size)
             {
-                consumeSpawnTemplateBurstRng(rng, 8);
+                if (self.effects) |effects| {
+                    effects.spawnBurst(
+                        @constCast(game_state),
+                        .{ .x = call_pos_x, .y = call_pos_y },
+                        8,
+                        5,
+                        0.4,
+                        null,
+                        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 },
+                    );
+                } else {
+                    consumeSpawnTemplateBurstRng(rng, 8);
+                }
             }
         }
     }
@@ -2121,6 +2136,7 @@ pub const CreaturePool = struct {
                         state,
                         players,
                         bonus_pool,
+                        self.effects,
                         creature.pos,
                         @floatCast(world_size),
                         true,
@@ -2457,6 +2473,7 @@ pub const CreaturePool = struct {
             state,
             players,
             bonus_pool,
+            self.effects,
             creature.pos,
             world_size,
             true,
@@ -2504,6 +2521,7 @@ pub const CreaturePool = struct {
             state,
             players,
             bonus_pool,
+            self.effects,
             creature.pos,
             world_size,
             false,
@@ -2552,6 +2570,7 @@ pub const CreaturePool = struct {
             state,
             players,
             bonus_pool,
+            self.effects,
             creature.pos,
             world_size,
             true,
@@ -2805,6 +2824,7 @@ pub const CreaturePool = struct {
             state,
             players,
             bonus_pool,
+            self.effects,
             creature.pos,
             world_size,
             true,
@@ -3446,12 +3466,23 @@ fn spawnSplitChildrenOnDeath(
         self.entries[child_idx] = child;
     }
 
-    // effects.spawn_burst(count=8) -> 4 random draws per burst element.
-    for (0..8) |_| {
-        _ = state.rng.rand();
-        _ = state.rng.rand();
-        _ = state.rng.rand();
-        _ = state.rng.rand();
+    if (self.effects) |effects| {
+        effects.spawnBurst(
+            state,
+            source.pos,
+            8,
+            5,
+            0.4,
+            null,
+            .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 },
+        );
+    } else {
+        for (0..8) |_| {
+            _ = state.rng.rand();
+            _ = state.rng.rand();
+            _ = state.rng.rand();
+            _ = state.rng.rand();
+        }
     }
 }
 
@@ -3492,6 +3523,7 @@ fn consumeDeathSideEffectsRng(
     state: *state_mod.GameplayState,
     players: []state_mod.PlayerState,
     bonus_pool: *bonus_runtime.BonusPool,
+    effects: ?*effects_mod.EffectPool,
     death_pos: state_mod.Vec2,
     world_size: f32,
     plan_death_sfx: bool,
@@ -3506,30 +3538,50 @@ fn consumeDeathSideEffectsRng(
         world_size,
     );
     if (spawned_bonus) |_| {
-        // effects.spawn_burst(count=16) -> 4 random draws per burst element.
-        for (0..16) |_| {
-            _ = state.rng.rand();
-            _ = state.rng.rand();
-            _ = state.rng.rand();
-            _ = state.rng.rand();
-        }
-    }
-    if (state.bonuses.freeze > 0.0) {
-        for (0..8) |_| {
-            _ = state.rng.rand() % 0x264;
-            for (0..6) |_| {
+        if (effects) |effect_pool| {
+            effect_pool.spawnBurst(
+                state,
+                death_pos,
+                16,
+                5,
+                0.4,
+                null,
+                .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 },
+            );
+        } else {
+            for (0..16) |_| {
+                _ = state.rng.rand();
+                _ = state.rng.rand();
+                _ = state.rng.rand();
                 _ = state.rng.rand();
             }
         }
-        _ = state.rng.rand() % 0x264;
-        for (0..4) |_| {
-            _ = state.rng.rand();
-            _ = state.rng.rand();
-        }
-        for (0..4) |_| {
+    }
+    if (state.bonuses.freeze > 0.0) {
+        if (effects) |effect_pool| {
+            for (0..8) |_| {
+                const angle = @as(f32, @floatFromInt(state.rng.rand() % 612)) * 0.01;
+                effect_pool.spawnFreezeShard(state, death_pos, angle, 5);
+            }
+            const shatter_angle = @as(f32, @floatFromInt(state.rng.rand() % 612)) * 0.01;
+            effect_pool.spawnFreezeShatter(state, death_pos, shatter_angle, 5);
+        } else {
+            for (0..8) |_| {
+                _ = state.rng.rand() % 0x264;
+                for (0..6) |_| {
+                    _ = state.rng.rand();
+                }
+            }
             _ = state.rng.rand() % 0x264;
-            for (0..6) |_| {
+            for (0..4) |_| {
                 _ = state.rng.rand();
+                _ = state.rng.rand();
+            }
+            for (0..4) |_| {
+                _ = state.rng.rand() % 0x264;
+                for (0..6) |_| {
+                    _ = state.rng.rand();
+                }
             }
         }
         runtime_helpers.consumeAddRandomRng(state);

--- a/crimson-zig/src/runtime/effects.zig
+++ b/crimson-zig/src/runtime/effects.zig
@@ -1,0 +1,594 @@
+const std = @import("std");
+const native_math = @import("native_math.zig");
+
+const state_mod = @import("state.zig");
+
+const narrowF32 = native_math.roundF32;
+
+pub const effect_pool_size: usize = 0x200;
+pub const sprite_effect_pool_size: usize = 0x180;
+
+pub const EffectId = enum(i32) {
+    burst = 0x00,
+    ring = 0x01,
+    shield_ring = 0x02,
+    effect_03 = 0x03,
+    effect_04 = 0x04,
+    effect_05 = 0x05,
+    effect_06 = 0x06,
+    blood_splatter = 0x07,
+    freeze_shard_0 = 0x08,
+    freeze_shard_1 = 0x09,
+    freeze_shard_2 = 0x0A,
+    effect_0b = 0x0B,
+    explosion_burst = 0x0C,
+    glow = 0x0D,
+    freeze_shatter = 0x0E,
+    effect_0f = 0x0F,
+    aura = 0x10,
+    explosion_puff = 0x11,
+    casing = 0x12,
+};
+
+pub const Color = struct {
+    r: f32 = 1.0,
+    g: f32 = 1.0,
+    b: f32 = 1.0,
+    a: f32 = 1.0,
+
+    pub fn withAlpha(self: Color, alpha: f32) Color {
+        return .{
+            .r = self.r,
+            .g = self.g,
+            .b = self.b,
+            .a = alpha,
+        };
+    }
+
+    pub fn clamped(self: Color) Color {
+        return .{
+            .r = std.math.clamp(self.r, @as(f32, 0.0), @as(f32, 1.0)),
+            .g = std.math.clamp(self.g, @as(f32, 0.0), @as(f32, 1.0)),
+            .b = std.math.clamp(self.b, @as(f32, 0.0), @as(f32, 1.0)),
+            .a = std.math.clamp(self.a, @as(f32, 0.0), @as(f32, 1.0)),
+        };
+    }
+
+    pub fn scaled(self: Color, factor: f32) Color {
+        return .{
+            .r = self.r * factor,
+            .g = self.g * factor,
+            .b = self.b * factor,
+            .a = self.a,
+        };
+    }
+};
+
+pub const SpriteEffect = struct {
+    active: bool = false,
+    color: Color = .{ .a = 0.0 },
+    rotation: f32 = 0.0,
+    pos: state_mod.Vec2 = .{},
+    vel: state_mod.Vec2 = .{},
+    scale: f32 = 1.0,
+};
+
+pub const SpriteEffectPool = struct {
+    entries: [sprite_effect_pool_size]SpriteEffect = [_]SpriteEffect{.{}} ** sprite_effect_pool_size,
+
+    pub fn reset(self: *SpriteEffectPool) void {
+        self.entries = [_]SpriteEffect{.{}} ** sprite_effect_pool_size;
+    }
+
+    pub fn spawn(
+        self: *SpriteEffectPool,
+        state: *state_mod.GameplayState,
+        pos: state_mod.Vec2,
+        vel: state_mod.Vec2,
+        scale: f32,
+        color: ?Color,
+    ) usize {
+        var idx: usize = 0;
+        while (idx < self.entries.len) : (idx += 1) {
+            if (!self.entries[idx].active) break;
+        }
+        if (idx >= self.entries.len) {
+            idx = state.rng.rand() % self.entries.len;
+        }
+
+        self.entries[idx] = .{
+            .active = true,
+            .color = color orelse .{},
+            .rotation = @as(f32, @floatFromInt(state.rng.rand() % 628)) * 0.01,
+            .pos = .{ .x = narrowF32(pos.x), .y = narrowF32(pos.y) },
+            .vel = .{ .x = narrowF32(vel.x), .y = narrowF32(vel.y) },
+            .scale = narrowF32(scale),
+        };
+        return idx;
+    }
+
+    pub fn update(self: *SpriteEffectPool, dt: f32) void {
+        if (!(dt > 0.0)) return;
+        for (&self.entries) |*entry| {
+            if (!entry.active) continue;
+            entry.pos = .{
+                .x = narrowF32(entry.pos.x + entry.vel.x * dt),
+                .y = narrowF32(entry.pos.y + entry.vel.y * dt),
+            };
+            entry.rotation = narrowF32(entry.rotation + dt * 3.0);
+            entry.color.a = narrowF32(entry.color.a - dt);
+            entry.scale = narrowF32(entry.scale + dt * 60.0);
+            if (!(entry.color.a > 0.0)) {
+                entry.active = false;
+            }
+        }
+    }
+};
+
+pub const EffectEntry = struct {
+    pos: state_mod.Vec2 = .{},
+    effect_id: i32 = 0,
+    vel: state_mod.Vec2 = .{},
+    rotation: f32 = 0.0,
+    scale: f32 = 1.0,
+    half_width: f32 = 0.0,
+    half_height: f32 = 0.0,
+    age: f32 = 0.0,
+    lifetime: f32 = 0.0,
+    flags: i32 = 0,
+    color: Color = .{},
+    rotation_step: f32 = 0.0,
+    scale_step: f32 = 0.0,
+};
+
+pub const EffectPool = struct {
+    entries: [effect_pool_size]EffectEntry = [_]EffectEntry{.{}} ** effect_pool_size,
+    free: [effect_pool_size]usize = initFree(),
+    free_len: usize = effect_pool_size,
+    detail_toggle: u32 = 0,
+    overwrite_cursor: usize = 0,
+
+    fn initFree() [effect_pool_size]usize {
+        var free: [effect_pool_size]usize = undefined;
+        var idx: usize = 0;
+        while (idx < effect_pool_size) : (idx += 1) {
+            free[idx] = effect_pool_size - 1 - idx;
+        }
+        return free;
+    }
+
+    pub fn reset(self: *EffectPool) void {
+        self.entries = [_]EffectEntry{.{}} ** effect_pool_size;
+        self.free = initFree();
+        self.free_len = effect_pool_size;
+        self.detail_toggle = 0;
+        self.overwrite_cursor = 0;
+    }
+
+    fn allocSlot(self: *EffectPool, detail_preset: i32) ?usize {
+        if (detail_preset < 3) {
+            const skip = (self.detail_toggle & 1) != 0;
+            self.detail_toggle += 1;
+            if (skip) return null;
+        }
+        if (self.free_len > 0) {
+            self.free_len -= 1;
+            return self.free[self.free_len];
+        }
+        if (self.entries.len == 0) return null;
+        const idx = self.overwrite_cursor % self.entries.len;
+        self.overwrite_cursor = idx + 1;
+        return idx;
+    }
+
+    pub fn freeSlot(self: *EffectPool, idx: usize) void {
+        if (idx >= self.entries.len) return;
+        self.entries[idx].flags = 0;
+        if (self.free_len < self.free.len) {
+            self.free[self.free_len] = idx;
+            self.free_len += 1;
+        }
+    }
+
+    pub fn spawn(
+        self: *EffectPool,
+        effect_id: i32,
+        pos: state_mod.Vec2,
+        vel: state_mod.Vec2,
+        rotation: f32,
+        scale: f32,
+        half_width: f32,
+        half_height: f32,
+        age: f32,
+        lifetime: f32,
+        flags: i32,
+        color: Color,
+        rotation_step: f32,
+        scale_step: f32,
+        detail_preset: i32,
+    ) ?usize {
+        const idx = self.allocSlot(detail_preset) orelse return null;
+        self.entries[idx] = .{
+            .pos = .{ .x = narrowF32(pos.x), .y = narrowF32(pos.y) },
+            .effect_id = effect_id,
+            .vel = .{ .x = narrowF32(vel.x), .y = narrowF32(vel.y) },
+            .rotation = narrowF32(rotation),
+            .scale = narrowF32(scale),
+            .half_width = narrowF32(half_width),
+            .half_height = narrowF32(half_height),
+            .age = narrowF32(age),
+            .lifetime = narrowF32(lifetime),
+            .flags = flags,
+            .color = color,
+            .rotation_step = narrowF32(rotation_step),
+            .scale_step = narrowF32(scale_step),
+        };
+        return idx;
+    }
+
+    pub fn update(self: *EffectPool, dt: f32) void {
+        if (!(dt > 0.0)) return;
+        for (&self.entries, 0..) |*entry, idx| {
+            const flags = entry.flags;
+            if (flags == 0) continue;
+
+            entry.age = narrowF32(entry.age + dt);
+            if (entry.age < entry.lifetime) {
+                if (entry.age >= 0.0) {
+                    entry.pos = .{
+                        .x = narrowF32(entry.pos.x + entry.vel.x * dt),
+                        .y = narrowF32(entry.pos.y + entry.vel.y * dt),
+                    };
+                    if ((flags & 0x4) != 0) {
+                        entry.rotation = narrowF32(entry.rotation + entry.rotation_step * dt);
+                    }
+                    if ((flags & 0x8) != 0) {
+                        entry.scale = narrowF32(entry.scale + entry.scale_step * dt);
+                    }
+                    if ((flags & 0x10) != 0) {
+                        const next_alpha = if (entry.lifetime > 1e-9)
+                            narrowF32(1.0 - entry.age / entry.lifetime)
+                        else
+                            0.0;
+                        entry.color.a = next_alpha;
+                    }
+                }
+                continue;
+            }
+            self.freeSlot(idx);
+        }
+    }
+
+    pub fn spawnShellCasing(
+        self: *EffectPool,
+        detail_preset: i32,
+        pos: state_mod.Vec2,
+        aim_heading: f32,
+        angle_draw: u32,
+        speed_draw: u32,
+        rotation_draw: u32,
+        rotation_step_draw: u32,
+    ) void {
+        const angle = aim_heading + @as(f32, @floatFromInt(angle_draw & 0x3F)) * 0.01;
+        const speed = @as(f32, @floatFromInt(speed_draw & 0x3F)) * 0.022727273 + 1.0;
+        const velocity = state_mod.Vec2.fromAngle(angle).mul(speed * 100.0);
+        const rotation = @as(f32, @floatFromInt((rotation_draw & 0x3F) -% 0x20)) * 0.1;
+        const rotation_step = (@as(f32, @floatFromInt(rotation_step_draw % 20)) * 0.1 - 1.0) * 14.0;
+        _ = self.spawn(
+            @intFromEnum(EffectId.casing),
+            pos,
+            velocity,
+            rotation,
+            1.0,
+            2.0,
+            2.0,
+            0.0,
+            0.15,
+            0x1C5,
+            .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 0.6 },
+            rotation_step,
+            0.0,
+            detail_preset,
+        );
+    }
+
+    pub fn spawnBloodSplatter(
+        self: *EffectPool,
+        state: *state_mod.GameplayState,
+        pos: state_mod.Vec2,
+        angle: f32,
+        age: f32,
+        detail_preset: i32,
+        violence_disabled: i32,
+    ) void {
+        if (violence_disabled != 0) return;
+        const lifetime = narrowF32(0.25 - age);
+        const base = narrowF32(angle + std.math.pi);
+        const direction = state_mod.Vec2.fromAngle(base);
+        for (0..2) |_| {
+            const rotation = @as(f32, @floatFromInt((state.rng.rand() & 0x3F) -% 0x20)) * 0.1 + base;
+            const half = @as(f32, @floatFromInt((state.rng.rand() & 7) + 1));
+            const speed_x = @as(f32, @floatFromInt((state.rng.rand() & 0x3F) + 100));
+            const speed_y = @as(f32, @floatFromInt((state.rng.rand() & 0x3F) + 100));
+            const velocity: state_mod.Vec2 = .{
+                .x = narrowF32(direction.x * speed_x),
+                .y = narrowF32(direction.y * speed_y),
+            };
+            const scale_step = @as(f32, @floatFromInt(state.rng.rand() & 0x7F)) * 0.03 + 0.1;
+            _ = self.spawn(
+                @intFromEnum(EffectId.blood_splatter),
+                pos,
+                velocity,
+                rotation,
+                1.0,
+                half,
+                half,
+                age,
+                lifetime,
+                0xC9,
+                .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 0.5 },
+                0.0,
+                scale_step,
+                detail_preset,
+            );
+        }
+    }
+
+    pub fn spawnBurst(
+        self: *EffectPool,
+        state: *state_mod.GameplayState,
+        pos: state_mod.Vec2,
+        count: i32,
+        detail_preset: i32,
+        lifetime: f32,
+        scale_step: ?f32,
+        color: Color,
+    ) void {
+        var idx: i32 = 0;
+        const safe_count = @max(count, 0);
+        while (idx < safe_count) : (idx += 1) {
+            const rotation_draw = state.rng.rand();
+            const vel_x_draw = state.rng.rand();
+            const vel_y_draw = state.rng.rand();
+            const scale_step_draw = if (scale_step == null) state.rng.rand() else 0;
+            self.spawnBurstParticle(
+                pos,
+                rotation_draw,
+                vel_x_draw,
+                vel_y_draw,
+                if (scale_step == null) scale_step_draw else null,
+                scale_step,
+                lifetime,
+                color,
+                detail_preset,
+            );
+        }
+    }
+
+    pub fn spawnBurstParticle(
+        self: *EffectPool,
+        pos: state_mod.Vec2,
+        rotation_draw: u32,
+        vel_x_draw: u32,
+        vel_y_draw: u32,
+        scale_step_draw: ?u32,
+        scale_step: ?f32,
+        lifetime: f32,
+        color: Color,
+        detail_preset: i32,
+    ) void {
+        const rotation = @as(f32, @floatFromInt(rotation_draw & 0x7F)) * 0.049087387;
+        const velocity: state_mod.Vec2 = .{
+            .x = @as(f32, @floatFromInt((vel_x_draw & 0x7F) -% 0x40)),
+            .y = @as(f32, @floatFromInt((vel_y_draw & 0x7F) -% 0x40)),
+        };
+        const step = if (scale_step) |fixed|
+            fixed
+        else
+            @as(f32, @floatFromInt(scale_step_draw.? % 100)) * 0.01 + 0.1;
+        _ = self.spawn(
+            @intFromEnum(EffectId.burst),
+            pos,
+            velocity,
+            rotation,
+            1.0,
+            32.0,
+            32.0,
+            0.0,
+            lifetime,
+            0x1D,
+            color,
+            0.0,
+            step,
+            detail_preset,
+        );
+    }
+
+    pub fn spawnRing(
+        self: *EffectPool,
+        pos: state_mod.Vec2,
+        detail_preset: i32,
+        color: Color,
+        lifetime: f32,
+        scale_step: f32,
+    ) void {
+        _ = self.spawn(
+            @intFromEnum(EffectId.ring),
+            pos,
+            .{},
+            0.0,
+            1.0,
+            32.0,
+            32.0,
+            0.0,
+            lifetime,
+            0x19,
+            color,
+            0.0,
+            scale_step,
+            detail_preset,
+        );
+    }
+
+    pub fn spawnFreezeShard(
+        self: *EffectPool,
+        state: *state_mod.GameplayState,
+        pos: state_mod.Vec2,
+        angle: f32,
+        detail_preset: i32,
+    ) void {
+        const lifetime = @as(f32, @floatFromInt(state.rng.rand() & 0xF)) * 0.01 + 0.2;
+        const base = narrowF32(angle + std.math.pi);
+        const rotation = @as(f32, @floatFromInt(state.rng.rand() % 100)) * 0.01 + base;
+        const half = @as(f32, @floatFromInt(state.rng.rand() % 5 + 7));
+        const velocity = state_mod.Vec2.fromAngle(base).mul(114.0);
+        const rotation_step = (@as(f32, @floatFromInt(state.rng.rand() % 20)) * 0.1 - 1.0) * 4.0;
+        const scale_step = -@as(f32, @floatFromInt(state.rng.rand() & 0xF)) * 0.1;
+        const effect_id = @as(i32, @intCast(state.rng.rand() % 3)) + 8;
+        _ = self.spawn(
+            effect_id,
+            pos,
+            velocity,
+            rotation,
+            1.0,
+            half,
+            half,
+            0.0,
+            lifetime,
+            0x1CD,
+            .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 0.5 },
+            rotation_step,
+            scale_step,
+            detail_preset,
+        );
+    }
+
+    pub fn spawnFreezeShatter(
+        self: *EffectPool,
+        state: *state_mod.GameplayState,
+        pos: state_mod.Vec2,
+        angle: f32,
+        detail_preset: i32,
+    ) void {
+        const lifetime: f32 = 1.1;
+        for (0..4) |idx| {
+            const rotation = @as(f32, @floatFromInt(idx)) * (std.math.pi / 2.0) + angle;
+            const velocity = state_mod.Vec2.fromAngle(rotation).mul(42.0);
+            const half = @as(f32, @floatFromInt(state.rng.rand() % 10 + 18));
+            const rotation_step = (@as(f32, @floatFromInt(state.rng.rand() % 20)) * 0.1 - 1.0) * 1.9;
+            _ = self.spawn(
+                @intFromEnum(EffectId.freeze_shatter),
+                pos,
+                velocity,
+                rotation,
+                1.0,
+                half,
+                half,
+                0.0,
+                lifetime,
+                0x5D,
+                .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 0.5 },
+                rotation_step,
+                0.0,
+                detail_preset,
+            );
+        }
+        for (0..4) |_| {
+            const shard_angle = @as(f32, @floatFromInt(state.rng.rand() % 612)) * 0.01;
+            self.spawnFreezeShard(state, pos, shard_angle, detail_preset);
+        }
+    }
+
+    pub fn spawnExplosionBurst(
+        self: *EffectPool,
+        state: *state_mod.GameplayState,
+        pos: state_mod.Vec2,
+        scale: f32,
+        detail_preset: i32,
+    ) void {
+        _ = self.spawn(
+            @intFromEnum(EffectId.ring),
+            pos,
+            .{},
+            0.0,
+            1.0,
+            32.0,
+            32.0,
+            -0.1,
+            0.35,
+            0x19,
+            .{ .r = 0.6, .g = 0.6, .b = 0.6, .a = 1.0 },
+            0.0,
+            scale * 25.0,
+            detail_preset,
+        );
+
+        if (detail_preset > 3) {
+            for (0..2) |idx| {
+                const age = @as(f32, @floatFromInt(idx)) * 0.2 - 0.5;
+                const lifetime = @as(f32, @floatFromInt(idx)) * 0.2 + 0.6;
+                const rotation = @as(f32, @floatFromInt(state.rng.rand() % 614)) * 0.02;
+                _ = self.spawn(
+                    @intFromEnum(EffectId.explosion_puff),
+                    pos,
+                    .{},
+                    rotation,
+                    1.0,
+                    32.0,
+                    32.0,
+                    age,
+                    lifetime,
+                    0x5D,
+                    .{ .r = 0.1, .g = 0.1, .b = 0.1, .a = 1.0 },
+                    1.4,
+                    scale * 5.0,
+                    detail_preset,
+                );
+            }
+        }
+
+        _ = self.spawn(
+            @intFromEnum(EffectId.burst),
+            pos,
+            .{},
+            0.0,
+            1.0,
+            32.0,
+            32.0,
+            0.0,
+            0.3,
+            0x19,
+            .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 },
+            0.0,
+            scale * 45.0,
+            detail_preset,
+        );
+
+        const count: usize = if (detail_preset < 2) 1 else 3 + (if (detail_preset > 3) @as(usize, 1) else 0);
+        for (0..count) |_| {
+            const rotation = @as(f32, @floatFromInt(state.rng.rand() % 314)) * 0.02;
+            const velocity: state_mod.Vec2 = .{
+                .x = @as(f32, @floatFromInt((state.rng.rand() & 0x3F) * 2 -% 0x40)),
+                .y = @as(f32, @floatFromInt((state.rng.rand() & 0x3F) * 2 -% 0x40)),
+            };
+            const scale_step = @as(f32, @floatFromInt((state.rng.rand() -% 3) & 7)) * scale;
+            const rotation_step = @as(f32, @floatFromInt((state.rng.rand() +% 3) & 7));
+            _ = self.spawn(
+                @intFromEnum(EffectId.explosion_burst),
+                pos,
+                velocity,
+                rotation,
+                1.0,
+                32.0,
+                32.0,
+                0.0,
+                0.7,
+                0x1D,
+                .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 },
+                rotation_step,
+                scale_step,
+                detail_preset,
+            );
+        }
+    }
+};

--- a/crimson-zig/src/runtime/particles.zig
+++ b/crimson-zig/src/runtime/particles.zig
@@ -4,6 +4,7 @@ const native_math = @import("native_math.zig");
 const bonus_runtime = @import("bonuses.zig");
 const creature_lifecycle = @import("lifecycle.zig").CreatureLifecycle;
 const creatures_mod = @import("creatures.zig");
+const effects_mod = @import("effects.zig");
 const owner_ref = @import("owner_ref.zig");
 const runtime_helpers = @import("helpers.zig");
 const state_mod = @import("state.zig");
@@ -112,6 +113,7 @@ pub const ParticlePool = struct {
         players: []state_mod.PlayerState,
         creatures: *creatures_mod.CreaturePool,
         bonuses: *bonus_runtime.BonusPool,
+        sprite_effects: *effects_mod.SpriteEffectPool,
         dt: f32,
         world_size: f32,
     ) void {
@@ -256,8 +258,17 @@ pub const ParticlePool = struct {
                         }
 
                         if ((particle_idx % 3) == 0) {
-                            _ = state.rng.rand() % 0x3c;
-                            _ = state.rng.rand() % 0x3c;
+                            const sprite_vel: state_mod.Vec2 = .{
+                                .x = @as(f32, @floatFromInt(state.rng.rand() % 60)) - 30.0,
+                                .y = @as(f32, @floatFromInt(state.rng.rand() % 60)) - 30.0,
+                            };
+                            _ = sprite_effects.spawn(
+                                state,
+                                creature.pos,
+                                sprite_vel,
+                                13.0,
+                                .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 0.7 },
+                            );
                         }
                         runtime_helpers.consumeAddRandomRng(state);
                     }

--- a/crimson-zig/src/runtime/perks.zig
+++ b/crimson-zig/src/runtime/perks.zig
@@ -5,6 +5,7 @@ const native_math = @import("native_math.zig");
 const bonus_runtime = @import("bonuses.zig");
 const creature_lifecycle = @import("lifecycle.zig").CreatureLifecycle;
 const creatures_mod = @import("creatures.zig");
+const effects_mod = @import("effects.zig");
 const owner_ref = @import("owner_ref.zig");
 const particles_mod = @import("particles.zig");
 const player_runtime = @import("player.zig");
@@ -389,6 +390,7 @@ pub fn applyPerkWithContext(
             state.bonus_spawn_guard = false;
         },
         PerkId.bandage => {
+            var effects: effects_mod.EffectPool = .{};
             for (players) |*player| {
                 if (player.health > 0.0) {
                     const amount: f32 = @floatFromInt(state.rng.rand() % 50 + 1);
@@ -397,7 +399,15 @@ pub fn applyPerkWithContext(
                     } else {
                         player.health = @min(100.0, narrowF32(player.health + amount));
                     }
-                    consumeSpawnBurstRng(state, 8);
+                    effects.spawnBurst(
+                        state,
+                        player.pos,
+                        8,
+                        5,
+                        0.4,
+                        null,
+                        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 },
+                    );
                 }
             }
         },
@@ -412,7 +422,8 @@ pub fn applyReplayPerkCreatureEffects(
     creatures: *creatures_mod.CreaturePool,
     dt_frame: f32,
 ) void {
-    applyPerkImmediateCreatureEffects(perk_id, state, .{
+    var effects: effects_mod.EffectPool = .{};
+    applyPerkImmediateCreatureEffectsWithEffects(perk_id, state, &effects, 5, .{
         .creatures = creatures,
         .dt_frame = dt_frame,
     });
@@ -421,6 +432,17 @@ pub fn applyReplayPerkCreatureEffects(
 fn applyPerkImmediateCreatureEffects(
     perk_id: PerkId,
     state: *state_mod.GameplayState,
+    context: PerkApplyContext,
+) void {
+    var effects: effects_mod.EffectPool = .{};
+    applyPerkImmediateCreatureEffectsWithEffects(perk_id, state, &effects, 5, context);
+}
+
+fn applyPerkImmediateCreatureEffectsWithEffects(
+    perk_id: PerkId,
+    state: *state_mod.GameplayState,
+    effects: *effects_mod.EffectPool,
+    detail_preset: i32,
     context: PerkApplyContext,
 ) void {
     const creatures = context.creatures orelse return;
@@ -441,7 +463,15 @@ fn applyPerkImmediateCreatureEffects(
                     (creature.flags & spawn_mod.CreatureFlags.anim_ping_pong) == 0)
                 {
                     creature.active = false;
-                    consumeSpawnBurstRng(state, 4);
+                    effects.spawnBurst(
+                        state,
+                        creature.pos,
+                        4,
+                        detail_preset,
+                        0.4,
+                        null,
+                        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 },
+                    );
                 }
                 kill_toggle = !kill_toggle;
             }
@@ -647,12 +677,39 @@ pub fn applyFinalRevengeOnDeathTransition(
     world_size: f32,
     detail_preset: i32,
 ) void {
+    var effects: effects_mod.EffectPool = .{};
+    applyFinalRevengeOnDeathTransitionWithEffects(
+        state,
+        players,
+        player_index,
+        health_before,
+        creatures,
+        bonuses,
+        &effects,
+        dt,
+        world_size,
+        detail_preset,
+    );
+}
+
+pub fn applyFinalRevengeOnDeathTransitionWithEffects(
+    state: *state_mod.GameplayState,
+    players: []state_mod.PlayerState,
+    player_index: usize,
+    health_before: f32,
+    creatures: *creatures_mod.CreaturePool,
+    bonuses: *bonus_runtime.BonusPool,
+    effects: *effects_mod.EffectPool,
+    dt: f32,
+    world_size: f32,
+    detail_preset: i32,
+) void {
     if (player_index >= players.len) return;
     const player = &players[player_index];
     if (!(health_before > 0.0) or !(player.health <= 0.0)) return;
     if (!perkActive(player, PerkId.final_revenge)) return;
 
-    consumeExplosionBurstRng(state, detail_preset);
+    effects.spawnExplosionBurst(state, player.pos, 1.0, detail_preset);
     const prev_spawn_guard = state.bonus_spawn_guard;
     state.bonus_spawn_guard = true;
     defer state.bonus_spawn_guard = prev_spawn_guard;

--- a/crimson-zig/src/runtime/projectiles.zig
+++ b/crimson-zig/src/runtime/projectiles.zig
@@ -5,6 +5,7 @@ const native_math = @import("native_math.zig");
 const bonus_runtime = @import("bonuses.zig");
 const creatures_mod = @import("creatures.zig");
 const creature_lifecycle = @import("lifecycle.zig").CreatureLifecycle;
+const effects_mod = @import("effects.zig");
 const owner_ref = @import("owner_ref.zig");
 const perks = @import("perks.zig");
 const runtime_helpers = @import("helpers.zig");
@@ -131,6 +132,21 @@ pub const ProjectilePool = struct {
         players: []state_mod.PlayerState,
         creatures: *creatures_mod.CreaturePool,
         bonuses: *bonus_runtime.BonusPool,
+        dt: f32,
+        world_size: f32,
+    ) ProjectileTickStats {
+        var effects: effects_mod.EffectPool = .{};
+        return self.updateWithEffects(state, players, creatures, bonuses, &effects, 5, dt, world_size);
+    }
+
+    pub fn updateWithEffects(
+        self: *ProjectilePool,
+        state: *state_mod.GameplayState,
+        players: []state_mod.PlayerState,
+        creatures: *creatures_mod.CreaturePool,
+        bonuses: *bonus_runtime.BonusPool,
+        effects: *effects_mod.EffectPool,
+        detail_preset: i32,
         dt: f32,
         world_size: f32,
     ) ProjectileTickStats {
@@ -348,10 +364,15 @@ pub const ProjectilePool = struct {
                     }
                 }
                 if (presentation_player) |player| {
-                    creatures_mod.consumeProjectileHitPresentationPreRng(
+                    emitProjectileHitPresentationPre(
                         state,
                         player,
                         proj.type_id,
+                        proj.origin,
+                        proj.pos,
+                        creatures.entries[hit_idx.?].pos,
+                        effects,
+                        detail_preset,
                     );
                 }
 
@@ -394,7 +415,13 @@ pub const ProjectilePool = struct {
                         .y = narrowF32(creatures.entries[hit_idx.?].pos.y + move.y * 3.0),
                     };
                 }
-                consumeIonHitEffectsRng(state, proj.type_id);
+                emitProjectileTypeHitEffects(
+                    state,
+                    proj.type_id,
+                    proj.pos,
+                    effects,
+                    detail_preset,
+                );
 
                 var dist = state_mod.Vec2.sub(proj.origin, proj.pos).length();
                 if (dist < 50.0) dist = 50.0;
@@ -460,7 +487,7 @@ pub const ProjectilePool = struct {
                     proj.type_id != @intFromEnum(game_ids.ProjectileTypeId.gauss_gun) and
                     proj.type_id != @intFromEnum(game_ids.ProjectileTypeId.fire_bullets))
                 {
-                    consumeFreezeHitShardRng(state);
+                    effects.spawnFreezeShard(state, proj.pos, proj.angle, detail_preset);
                 }
 
                 if (proj.damage_pool == 1.0) {
@@ -580,15 +607,182 @@ fn applyIonLingerDamage(
     }
 }
 
-fn consumeFreezeHitShardRng(state: *state_mod.GameplayState) void {
-    // `shard_angle` draw + `effect_spawn_freeze_shard` internal draws.
-    _ = state.rng.rand() % 0x264;
-    _ = state.rng.rand() & 0xF;
-    _ = state.rng.rand() % 100;
-    _ = state.rng.rand() % 5;
-    _ = state.rng.rand() % 0x14;
-    _ = state.rng.rand() & 0xF;
-    _ = state.rng.rand() % 3;
+fn emitProjectileHitPresentationPre(
+    state: *state_mod.GameplayState,
+    player: *const state_mod.PlayerState,
+    projectile_type_id: i32,
+    hit_origin: state_mod.Vec2,
+    hit_pos: state_mod.Vec2,
+    hit_target: state_mod.Vec2,
+    effects: *effects_mod.EffectPool,
+    detail_preset: i32,
+) void {
+    const freeze_active = state.bonuses.freeze > 0.0;
+    const base_angle = state_mod.Vec2.sub(hit_pos, hit_origin).toAngle();
+
+    if (projectile_type_id == @intFromEnum(game_ids.ProjectileTypeId.blade_gun)) {
+        for (0..8) |_| {
+            const angle = @as(f32, @floatFromInt(state.rng.rand() & 0xff)) * 0.024543693;
+            effects.spawnBloodSplatter(state, hit_pos, angle, 0.0, detail_preset, state.gore_disabled);
+        }
+    }
+
+    if (perks.perkActive(player, PerkId.bloody_mess_quick_learner)) {
+        for (0..8) |_| {
+            const spread = (@as(f32, @floatFromInt(state.rng.rand() & 0x1f)) - 16.0) * 0.0625;
+            effects.spawnBloodSplatter(state, hit_pos, base_angle + spread, 0.0, detail_preset, state.gore_disabled);
+        }
+        effects.spawnBloodSplatter(state, hit_pos, base_angle + std.math.pi, 0.0, detail_preset, state.gore_disabled);
+
+        var lo: i32 = -30;
+        var hi: i32 = 30;
+        while (lo > -60) {
+            const span: u32 = @intCast(hi - lo);
+            for (0..2) |_| {
+                _ = state.rng.rand() % span;
+                _ = state.rng.rand() % span;
+                runtime_helpers.consumeAddRandomRng(state);
+            }
+            lo -= 10;
+            hi += 10;
+        }
+    } else if (!freeze_active) {
+        for (0..2) |_| {
+            effects.spawnBloodSplatter(state, hit_pos, base_angle, 0.0, detail_preset, state.gore_disabled);
+            if ((state.rng.rand() & 7) == 2) {
+                effects.spawnBloodSplatter(state, hit_pos, base_angle + std.math.pi, 0.0, detail_preset, state.gore_disabled);
+            }
+        }
+    }
+
+    _ = hit_target;
+}
+
+fn emitProjectileTypeHitEffects(
+    state: *state_mod.GameplayState,
+    projectile_type_id: i32,
+    pos: state_mod.Vec2,
+    effects: *effects_mod.EffectPool,
+    detail_preset: i32,
+) void {
+    switch (projectile_type_id) {
+        @intFromEnum(game_ids.ProjectileTypeId.shrinkifier) => {
+            _ = effects.spawn(
+                @intFromEnum(effects_mod.EffectId.ring),
+                pos,
+                .{},
+                0.0,
+                1.0,
+                36.0,
+                36.0,
+                0.0,
+                0.3,
+                0x19,
+                .{ .r = 0.3, .g = 0.6, .b = 0.9, .a = 1.0 },
+                0.0,
+                -4.0,
+                detail_preset,
+            );
+            const count: usize = if (detail_preset < 3) 2 else 4;
+            for (0..count) |_| {
+                effects.spawnBurstParticle(
+                    pos,
+                    state.rng.rand(),
+                    state.rng.rand(),
+                    state.rng.rand(),
+                    state.rng.rand(),
+                    null,
+                    0.3,
+                    .{ .r = 0.4, .g = 0.5, .b = 1.0, .a = 0.5 },
+                    detail_preset,
+                );
+            }
+        },
+        @intFromEnum(game_ids.ProjectileTypeId.ion_minigun),
+        @intFromEnum(game_ids.ProjectileTypeId.ion_rifle),
+        @intFromEnum(game_ids.ProjectileTypeId.ion_cannon),
+        => {
+            const ring_scale: f32 = switch (projectile_type_id) {
+                @intFromEnum(game_ids.ProjectileTypeId.ion_minigun) => 1.5,
+                @intFromEnum(game_ids.ProjectileTypeId.ion_rifle) => 1.2,
+                @intFromEnum(game_ids.ProjectileTypeId.ion_cannon) => 1.0,
+                else => 0.0,
+            };
+            const ring_strength: f32 = switch (projectile_type_id) {
+                @intFromEnum(game_ids.ProjectileTypeId.ion_minigun) => 0.1,
+                @intFromEnum(game_ids.ProjectileTypeId.ion_rifle) => 0.4,
+                @intFromEnum(game_ids.ProjectileTypeId.ion_cannon) => 1.0,
+                else => 0.0,
+            };
+            const burst_scale: f32 = switch (projectile_type_id) {
+                @intFromEnum(game_ids.ProjectileTypeId.ion_minigun) => 0.8,
+                @intFromEnum(game_ids.ProjectileTypeId.ion_rifle) => 1.2,
+                @intFromEnum(game_ids.ProjectileTypeId.ion_cannon) => 2.2,
+                else => 0.0,
+            };
+            effects.spawnRing(
+                pos,
+                detail_preset,
+                .{ .r = 0.6, .g = 0.6, .b = 0.9, .a = 1.0 },
+                ring_strength * 0.8,
+                ring_scale * 45.0,
+            );
+            const burst = burst_scale * 0.8;
+            var count: i32 = @intFromFloat(burst * 5.0);
+            if (detail_preset < 3) count = @divTrunc(count, 2);
+            var idx: i32 = 0;
+            while (idx < count) : (idx += 1) {
+                _ = effects.spawn(
+                    @intFromEnum(effects_mod.EffectId.burst),
+                    pos,
+                    .{
+                        .x = (@as(f32, @floatFromInt(state.rng.rand() & 0x7f)) - 64.0) * burst * 1.4,
+                        .y = (@as(f32, @floatFromInt(state.rng.rand() & 0x7f)) - 64.0) * burst * 1.4,
+                    },
+                    @as(f32, @floatFromInt(state.rng.rand() & 0x7f)) * 0.049087387,
+                    1.0,
+                    burst * 32.0,
+                    burst * 32.0,
+                    0.0,
+                    @min(burst * 0.7, 1.1),
+                    0x1D,
+                    .{ .r = 0.4, .g = 0.5, .b = 1.0, .a = 0.5 },
+                    0.0,
+                    (@as(f32, @floatFromInt(state.rng.rand() % 100)) * 0.01 + 0.1) * burst,
+                    detail_preset,
+                );
+            }
+        },
+        @intFromEnum(game_ids.ProjectileTypeId.plasma_cannon) => {
+            effects.spawnRing(pos, detail_preset, .{ .r = 0.9, .g = 0.6, .b = 0.3, .a = 1.0 }, 1.0, 1.5 * 45.0);
+            effects.spawnRing(pos, detail_preset, .{ .r = 0.9, .g = 0.6, .b = 0.3, .a = 1.0 }, 1.0, 1.0 * 45.0);
+        },
+        @intFromEnum(game_ids.ProjectileTypeId.splitter_gun) => {
+            for (0..3) |_| {
+                const angle = @as(f32, @floatFromInt(state.rng.rand() & 0x1ff)) * (std.math.tau / 512.0);
+                const radius = @as(f32, @floatFromInt(state.rng.rand() % 26));
+                const jitter_age = -@as(f32, @floatFromInt(state.rng.rand() & 0xff)) * 0.0012;
+                const offset = state_mod.Vec2.fromAngle(angle).mul(radius);
+                _ = effects.spawn(
+                    @intFromEnum(effects_mod.EffectId.burst),
+                    state_mod.Vec2.add(pos, offset),
+                    .{},
+                    0.0,
+                    1.0,
+                    4.0,
+                    4.0,
+                    jitter_age,
+                    0.1 - jitter_age,
+                    0x19,
+                    .{ .r = 1.0, .g = 0.9, .b = 0.1, .a = 1.0 },
+                    0.0,
+                    55.0,
+                    detail_preset,
+                );
+            }
+        },
+        else => {},
+    }
 }
 
 fn creatureHitRadius(size: f32) f32 {

--- a/crimson-zig/src/runtime/replay/capture_state.zig
+++ b/crimson-zig/src/runtime/replay/capture_state.zig
@@ -6,6 +6,7 @@ const runtime_bootstrap = @import("../bootstrap.zig");
 const bonus_runtime = @import("../bonuses.zig");
 const creature_lifecycle = @import("../lifecycle.zig").CreatureLifecycle;
 const creatures_mod = @import("../creatures.zig");
+const effects_mod = @import("../effects.zig");
 const particles_mod = @import("../particles.zig");
 const player_runtime = @import("../player.zig");
 const projectiles_mod = @import("../projectiles.zig");
@@ -315,6 +316,8 @@ pub fn applyCaptureStateReset(
     state: *state_mod.GameplayState,
     players: []state_mod.PlayerState,
     creatures: *creatures_mod.CreaturePool,
+    effects: *effects_mod.EffectPool,
+    sprite_effects: *effects_mod.SpriteEffectPool,
     particles: *particles_mod.ParticlePool,
     projectiles: *projectiles_mod.ProjectilePool,
     secondary_projectiles: *secondary_projectiles_mod.SecondaryProjectilePool,
@@ -379,6 +382,9 @@ pub fn applyCaptureStateReset(
     }
 
     creatures.reset();
+    creatures.effects = effects;
+    effects.reset();
+    sprite_effects.reset();
     particles.reset();
     projectiles.reset();
     secondary_projectiles.reset();
@@ -428,6 +434,12 @@ test "capture state reset clears transient pools and restores header fx toggle" 
     creatures.entries[0].active = true;
     creatures.entries[0].lifecycle_stage = creature_lifecycle.alive;
 
+    var effects: effects_mod.EffectPool = .{};
+    effects.entries[0].flags = 1;
+
+    var sprite_effects: effects_mod.SpriteEffectPool = .{};
+    sprite_effects.entries[0].active = true;
+
     var particles: particles_mod.ParticlePool = .{};
     particles.entries[0].active = true;
 
@@ -451,6 +463,8 @@ test "capture state reset clears transient pools and restores header fx toggle" 
         &state,
         players,
         &creatures,
+        &effects,
+        &sprite_effects,
         &particles,
         &projectiles,
         &secondary_projectiles,
@@ -470,6 +484,8 @@ test "capture state reset clears transient pools and restores header fx toggle" 
     try std.testing.expectEqual(@as(i32, 0), state.gore_disabled);
     try std.testing.expectEqual(@as(i32, 2), state.perk_selection.pending_count);
     try std.testing.expect(!creatures.entries[0].active);
+    try std.testing.expectEqual(@as(i32, 0), effects.entries[0].flags);
+    try std.testing.expect(!sprite_effects.entries[0].active);
     try std.testing.expect(!particles.entries[0].active);
     try std.testing.expect(!projectiles.entries[0].active);
     try std.testing.expect(!secondary_projectiles.entries[0].active);

--- a/crimson-zig/src/runtime/replay/step.zig
+++ b/crimson-zig/src/runtime/replay/step.zig
@@ -172,6 +172,8 @@ pub fn stepTick(
             &context.state,
             context.players(),
             &context.creatures,
+            &context.effects,
+            &context.sprite_effects,
             &context.particles,
             &context.projectiles,
             &context.secondary_projectiles,
@@ -279,6 +281,7 @@ pub fn stepTick(
     }
 
     callPhaseHook(options.hooks, context, .pre_effects, &frame);
+    context.effects.update(frame.dt);
     perks.updateEvilEyesTargets(players, context.creatures.entries[0..]);
     perks.updatePerkEffects(&context.state, players, frame.dt_sim);
     perks.applyJinxedEffects(&context.state, players, &context.creatures, frame.dt_sim);
@@ -305,34 +308,39 @@ pub fn stepTick(
     frame.rng_after_creatures = context.state.rng.state;
 
     for (players, 0..) |_, player_idx| {
-        perks.applyFinalRevengeOnDeathTransition(
+        perks.applyFinalRevengeOnDeathTransitionWithEffects(
             &context.state,
             players,
             player_idx,
             health_before_creatures[player_idx],
             &context.creatures,
             &context.bonuses,
+            &context.effects,
             frame.dt_sim,
             context.world_size,
             context.detail_preset,
         );
     }
 
-    frame.projectile_tick_stats = context.projectiles.update(
+    frame.projectile_tick_stats = context.projectiles.updateWithEffects(
         &context.state,
         players,
         &context.creatures,
         &context.bonuses,
+        &context.effects,
+        context.detail_preset,
         frame.dt_sim,
         context.world_size,
     );
     frame.rng_after_projectiles = context.state.rng.state;
 
-    context.secondary_projectiles.updatePulseGun(
+    context.secondary_projectiles.updatePulseGunWithEffects(
         &context.state,
         players,
         &context.creatures,
         &context.bonuses,
+        &context.effects,
+        &context.sprite_effects,
         frame.dt_sim,
         context.world_size,
         context.detail_preset,
@@ -344,9 +352,11 @@ pub fn stepTick(
         players,
         &context.creatures,
         &context.bonuses,
+        &context.sprite_effects,
         frame.dt_sim,
         context.world_size,
     );
+    context.sprite_effects.update(frame.dt);
     frame.rng_after_particles = context.state.rng.state;
     callPhaseHook(options.hooks, context, .post_core_simulation, &frame);
 
@@ -356,17 +366,20 @@ pub fn stepTick(
     }
     var player_preprocessed_alive = [_]bool{false} ** state_mod.max_players;
     for (players, 0..) |*player, player_idx| {
-        const should_tick_perks = weapons_runtime.preprocessPlayerForPerkTicks(
+        const should_tick_perks = weapons_runtime.preprocessPlayerForPerkTicksWithEffects(
             &context.state,
             player,
+            &context.effects,
+            context.detail_preset,
             frame.dt_sim,
         );
         player_preprocessed_alive[player_idx] = should_tick_perks;
         if (!should_tick_perks) continue;
-        weapons_runtime.applyPlayerPerkTicks(
+        weapons_runtime.applyPlayerPerkTicksWithEffects(
             &context.state,
             player,
             &context.projectiles,
+            &context.sprite_effects,
             frame.dt_sim,
         );
     }
@@ -385,13 +398,16 @@ pub fn stepTick(
             &context.creatures,
             frame.dt_sim,
         );
-        try weapons_runtime.stepPlayerForTick(
+        try weapons_runtime.stepPlayerForTickWithEffects(
             &context.state,
             player,
             &context.projectiles,
             &context.secondary_projectiles,
             &context.creatures,
             &context.particles,
+            &context.effects,
+            &context.sprite_effects,
+            context.detail_preset,
             .{
                 .fire_down = flags.fire_down,
                 .fire_pressed = flags.fire_pressed,
@@ -403,13 +419,14 @@ pub fn stepTick(
             },
             frame.dt_sim,
         );
-        perks.applyFinalRevengeOnDeathTransition(
+        perks.applyFinalRevengeOnDeathTransitionWithEffects(
             &context.state,
             players,
             player_idx,
             health_before_player_step,
             &context.creatures,
             &context.bonuses,
+            &context.effects,
             frame.dt_sim,
             context.world_size,
             context.detail_preset,
@@ -559,6 +576,12 @@ pub fn stepTick(
         dt_after_player,
         &context.tick_bonus_pickups,
     );
+    bonus_runtime.emitBonusPickupEffects(
+        &context.state,
+        context.tick_bonus_pickups.constSlice(),
+        &context.effects,
+        context.detail_preset,
+    );
     if (context.state.debug_last_picked_bonus_id == game_ids.BonusId.freeze) {
         bonus_runtime.applyFreezePickupCorpseCleanupRng(
             &context.state,
@@ -566,12 +589,13 @@ pub fn stepTick(
             freeze_corpse_at_tick_start[0..],
         );
     }
-    bonus_runtime.applyPendingBonusEffects(
+    bonus_runtime.applyPendingBonusEffectsWithEffects(
         &context.state,
         players,
         &context.projectiles,
         &context.creatures,
         &context.bonuses,
+        &context.effects,
         dt_after_player,
         context.world_size,
         tick_index,

--- a/crimson-zig/src/runtime/secondary_projectiles.zig
+++ b/crimson-zig/src/runtime/secondary_projectiles.zig
@@ -3,6 +3,7 @@ const native_math = @import("native_math.zig");
 const bonus_runtime = @import("bonuses.zig");
 const creature_lifecycle = @import("lifecycle.zig").CreatureLifecycle;
 const creatures_mod = @import("creatures.zig");
+const effects_mod = @import("effects.zig");
 const owner_ref = @import("owner_ref.zig");
 const runtime_helpers = @import("helpers.zig");
 const state_mod = @import("state.zig");
@@ -116,6 +117,33 @@ pub const SecondaryProjectilePool = struct {
         players: []state_mod.PlayerState,
         creatures: *creatures_mod.CreaturePool,
         bonuses: *bonus_runtime.BonusPool,
+        dt: f32,
+        world_size: f32,
+        detail_preset: i32,
+    ) void {
+        var effects: effects_mod.EffectPool = .{};
+        var sprite_effects: effects_mod.SpriteEffectPool = .{};
+        self.updatePulseGunWithEffects(
+            state,
+            players,
+            creatures,
+            bonuses,
+            &effects,
+            &sprite_effects,
+            dt,
+            world_size,
+            detail_preset,
+        );
+    }
+
+    pub fn updatePulseGunWithEffects(
+        self: *SecondaryProjectilePool,
+        state: *state_mod.GameplayState,
+        players: []state_mod.PlayerState,
+        creatures: *creatures_mod.CreaturePool,
+        bonuses: *bonus_runtime.BonusPool,
+        effects: *effects_mod.EffectPool,
+        sprite_effects: *effects_mod.SpriteEffectPool,
         dt: f32,
         world_size: f32,
         detail_preset: i32,
@@ -271,8 +299,16 @@ pub const SecondaryProjectilePool = struct {
             const trail_decay = narrowF32((@abs(entry.vel.x) + @abs(entry.vel.y)) * dt_f32 * 0.01);
             entry.trail_timer = narrowF32(entry.trail_timer - trail_decay);
             if (entry.trail_timer < 0.0) {
-                // `sprite_effects.spawn` consumes one rotation RNG draw.
-                _ = state.rng.rand() % 0x274;
+                const direction = runtime_helpers.directionFromHeading(entry.angle);
+                const spawn_pos = state_mod.Vec2.sub(entry.pos, direction.mul(9.0));
+                const trail_velocity = runtime_helpers.directionFromHeading(entry.angle + native_math.native_pi).mul(90.0);
+                _ = sprite_effects.spawn(
+                    state,
+                    spawn_pos,
+                    trail_velocity,
+                    14.0,
+                    .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 0.25 },
+                );
                 entry.trail_timer = narrowF32(0.06);
             }
 
@@ -302,8 +338,8 @@ pub const SecondaryProjectilePool = struct {
 
                 if (freeze_active) {
                     for (0..4) |_| {
-                        _ = state.rng.rand() % 0x264;
-                        runtime_helpers.consumeFreezeShardRng(state);
+                        const shard_angle = @as(f32, @floatFromInt(state.rng.rand() % 612)) * 0.01;
+                        effects.spawnFreezeShard(state, entry.pos, shard_angle, detail_preset);
                     }
                 } else {
                     for (0..3) |_| {
@@ -314,7 +350,7 @@ pub const SecondaryProjectilePool = struct {
                 }
 
                 if (entry.type_id == SecondaryProjectileTypeId.rocket and detail_preset > 2) {
-                    consumeExplosionBurstRng(state, detail_preset);
+                    effects.spawnExplosionBurst(state, entry.pos, 1.0, detail_preset);
                 }
 
                 const damage: f32 = switch (entry.type_id) {
@@ -347,8 +383,8 @@ pub const SecondaryProjectilePool = struct {
 
                 if (freeze_active) {
                     for (0..8) |_| {
-                        _ = state.rng.rand() % 0x264;
-                        runtime_helpers.consumeFreezeShardRng(state);
+                        const shard_angle = @as(f32, @floatFromInt(state.rng.rand() % 612)) * 0.01;
+                        effects.spawnFreezeShard(state, entry.pos, shard_angle, detail_preset);
                     }
                 } else {
                     const extra_decals: i32 = if (det_scale == 1.0)
@@ -380,10 +416,16 @@ pub const SecondaryProjectilePool = struct {
                     }
                 }
 
-                for (0..10) |_| {
-                    _ = state.rng.rand() % 800;
-                    // Each sprite spawn consumes one rotation RNG draw.
-                    _ = state.rng.rand() % 0x274;
+                for (0..10) |sprite_idx| {
+                    const mag = @as(f32, @floatFromInt(state.rng.rand() % 800)) * 0.1;
+                    const ang = @as(f32, @floatFromInt(sprite_idx)) * (native_math.native_tau / 10.0);
+                    _ = sprite_effects.spawn(
+                        state,
+                        entry.pos,
+                        state_mod.Vec2.fromAngle(ang).mul(mag),
+                        16.0,
+                        .{ .r = 1.0, .g = 0.5, .b = 0.2, .a = 0.35 },
+                    );
                 }
 
                 _ = hit_type;

--- a/crimson-zig/src/runtime/session.zig
+++ b/crimson-zig/src/runtime/session.zig
@@ -5,6 +5,7 @@ const replay_codec = @import("../replay_codec.zig");
 const bonus_runtime = @import("bonuses.zig");
 const runtime_bootstrap = @import("bootstrap.zig");
 const creatures_mod = @import("creatures.zig");
+const effects_mod = @import("effects.zig");
 const particles_mod = @import("particles.zig");
 const player_runtime = @import("player.zig");
 const projectiles_mod = @import("projectiles.zig");
@@ -104,6 +105,8 @@ pub const DeterministicSession = struct {
     players_len: usize,
 
     creatures: creatures_mod.CreaturePool = .{},
+    effects: effects_mod.EffectPool = .{},
+    sprite_effects: effects_mod.SpriteEffectPool = .{},
     particles: particles_mod.ParticlePool = .{},
     projectiles: projectiles_mod.ProjectilePool = .{},
     secondary_projectiles: secondary_projectiles_mod.SecondaryProjectilePool = .{},
@@ -213,6 +216,7 @@ pub const DeterministicSession = struct {
 
         player_runtime.resetPlayers(session.players(), config.world_size, null);
         session.creatures.capture_spawn_events_authoritative = options.capture_spawn_events_authoritative;
+        session.creatures.effects = &session.effects;
 
         if (config.game_mode == .rush) {
             runtime_bootstrap.enforceRushLoadout(session.players());

--- a/crimson-zig/src/runtime/weapons.zig
+++ b/crimson-zig/src/runtime/weapons.zig
@@ -3,6 +3,7 @@ const game_ids = @import("../game_ids.zig");
 const native_math = @import("native_math.zig");
 
 const creatures_mod = @import("creatures.zig");
+const effects_mod = @import("effects.zig");
 const fire_recipes = @import("fire_recipes.zig");
 const owner_ref = @import("owner_ref.zig");
 const particles_mod = @import("particles.zig");
@@ -31,6 +32,16 @@ pub const WeaponRuntimeError = error{
 
 const reload_preload_underflow_eps: f32 = 1e-7;
 const movement_control_mouse_point_click: i32 = 4;
+
+const MuzzleSpriteSpec = struct {
+    speed: f32,
+    scale: f32,
+    alpha: f32,
+};
+
+const fire_bullets_muzzle_specs = [_]MuzzleSpriteSpec{
+    .{ .speed = 25.0, .scale = 1.0, .alpha = 0.413 },
+};
 
 inline fn weaponId(value: i32) WeaponId {
     return weapon_data.weaponIdFromInt(value);
@@ -63,6 +74,17 @@ pub fn preprocessPlayerForPerkTicks(
     player: *state_mod.PlayerState,
     dt: f32,
 ) bool {
+    var effects: effects_mod.EffectPool = .{};
+    return preprocessPlayerForPerkTicksWithEffects(state, player, &effects, 5, dt);
+}
+
+pub fn preprocessPlayerForPerkTicksWithEffects(
+    state: *state_mod.GameplayState,
+    player: *state_mod.PlayerState,
+    effects: *effects_mod.EffectPool,
+    detail_preset: i32,
+    dt: f32,
+) bool {
     if (!(dt > 0.0)) return false;
 
     if (player.health <= 0.0) {
@@ -74,7 +96,17 @@ pub fn preprocessPlayerForPerkTicks(
         const next_low_health_timer = narrowF32(player.low_health_timer - dt);
         player.low_health_timer = next_low_health_timer;
         if (next_low_health_timer < 0.0) {
-            consumeLowHealthPulseRng(state);
+            for (0..3) |_| {
+                effects.spawnBloodSplatter(
+                    state,
+                    player.pos,
+                    player.aim_heading,
+                    0.0,
+                    detail_preset,
+                    state.gore_disabled,
+                );
+            }
+            _ = state.rng.rand() & 1;
             player.low_health_timer = 1.0;
         }
     }
@@ -92,10 +124,40 @@ pub fn stepPlayerForTick(
     input_flags: TickInputFlags,
     dt: f32,
 ) WeaponRuntimeError!void {
+    var effects: effects_mod.EffectPool = .{};
+    var sprite_effects: effects_mod.SpriteEffectPool = .{};
+    return stepPlayerForTickWithEffects(
+        state,
+        player,
+        projectiles,
+        secondary_projectiles,
+        creatures,
+        particles,
+        &effects,
+        &sprite_effects,
+        5,
+        input_flags,
+        dt,
+    );
+}
+
+pub fn stepPlayerForTickWithEffects(
+    state: *state_mod.GameplayState,
+    player: *state_mod.PlayerState,
+    projectiles: *projectiles_mod.ProjectilePool,
+    secondary_projectiles: *secondary_projectiles_mod.SecondaryProjectilePool,
+    creatures: *creatures_mod.CreaturePool,
+    particles: *particles_mod.ParticlePool,
+    effects: *effects_mod.EffectPool,
+    sprite_effects: *effects_mod.SpriteEffectPool,
+    detail_preset: i32,
+    input_flags: TickInputFlags,
+    dt: f32,
+) WeaponRuntimeError!void {
     if (!(dt > 0.0)) return;
 
     if (!input_flags.preprocessed_player_tick) {
-        if (!preprocessPlayerForPerkTicks(state, player, dt)) return;
+        if (!preprocessPlayerForPerkTicksWithEffects(state, player, effects, detail_preset, dt)) return;
     } else if (player.health <= 0.0) {
         return;
     }
@@ -240,6 +302,9 @@ pub fn stepPlayerForTick(
             secondary_projectiles,
             creatures,
             particles,
+            effects,
+            sprite_effects,
+            detail_preset,
             force_pre_swap_fire_gate,
         );
     }
@@ -253,6 +318,32 @@ pub fn tryFireWeapon(
     creatures: *creatures_mod.CreaturePool,
     particles: *particles_mod.ParticlePool,
 ) WeaponRuntimeError!bool {
+    var effects: effects_mod.EffectPool = .{};
+    var sprite_effects: effects_mod.SpriteEffectPool = .{};
+    return tryFireWeaponWithEffects(
+        state,
+        player,
+        projectiles,
+        secondary_projectiles,
+        creatures,
+        particles,
+        &effects,
+        &sprite_effects,
+        5,
+    );
+}
+
+pub fn tryFireWeaponWithEffects(
+    state: *state_mod.GameplayState,
+    player: *state_mod.PlayerState,
+    projectiles: *projectiles_mod.ProjectilePool,
+    secondary_projectiles: *secondary_projectiles_mod.SecondaryProjectilePool,
+    creatures: *creatures_mod.CreaturePool,
+    particles: *particles_mod.ParticlePool,
+    effects: *effects_mod.EffectPool,
+    sprite_effects: *effects_mod.SpriteEffectPool,
+    detail_preset: i32,
+) WeaponRuntimeError!bool {
     return tryFireWeaponWithForce(
         state,
         player,
@@ -260,6 +351,9 @@ pub fn tryFireWeapon(
         secondary_projectiles,
         creatures,
         particles,
+        effects,
+        sprite_effects,
+        detail_preset,
         false,
     );
 }
@@ -271,6 +365,9 @@ fn tryFireWeaponWithForce(
     secondary_projectiles: *secondary_projectiles_mod.SecondaryProjectilePool,
     creatures: *creatures_mod.CreaturePool,
     particles: *particles_mod.ParticlePool,
+    effects: *effects_mod.EffectPool,
+    sprite_effects: *effects_mod.SpriteEffectPool,
+    detail_preset: i32,
     force_pre_swap_fire_gate: bool,
 ) WeaponRuntimeError!bool {
     if (player.weapon.shot_cooldown > 0.0 and !force_pre_swap_fire_gate) return false;
@@ -340,11 +437,19 @@ fn tryFireWeaponWithForce(
     const weapon_flags = weapon_data.weapon_stats.get(player.weapon.weapon_id).flags;
 
     if ((weapon_flags & 0x1) != 0) {
-        // spawn_shell_casing randoms: angle speed rotation rotation_step.
-        _ = state.rng.rand();
-        _ = state.rng.rand();
-        _ = state.rng.rand();
-        _ = state.rng.rand();
+        const angle_draw = state.rng.rand();
+        const speed_draw = state.rng.rand();
+        const rotation_draw = state.rng.rand();
+        const rotation_step_draw = state.rng.rand();
+        effects.spawnShellCasing(
+            detail_preset,
+            player.pos,
+            aim_heading,
+            angle_draw,
+            speed_draw,
+            rotation_draw,
+            rotation_step_draw,
+        );
     }
 
     const dist = aim_delta.length();
@@ -370,7 +475,7 @@ fn tryFireWeaponWithForce(
         player.weapon.weapon_id == WeaponId.pistol or
         player.weapon.weapon_id == WeaponId.shrinkifier_5k;
     if (!spawn_muzzle_after_projectile) {
-        consumeMuzzleSpriteRng(state, player.weapon.weapon_id, is_fire_bullets);
+        spawnNativeFireMuzzleSprites(state, sprite_effects, player.weapon.weapon_id, muzzle, aim_heading, is_fire_bullets);
     }
 
     const recipe = fire_recipes.resolveFireRecipe(
@@ -474,7 +579,7 @@ fn tryFireWeaponWithForce(
     }
 
     if (spawn_muzzle_after_projectile) {
-        consumeMuzzleSpriteRng(state, player.weapon.weapon_id, is_fire_bullets);
+        spawnNativeFireMuzzleSprites(state, sprite_effects, player.weapon.weapon_id, muzzle, aim_heading, is_fire_bullets);
     }
 
     const player_idx = player.index;
@@ -504,6 +609,11 @@ fn tryFireWeaponWithForce(
         );
     }
 
+    const muzzle_inc = if (is_fire_bullets and pellet_count == 1) fire_bullets_spread_heat else weapon_spread_heat;
+    player.muzzle_flash_alpha = @min(1.0, player.muzzle_flash_alpha);
+    player.muzzle_flash_alpha = @min(1.0, player.muzzle_flash_alpha + muzzle_inc);
+    player.muzzle_flash_alpha = @min(0.8, player.muzzle_flash_alpha);
+
     if (player.weapon.ammo <= 0.0 and (force_pre_swap_fire_gate or player.weapon.reload_timer <= 0.0)) {
         player_runtime.playerStartReload(player, state);
     }
@@ -517,9 +627,20 @@ pub fn applyPlayerPerkTicks(
     projectiles: *projectiles_mod.ProjectilePool,
     dt: f32,
 ) void {
+    var sprite_effects: effects_mod.SpriteEffectPool = .{};
+    applyPlayerPerkTicksWithEffects(state, player, projectiles, &sprite_effects, dt);
+}
+
+pub fn applyPlayerPerkTicksWithEffects(
+    state: *state_mod.GameplayState,
+    player: *state_mod.PlayerState,
+    projectiles: *projectiles_mod.ProjectilePool,
+    sprite_effects: *effects_mod.SpriteEffectPool,
+    dt: f32,
+) void {
     tickManBomb(state, player, projectiles, dt);
     tickLivingFortress(player, dt);
-    tickFireCaugh(state, player, projectiles, dt);
+    tickFireCaugh(state, player, projectiles, sprite_effects, dt);
     tickHotTempered(state, player, projectiles, dt);
 }
 
@@ -578,6 +699,7 @@ fn tickFireCaugh(
     state: *state_mod.GameplayState,
     player: *state_mod.PlayerState,
     projectiles: *projectiles_mod.ProjectilePool,
+    sprite_effects: *effects_mod.SpriteEffectPool,
     dt: f32,
 ) void {
     if (!perks.perkActive(player, PerkId.fire_caugh)) {
@@ -621,8 +743,13 @@ fn tickFireCaugh(
         owner,
     );
 
-    // sprite_effects.spawn(...): slot scan + one rotation RNG draw in common case.
-    _ = state.rng.rand() % 0x274;
+    _ = sprite_effects.spawn(
+        state,
+        muzzle,
+        state_mod.Vec2.fromAngle(aim_heading).mul(25.0),
+        1.0,
+        .{ .r = 0.5, .g = 0.5, .b = 0.5, .a = 0.413 },
+    );
 
     player.fire_cough_timer -= state.perk_interval_fire_cough;
     state.perk_interval_fire_cough = @as(f32, @floatFromInt(state.rng.rand() % 4)) + 2.0;
@@ -749,50 +876,67 @@ fn applySpeedScaleRule(
     }
 }
 
-fn consumeMuzzleSpriteRng(
+fn spawnNativeFireMuzzleSprites(
     state: *state_mod.GameplayState,
+    sprite_effects: *effects_mod.SpriteEffectPool,
     weapon_id: WeaponId,
+    muzzle: state_mod.Vec2,
+    aim_heading: f32,
     fire_bullets_active: bool,
 ) void {
-    var count: usize = 0;
-    if (fire_bullets_active) {
-        count = 1;
-    } else {
-        count = switch (weapon_id) {
-            .pistol,
-            .assault_rifle,
-            .shotgun,
-            .sawed_off_shotgun,
-            .submachine_gun,
-            .gauss_gun,
-            .rocket_launcher,
-            .seeker_rockets,
-            .mini_rocket_swarmers,
-            .shrinkifier_5k,
-            .gauss_shotgun,
-            => 2,
-            .rocket_minigun, .jackhammer => 1,
-            else => 0,
-        };
-    }
-    for (0..count) |_| {
-        _ = state.rng.rand();
+    const specs = if (fire_bullets_active)
+        fire_bullets_muzzle_specs[0..]
+    else
+        muzzleSpriteSpecs(weapon_id);
+    for (specs) |spec| {
+        _ = sprite_effects.spawn(
+            state,
+            muzzle,
+            state_mod.Vec2.fromAngle(aim_heading).mul(spec.speed),
+            spec.scale,
+            .{ .r = 0.5, .g = 0.5, .b = 0.5, .a = spec.alpha },
+        );
     }
 }
 
-fn consumeLowHealthPulseRng(state: *state_mod.GameplayState) void {
-    // `player_update` low-health pulse: 3x `spawn_blood_splatter` (10 draws each)
-    // plus one bloodspill SFX-variant draw.
-    for (0..3) |_| {
-        for (0..2) |_| {
-            _ = state.rng.rand();
-            _ = state.rng.rand();
-            _ = state.rng.rand();
-            _ = state.rng.rand();
-            _ = state.rng.rand();
-        }
-    }
-    _ = state.rng.rand() & 1;
+fn muzzleSpriteSpecs(weapon_id: WeaponId) []const MuzzleSpriteSpec {
+    return switch (weapon_id) {
+        .pistol,
+        .assault_rifle,
+        .submachine_gun,
+        .shrinkifier_5k,
+        => &.{
+            .{ .speed = 25.0, .scale = 1.0, .alpha = 0.23 },
+            .{ .speed = 15.0, .scale = 2.0, .alpha = 0.213 },
+        },
+        .shotgun => &.{
+            .{ .speed = 25.0, .scale = 1.0, .alpha = 0.25 },
+            .{ .speed = 15.0, .scale = 2.0, .alpha = 0.223 },
+        },
+        .sawed_off_shotgun => &.{
+            .{ .speed = 25.0, .scale = 1.0, .alpha = 0.26 },
+            .{ .speed = 15.0, .scale = 2.0, .alpha = 0.233 },
+        },
+        .gauss_gun, .gauss_shotgun => &.{
+            .{ .speed = 25.0, .scale = 1.0, .alpha = 0.33 },
+            .{ .speed = 15.0, .scale = 2.0, .alpha = 0.263 },
+        },
+        .rocket_launcher,
+        .mini_rocket_swarmers,
+        .rocket_minigun,
+        => &.{
+            .{ .speed = 25.0, .scale = 1.0, .alpha = 0.34 },
+            .{ .speed = 15.0, .scale = 2.0, .alpha = 0.283 },
+        },
+        .seeker_rockets => &.{
+            .{ .speed = 25.0, .scale = 1.0, .alpha = 0.31 },
+            .{ .speed = 15.0, .scale = 2.0, .alpha = 0.243 },
+        },
+        .jackhammer => &.{
+            .{ .speed = 15.0, .scale = 2.0, .alpha = 0.223 },
+        },
+        else => &.{},
+    };
 }
 
 fn computeShotCount(

--- a/crimson-zig/src/test_root.zig
+++ b/crimson-zig/src/test_root.zig
@@ -6,6 +6,7 @@ test {
     _ = @import("audio/mod.zig");
     _ = cz.bonuses;
     _ = cz.creatures;
+    _ = cz.effects;
     _ = cz.hash;
     _ = cz.formats;
     _ = cz.helpers;

--- a/crimson-zig/src/window_atlas.zig
+++ b/crimson-zig/src/window_atlas.zig
@@ -15,6 +15,9 @@ pub const AtlasRect = struct {
 };
 
 pub const EffectId = enum(i32) {
+    burst = 0x00,
+    ring = 0x01,
+    shield_ring = 0x02,
     effect_03 = 0x03,
     effect_04 = 0x04,
     effect_05 = 0x05,
@@ -23,12 +26,14 @@ pub const EffectId = enum(i32) {
     freeze_shard_0 = 0x08,
     freeze_shard_1 = 0x09,
     freeze_shard_2 = 0x0A,
+    effect_0b = 0x0B,
     explosion_burst = 0x0C,
-    shield_ring = 0x02,
     glow = 0x0D,
     freeze_shatter = 0x0E,
+    effect_0f = 0x0F,
     aura = 0x10,
     explosion_puff = 0x11,
+    casing = 0x12,
 };
 
 pub const ColorRgb = struct {
@@ -122,6 +127,8 @@ pub fn effectRectById(texture_width: i32, texture_height: i32, effect_id_raw: i3
         frame: i32,
     };
     const entry = switch (effect_id_raw) {
+        0x00 => EffectEntry{ .size_code = 0x80, .frame = 0x02 },
+        0x01 => EffectEntry{ .size_code = 0x80, .frame = 0x03 },
         0x02 => EffectEntry{ .size_code = 0x20, .frame = 0x00 },
         0x03 => EffectEntry{ .size_code = 0x20, .frame = 0x01 },
         0x04 => EffectEntry{ .size_code = 0x20, .frame = 0x02 },
@@ -131,11 +138,14 @@ pub fn effectRectById(texture_width: i32, texture_height: i32, effect_id_raw: i3
         0x08 => EffectEntry{ .size_code = 0x20, .frame = 0x08 },
         0x09 => EffectEntry{ .size_code = 0x20, .frame = 0x09 },
         0x0A => EffectEntry{ .size_code = 0x20, .frame = 0x0A },
+        0x0B => EffectEntry{ .size_code = 0x20, .frame = 0x0B },
         0x0C => EffectEntry{ .size_code = 0x40, .frame = 0x05 },
         0x0D => EffectEntry{ .size_code = 0x40, .frame = 0x03 },
         0x0E => EffectEntry{ .size_code = 0x40, .frame = 0x04 },
+        0x0F => EffectEntry{ .size_code = 0x40, .frame = 0x05 },
         0x10 => EffectEntry{ .size_code = 0x40, .frame = 0x06 },
         0x11 => EffectEntry{ .size_code = 0x40, .frame = 0x07 },
+        0x12 => EffectEntry{ .size_code = 0x10, .frame = 0x26 },
         else => return null,
     };
     const grid: i32 = switch (entry.size_code) {

--- a/crimson-zig/src/window_effects.zig
+++ b/crimson-zig/src/window_effects.zig
@@ -1,0 +1,167 @@
+const std = @import("std");
+const rl = @import("raylib");
+
+const cz = @import("crimson_zig");
+const window_assets = @import("window_assets.zig");
+const window_atlas = cz.window_atlas;
+
+const effects_runtime = cz.effects;
+const runtime_particles = cz.particles;
+const runtime_session = cz.session;
+const state_mod = cz.state;
+
+pub const DrawCtx = struct {
+    session: *const runtime_session.DeterministicSession,
+    assets: *const window_assets.RuntimeAssets,
+};
+
+pub fn drawParticlePool(ctx: DrawCtx) void {
+    const texture = ctx.assets.texture(.particles);
+    const src_large = window_atlas.effectRectById(texture.width, texture.height, @intFromEnum(window_atlas.EffectId.glow)) orelse return;
+    const src_normal = window_atlas.effectRectById(texture.width, texture.height, @intFromEnum(window_atlas.EffectId.explosion_burst)) orelse return;
+    const src_style_8 = window_atlas.effectRectById(texture.width, texture.height, @intFromEnum(window_atlas.EffectId.shield_ring)) orelse return;
+
+    rl.beginBlendMode(.additive);
+    for (ctx.session.particles.entries, 0..) |entry, idx| {
+        if (!entry.active or entry.style_id == .bubblegun or (idx & 1) != 0) continue;
+        const radius = @max((std.math.sin((1.0 - entry.intensity) * std.math.pi / 2.0) + 0.1) * 55.0 + 4.0, 16.0);
+        drawTextureRegionCenteredRotated(
+            texture,
+            src_large,
+            toRlVec(entry.pos),
+            radius * 2.0,
+            radius * 2.0,
+            0.0,
+            colorWithAlpha(rl.Color.white, 0.065),
+        );
+    }
+
+    for (ctx.session.particles.entries) |entry| {
+        if (!entry.active or entry.style_id == .bubblegun) continue;
+        var radius = std.math.sin((1.0 - entry.intensity) * std.math.pi / 2.0) * 24.0;
+        if (entry.style_id == .blow_torch) radius *= 0.8;
+        radius = @max(radius, 2.0);
+        drawTextureRegionCenteredRotated(
+            texture,
+            src_normal,
+            toRlVec(entry.pos),
+            radius * 2.0,
+            radius * 2.0,
+            radiansToDegrees(entry.spin),
+            rlColorFromRgbAlpha(entry.scale_x, entry.scale_y, entry.scale_z, entry.age),
+        );
+    }
+
+    for (ctx.session.particles.entries) |entry| {
+        if (!entry.active or entry.style_id != .bubblegun) continue;
+        const wobble = std.math.sin(entry.spin) * 3.0;
+        const half_h = (wobble + 15.0) * entry.scale_x * 7.0;
+        const half_w = (15.0 - wobble) * entry.scale_x * 7.0;
+        drawTextureRegionCenteredRotated(
+            texture,
+            src_style_8,
+            toRlVec(entry.pos),
+            half_w * 2.0,
+            half_h * 2.0,
+            0.0,
+            colorWithAlpha(rl.Color.white, entry.age),
+        );
+    }
+    rl.endBlendMode();
+}
+
+pub fn drawSpriteEffectPool(ctx: DrawCtx) void {
+    const texture = ctx.assets.texture(.particles);
+    const src = window_atlas.effectRectById(texture.width, texture.height, @intFromEnum(window_atlas.EffectId.explosion_puff)) orelse return;
+
+    rl.beginBlendMode(.alpha);
+    for (ctx.session.sprite_effects.entries) |entry| {
+        if (!entry.active) continue;
+        drawTextureRegionCenteredRotated(
+            texture,
+            src,
+            toRlVec(entry.pos),
+            entry.scale,
+            entry.scale,
+            radiansToDegrees(entry.rotation),
+            rlColorFromEffect(entry.color),
+        );
+    }
+    rl.endBlendMode();
+}
+
+pub fn drawEffectPool(ctx: DrawCtx) void {
+    const texture = ctx.assets.texture(.particles);
+
+    rl.beginBlendMode(.alpha);
+    for (ctx.session.effects.entries) |entry| {
+        if (entry.flags == 0 or entry.age < 0.0 or (entry.flags & 0x40) == 0) continue;
+        drawEffectEntry(texture, entry);
+    }
+    rl.endBlendMode();
+
+    rl.beginBlendMode(.additive);
+    for (ctx.session.effects.entries) |entry| {
+        if (entry.flags == 0 or entry.age < 0.0 or (entry.flags & 0x40) != 0) continue;
+        drawEffectEntry(texture, entry);
+    }
+    rl.endBlendMode();
+}
+
+fn drawEffectEntry(texture: rl.Texture, entry: effects_runtime.EffectEntry) void {
+    const src = window_atlas.effectRectById(texture.width, texture.height, entry.effect_id) orelse return;
+    drawTextureRegionCenteredRotated(
+        texture,
+        src,
+        toRlVec(entry.pos),
+        entry.half_width * 2.0 * entry.scale,
+        entry.half_height * 2.0 * entry.scale,
+        radiansToDegrees(entry.rotation),
+        rlColorFromEffect(entry.color),
+    );
+}
+
+fn rlColorFromEffect(color: effects_runtime.Color) rl.Color {
+    return rlColorFromRgbAlpha(color.r, color.g, color.b, color.a);
+}
+
+fn rlColorFromRgbAlpha(r: f32, g: f32, b: f32, a: f32) rl.Color {
+    return rl.Color.init(
+        floatByte(r),
+        floatByte(g),
+        floatByte(b),
+        floatByte(a),
+    );
+}
+
+fn floatByte(value: f32) u8 {
+    return @intFromFloat(std.math.clamp(value, @as(f32, 0.0), @as(f32, 1.0)) * 255.0 + 0.5);
+}
+
+fn colorWithAlpha(color: rl.Color, alpha: f32) rl.Color {
+    return rl.Color.init(color.r, color.g, color.b, floatByte(alpha));
+}
+
+fn toRlVec(vec: state_mod.Vec2) rl.Vector2 {
+    return .{ .x = vec.x, .y = vec.y };
+}
+
+fn radiansToDegrees(radians: f32) f32 {
+    return radians * (180.0 / std.math.pi);
+}
+
+fn drawTextureRegionCenteredRotated(
+    texture: rl.Texture,
+    src_rect: window_atlas.AtlasRect,
+    center: rl.Vector2,
+    width: f32,
+    height: f32,
+    rotation_deg: f32,
+    tint: rl.Color,
+) void {
+    if (!(width > 0.0) or !(height > 0.0)) return;
+    const dst = rl.Rectangle.init(center.x, center.y, width, height);
+    const origin = rl.Vector2.init(width * 0.5, height * 0.5);
+    const src = rl.Rectangle.init(src_rect.x, src_rect.y, src_rect.width, src_rect.height);
+    rl.drawTexturePro(texture, src, dst, origin, rotation_deg, tint);
+}

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -14,6 +14,7 @@ const live_audio = @import("audio/live_audio.zig");
 const window_assets = @import("window_assets.zig");
 const window_atlas = cz.window_atlas;
 const window_boot = @import("window_boot.zig");
+const window_effects = @import("window_effects.zig");
 const window_ground = @import("window_ground.zig");
 const window_menu = @import("window_menu.zig");
 const window_menu_panels = @import("window_menu_panels.zig");
@@ -844,6 +845,7 @@ const App = struct {
             drawPlayers(runner, runtime_assets);
             drawCreatures(runner, runtime_assets);
             drawProjectiles(runner, runtime_assets);
+            drawWorldEffects(runner, runtime_assets);
             drawBonuses(runner, runtime_assets);
             camera.end();
 
@@ -1512,6 +1514,15 @@ fn drawProjectiles(runner: *const live_runner.LiveRunner, runtime_assets: ?*cons
         }
         rl.drawCircleV(toRlVec(projectile.pos), 3.0, projectile_color);
     }
+}
+
+fn drawWorldEffects(runner: *const live_runner.LiveRunner, runtime_assets: ?*const window_assets.RuntimeAssets) void {
+    if (runtime_assets) |assets| {
+        window_effects.drawParticlePool(.{
+            .session = &runner.session,
+            .assets = assets,
+        });
+    }
     for (runner.session.secondary_projectiles.entries) |projectile| {
         if (!projectile.active) continue;
         if (runtime_assets) |assets| {
@@ -1521,6 +1532,16 @@ fn drawProjectiles(runner: *const live_runner.LiveRunner, runtime_assets: ?*cons
             })) continue;
         }
         rl.drawCircleV(toRlVec(projectile.pos), 6.0, secondary_projectile_color);
+    }
+    if (runtime_assets) |assets| {
+        window_effects.drawSpriteEffectPool(.{
+            .session = &runner.session,
+            .assets = assets,
+        });
+        window_effects.drawEffectPool(.{
+            .session = &runner.session,
+            .assets = assets,
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- add a real transient FX runtime for Zig with shared effect and sprite-effect pools
- wire deterministic update and desktop draw order so particles, sprite effects, and effect-pool entries render like the Python world pass
- replace major RNG-only placeholders in weapons, projectiles, secondary projectiles, bonuses, perks, and creature spawn/death paths with real FX emission

## Testing
- zig build test
- zig build window
- zig build wasm
- zig build run-window
