### PR TITLE
refactor(zig): remove fallback shell paths

### DIFF
--- a/crimson-zig/src/runtime/bonuses.zig
+++ b/crimson-zig/src/runtime/bonuses.zig
@@ -5,7 +5,6 @@ const native_math = @import("native_math.zig");
 const creature_lifecycle = @import("lifecycle.zig").CreatureLifecycle;
 const creatures_mod = @import("creatures.zig");
 const effects_mod = @import("effects.zig");
-const runtime_helpers = @import("helpers.zig");
 const owner_ref = @import("owner_ref.zig");
 const perks = @import("perks.zig");
 const player_runtime = @import("player.zig");
@@ -444,9 +443,11 @@ pub fn applyPendingCreatureProjectiles(
     state.pending_creature_projectile_count = 0;
 }
 
-pub fn applyFreezePickupCorpseCleanupRng(
+pub fn applyFreezePickupCorpseEffects(
     state: *state_mod.GameplayState,
     creatures: *creatures_mod.CreaturePool,
+    effects: *effects_mod.EffectPool,
+    detail_preset: i32,
     freeze_corpse_at_tick_start: []const bool,
 ) void {
     for (&creatures.entries, 0..) |*creature, idx| {
@@ -459,11 +460,12 @@ pub fn applyFreezePickupCorpseCleanupRng(
         }
 
         if (idx < freeze_corpse_at_tick_start.len and freeze_corpse_at_tick_start[idx]) {
-            runtime_helpers.consumeFreezeShatterRng(
-                state,
-                rng_callers.bonus_apply_freeze_shard_angle,
-                rng_callers.bonus_apply_freeze_shatter_angle,
-            );
+            for (0..8) |_| {
+                const angle = @as(f32, @floatFromInt(state.rng.randTagged(rng_callers.bonus_apply_freeze_shard_angle) % 612)) * 0.01;
+                effects.spawnFreezeShard(state, creature.pos, angle, detail_preset);
+            }
+            const shatter_angle = @as(f32, @floatFromInt(state.rng.randTagged(rng_callers.bonus_apply_freeze_shatter_angle) % 612)) * 0.01;
+            effects.spawnFreezeShatter(state, creature.pos, shatter_angle, detail_preset);
         }
 
         creature.active = false;
@@ -1073,23 +1075,6 @@ fn appendPickupRecord(
     records.append(record) catch |err| switch (err) {
         error.OutOfSpace => {},
     };
-}
-
-fn consumeBonusPickupEffectsRng(
-    state: *state_mod.GameplayState,
-    bonus_id: BonusId,
-) void {
-    if (bonus_id != .nuke) {
-        // emit_bonus_pickup_effects -> spawn_burst(count=12, scale_step set).
-        runtime_helpers.consumeBurstRng(state, 12, false);
-    }
-}
-
-fn consumeSpawnBurstRng(
-    state: *state_mod.GameplayState,
-    count: usize,
-) void {
-    runtime_helpers.consumeBurstRng(state, count, true);
 }
 
 const quest_unlock_weapon_by_index = [_]i32{

--- a/crimson-zig/src/runtime/creatures.zig
+++ b/crimson-zig/src/runtime/creatures.zig
@@ -9,7 +9,6 @@ const effects_mod = @import("effects.zig");
 const owner_ref = @import("owner_ref.zig");
 const perks = @import("perks.zig");
 const rng_callers = @import("../rng_caller_static.zig");
-const runtime_helpers = @import("helpers.zig");
 const spawn_mod = @import("spawn.zig");
 const state_mod = @import("state.zig");
 const terrain_fx_mod = @import("terrain_fx.zig");
@@ -2132,7 +2131,16 @@ pub const CreaturePool = struct {
                 };
 
                 if (state.bonuses.energizer > 0.0 and creature.max_hp < 380.0) {
-                    runtime_helpers.consumeBurstRng(state, 6, true);
+                    const effects = self.effects orelse unreachable;
+                    effects.spawnBurst(
+                        state,
+                        creature.pos,
+                        6,
+                        5,
+                        0.4,
+                        null,
+                        .{ .r = 1.0, .g = 1.0, .b = 1.0, .a = 1.0 },
+                    );
                     creature.last_hit_owner = owner_ref.OwnerRef.fromPlayer(@intCast(player.index));
                     const prev_spawn_guard = state.bonus_spawn_guard;
                     state.bonus_spawn_guard = true;

--- a/crimson-zig/src/runtime/helpers.zig
+++ b/crimson-zig/src/runtime/helpers.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const native_math = @import("native_math.zig");
-const rng_callers = @import("../rng_caller_static.zig");
 
 const state_mod = @import("state.zig");
 const runtime_math = @import("math.zig");
@@ -45,55 +44,4 @@ pub fn distanceSq(a: state_mod.Vec2, b: state_mod.Vec2) f32 {
 
 pub fn distanceSqRoundedF32(a: state_mod.Vec2, b: state_mod.Vec2) f32 {
     return narrowF32(distanceSq(a, b));
-}
-
-pub fn consumeBurstRng(
-    state: *state_mod.GameplayState,
-    count: usize,
-    include_scale_step: bool,
-) void {
-    for (0..count) |_| {
-        _ = state.rng.randTagged(rng_callers.effect_spawn_burst_rotation);
-        _ = state.rng.randTagged(rng_callers.effect_spawn_burst_vel_x);
-        _ = state.rng.randTagged(rng_callers.effect_spawn_burst_vel_y);
-        if (include_scale_step) {
-            _ = state.rng.randTagged(rng_callers.effect_spawn_burst_scale_step);
-        }
-    }
-}
-
-pub fn consumeAddRandomRng(state: *state_mod.GameplayState) void {
-    _ = state.rng.randTagged(rng_callers.fx_queue_add_random_gray);
-    _ = state.rng.randTagged(rng_callers.fx_queue_add_random_width);
-    _ = state.rng.randTagged(rng_callers.fx_queue_add_random_rotation);
-    _ = state.rng.randTagged(rng_callers.fx_queue_add_random_effect_id);
-}
-
-pub fn consumeFreezeShardRng(state: *state_mod.GameplayState) void {
-    _ = state.rng.randTagged(rng_callers.effect_spawn_freeze_shard_lifetime);
-    _ = state.rng.randTagged(rng_callers.effect_spawn_freeze_shard_rotation);
-    _ = state.rng.randTagged(rng_callers.effect_spawn_freeze_shard_half);
-    _ = state.rng.randTagged(rng_callers.effect_spawn_freeze_shard_rotation_step);
-    _ = state.rng.randTagged(rng_callers.effect_spawn_freeze_shard_scale_step);
-    _ = state.rng.randTagged(rng_callers.effect_spawn_freeze_shard_effect_id);
-}
-
-pub fn consumeFreezeShatterRng(
-    state: *state_mod.GameplayState,
-    shard_angle_caller: rng_callers.Caller,
-    shatter_angle_caller: rng_callers.Caller,
-) void {
-    for (0..8) |_| {
-        _ = state.rng.randTagged(shard_angle_caller) % 0x264;
-        consumeFreezeShardRng(state);
-    }
-    _ = state.rng.randTagged(shatter_angle_caller) % 0x264;
-    for (0..4) |_| {
-        _ = state.rng.randTagged(rng_callers.effect_spawn_freeze_shatter_half);
-        _ = state.rng.randTagged(rng_callers.effect_spawn_freeze_shatter_rotation_step);
-    }
-    for (0..4) |_| {
-        _ = state.rng.randTagged(rng_callers.effect_spawn_freeze_shatter_shard_angle) % 0x264;
-        consumeFreezeShardRng(state);
-    }
 }

--- a/crimson-zig/src/runtime/perks.zig
+++ b/crimson-zig/src/runtime/perks.zig
@@ -6,7 +6,6 @@ const bonus_runtime = @import("bonuses.zig");
 const creature_lifecycle = @import("lifecycle.zig").CreatureLifecycle;
 const creatures_mod = @import("creatures.zig");
 const effects_mod = @import("effects.zig");
-const runtime_helpers = @import("helpers.zig");
 const owner_ref = @import("owner_ref.zig");
 const particles_mod = @import("particles.zig");
 const player_runtime = @import("player.zig");
@@ -483,13 +482,6 @@ fn applyPerkImmediateCreatureEffectsWithEffects(
     }
 }
 
-fn consumeSpawnBurstRng(
-    state: *state_mod.GameplayState,
-    count: usize,
-) void {
-    runtime_helpers.consumeBurstRng(state, count, true);
-}
-
 pub fn updatePerkEffects(
     state: *state_mod.GameplayState,
     players: []state_mod.PlayerState,
@@ -764,25 +756,6 @@ pub fn creatureFindInRadius(
         return @intCast(idx);
     }
     return -1;
-}
-
-pub fn consumeExplosionBurstRng(
-    state: *state_mod.GameplayState,
-    detail_preset: i32,
-) void {
-    if (detail_preset > 3) {
-        for (0..2) |_| {
-            _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_puff_rotation) % 0x266;
-        }
-    }
-    const count: usize = if (detail_preset < 2) 1 else 3 + (if (detail_preset > 3) @as(usize, 1) else 0);
-    for (0..count) |_| {
-        _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_rotation) % 0x13A;
-        _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_vel_x) & 0x3F;
-        _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_vel_y) & 0x3F;
-        _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_scale_step);
-        _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_rotation_STEP);
-    }
 }
 
 fn selectJinxedAccidentTarget(

--- a/crimson-zig/src/runtime/replay/step.zig
+++ b/crimson-zig/src/runtime/replay/step.zig
@@ -593,9 +593,11 @@ pub fn stepTick(
         context.detail_preset,
     );
     if (context.state.debug_last_picked_bonus_id == game_ids.BonusId.freeze) {
-        bonus_runtime.applyFreezePickupCorpseCleanupRng(
+        bonus_runtime.applyFreezePickupCorpseEffects(
             &context.state,
             &context.creatures,
+            &context.effects,
+            context.detail_preset,
             freeze_corpse_at_tick_start[0..],
         );
     }

--- a/crimson-zig/src/runtime/replay_runner.zig
+++ b/crimson-zig/src/runtime/replay_runner.zig
@@ -100,7 +100,7 @@ fn isAi7LinkTimerRolloverValue(link_index: i32) bool {
         link_index <= ai7_link_timer_rollover_max;
 }
 
-pub const ReplayScaffoldResult = struct {
+pub const ReplayRunResult = struct {
     ticks: usize,
     elapsed_ms_nominal: i64,
     elapsed_ms_sim: i64,
@@ -139,7 +139,7 @@ pub fn deinitReplayTickTraceRows(
     replay_diagnostic_trace.deinitReplayTickTraceSlice(allocator, rows);
 }
 
-pub const ReplayScaffoldOptions = struct {
+pub const ReplayRunOptions = struct {
     strict_events: bool = true,
     max_ticks: ?usize = null,
     inter_tick_rand_draws: i32 = 0,
@@ -153,17 +153,17 @@ fn ensureSupportedReplayFeatureFlags(
     if (demo_mode_active) return error.UnsupportedDemoMode;
 }
 
-pub fn runReplayScaffold(
+pub fn runReplay(
     replay: replay_codec.Replay,
-) ReplayRunnerError!ReplayScaffoldResult {
-    return runReplayScaffoldWithOptions(replay, .{});
+) ReplayRunnerError!ReplayRunResult {
+    return runReplayWithOptions(replay, .{});
 }
 
-pub fn runReplayScaffoldWithOptions(
+pub fn runReplayWithOptions(
     replay: replay_codec.Replay,
-    options: ReplayScaffoldOptions,
-) ReplayRunnerError!ReplayScaffoldResult {
-    return runReplayScaffoldWithTrace(
+    options: ReplayRunOptions,
+) ReplayRunnerError!ReplayRunResult {
+    return runReplayWithTrace(
         std.heap.page_allocator,
         replay,
         null,
@@ -171,12 +171,12 @@ pub fn runReplayScaffoldWithOptions(
     );
 }
 
-pub fn runReplayScaffoldWithTrace(
+pub fn runReplayWithTrace(
     trace_allocator: std.mem.Allocator,
     replay: replay_codec.Replay,
     trace_out: ?*std.ArrayList(ReplayTickTrace),
-    options: ReplayScaffoldOptions,
-) ReplayRunnerError!ReplayScaffoldResult {
+    options: ReplayRunOptions,
+) ReplayRunnerError!ReplayRunResult {
     const header = replay.header;
     const game_mode = std.meta.intToEnum(GameModeId, header.game_mode_id) catch {
         return error.UnsupportedGameMode;
@@ -652,7 +652,7 @@ fn applyCaptureCreatureSpawnEvent(
     }
 }
 
-test "replay scaffold rejects unsupported demo/preserve feature flags" {
+test "replay run rejects unsupported demo/preserve feature flags" {
     try std.testing.expectError(
         error.UnsupportedDemoMode,
         ensureSupportedReplayFeatureFlags(true),
@@ -660,7 +660,7 @@ test "replay scaffold rejects unsupported demo/preserve feature flags" {
     try ensureSupportedReplayFeatureFlags(false);
 }
 
-test "survival scaffold accepts preserve bugs replay headers" {
+test "survival run accepts preserve bugs replay headers" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -672,13 +672,13 @@ test "survival scaffold accepts preserve bugs replay headers" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffold(replay);
+    const result = try runReplay(replay);
     try std.testing.expectEqual(@as(usize, 1), result.ticks);
     try std.testing.expectEqual(@as(i64, 17), result.elapsed_ms_nominal);
     try std.testing.expectEqual(@as(i64, 16), result.elapsed_ms_sim);
 }
 
-test "survival scaffold tracks event and input counters" {
+test "survival run tracks event and input counters" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -693,7 +693,7 @@ test "survival scaffold tracks event and input counters" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffold(replay);
+    const result = try runReplay(replay);
     try std.testing.expectEqual(@as(usize, 2), result.ticks);
     try std.testing.expectEqual(@as(i64, 33), result.elapsed_ms_nominal);
     try std.testing.expectEqual(@as(i64, 32), result.elapsed_ms_sim);
@@ -712,7 +712,7 @@ test "survival scaffold tracks event and input counters" {
     try std.testing.expect(!result.survival_reward_fire_seen);
 }
 
-test "survival scaffold rejects unsupported event player index" {
+test "survival run rejects unsupported event player index" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -726,11 +726,11 @@ test "survival scaffold rejects unsupported event player index" {
 
     try std.testing.expectError(
         error.UnsupportedEventPlayerIndex,
-        runReplayScaffold(replay),
+        runReplay(replay),
     );
 }
 
-test "survival scaffold accepts multiplayer event player indices" {
+test "survival run accepts multiplayer event player indices" {
     const allocator = std.testing.allocator;
 
     const replay = try buildTestReplayMulti(allocator, .{
@@ -745,14 +745,14 @@ test "survival scaffold accepts multiplayer event player indices" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffold(replay);
+    const result = try runReplay(replay);
     try std.testing.expectEqual(@as(usize, 1), result.ticks);
     try std.testing.expectEqual(@as(usize, 1), result.perk_menu_open_count);
     try std.testing.expectEqual(@as(usize, 1), result.fire_pressed_count);
     try std.testing.expectEqual(@as(usize, 1), result.reload_pressed_count);
 }
 
-test "survival scaffold rejects multiplayer event player index out of bounds" {
+test "survival run rejects multiplayer event player index out of bounds" {
     const allocator = std.testing.allocator;
 
     const replay = try buildTestReplayMulti(allocator, .{
@@ -769,11 +769,11 @@ test "survival scaffold rejects multiplayer event player index out of bounds" {
 
     try std.testing.expectError(
         error.UnsupportedEventPlayerIndex,
-        runReplayScaffold(replay),
+        runReplay(replay),
     );
 }
 
-test "survival scaffold rejects invalid perk pick event in strict mode" {
+test "survival run rejects invalid perk pick event in strict mode" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -787,11 +787,11 @@ test "survival scaffold rejects invalid perk pick event in strict mode" {
 
     try std.testing.expectError(
         error.InvalidPerkPickEvent,
-        runReplayScaffold(replay),
+        runReplay(replay),
     );
 }
 
-test "survival scaffold can skip invalid perk pick event in non-strict mode" {
+test "survival run can skip invalid perk pick event in non-strict mode" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -803,7 +803,7 @@ test "survival scaffold can skip invalid perk pick event in non-strict mode" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffoldWithOptions(replay, .{
+    const result = try runReplayWithOptions(replay, .{
         .strict_events = false,
     });
     try std.testing.expectEqual(@as(usize, 1), result.ticks);
@@ -811,7 +811,7 @@ test "survival scaffold can skip invalid perk pick event in non-strict mode" {
     try std.testing.expectEqual(@as(i32, 0), result.perk_pending_count);
 }
 
-test "survival scaffold treats same-tick stale perk pick after menu open as strict no-op" {
+test "survival run treats same-tick stale perk pick after menu open as strict no-op" {
     const allocator = std.testing.allocator;
 
     const menu_only = try buildTestReplay(allocator, .{
@@ -833,22 +833,22 @@ test "survival scaffold treats same-tick stale perk pick after menu open as stri
     });
     defer with_stale_pick.deinit(allocator);
 
-    const menu_result = try runReplayScaffold(menu_only);
-    const stale_result = try runReplayScaffold(with_stale_pick);
+    const menu_result = try runReplay(menu_only);
+    const stale_result = try runReplay(with_stale_pick);
 
     try std.testing.expectEqual(menu_result.wave_spawn_rng_state, stale_result.wave_spawn_rng_state);
     try std.testing.expectEqual(menu_result.perk_pending_count, stale_result.perk_pending_count);
     try std.testing.expectEqual(@as(usize, 0), stale_result.perk_pick_count);
 }
 
-test "survival scaffold defers menu-open processing in original capture replays" {
+test "survival run defers menu-open processing in original capture replays" {
     const allocator = std.testing.allocator;
 
     const run = struct {
         fn runCase(
             allocator_inner: std.mem.Allocator,
             menu_before_pick: bool,
-        ) !ReplayScaffoldResult {
+        ) !ReplayRunResult {
             var bootstrap: replay_codec.CaptureBootstrapEvent = .{
                 .tick_index = 0,
             };
@@ -888,7 +888,7 @@ test "survival scaffold defers menu-open processing in original capture replays"
                     },
             });
             defer replay.deinit(allocator_inner);
-            return runReplayScaffold(replay);
+            return runReplay(replay);
         }
     }.runCase;
 
@@ -901,7 +901,7 @@ test "survival scaffold defers menu-open processing in original capture replays"
     try std.testing.expectEqual(menu_first.perk_pending_count, pick_first.perk_pending_count);
 }
 
-test "survival scaffold tracks weapon runtime counters" {
+test "survival run tracks weapon runtime counters" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -914,13 +914,13 @@ test "survival scaffold tracks weapon runtime counters" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffold(replay);
+    const result = try runReplay(replay);
     try std.testing.expectEqual(@as(i32, 1), result.shots_fired);
     try std.testing.expectEqual(@as(i32, 0), result.shots_hit);
     try std.testing.expectEqual(@intFromEnum(game_ids.WeaponId.pistol), result.most_used_weapon_id);
 }
 
-test "survival scaffold consumes replay dt rows for elapsed_ms" {
+test "survival run consumes replay dt rows for elapsed_ms" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -931,11 +931,11 @@ test "survival scaffold consumes replay dt rows for elapsed_ms" {
     defer replay.deinit(allocator);
 
     replay.dt[0] = 0.5;
-    const result = try runReplayScaffoldWithOptions(replay, .{});
+    const result = try runReplayWithOptions(replay, .{});
     try std.testing.expectEqual(@as(i64, 500), result.elapsed_ms_sim);
 }
 
-test "survival scaffold inter-tick rand draws shift rng deterministically" {
+test "survival run inter-tick rand draws shift rng deterministically" {
     const allocator = std.testing.allocator;
 
     const replay = try buildTestReplay(allocator, .{
@@ -946,11 +946,11 @@ test "survival scaffold inter-tick rand draws shift rng deterministically" {
     });
     defer replay.deinit(allocator);
 
-    const baseline = try runReplayScaffold(replay);
-    const shifted = try runReplayScaffoldWithOptions(replay, .{
+    const baseline = try runReplay(replay);
+    const shifted = try runReplayWithOptions(replay, .{
         .inter_tick_rand_draws = 1,
     });
-    const shifted_again = try runReplayScaffoldWithOptions(replay, .{
+    const shifted_again = try runReplayWithOptions(replay, .{
         .inter_tick_rand_draws = 1,
     });
 
@@ -959,7 +959,7 @@ test "survival scaffold inter-tick rand draws shift rng deterministically" {
     try std.testing.expect(shifted.wave_spawn_rng_state != baseline.wave_spawn_rng_state);
 }
 
-test "survival scaffold applies capture bootstrap payload state" {
+test "survival run applies capture bootstrap payload state" {
     const allocator = std.testing.allocator;
 
     var bootstrap: replay_codec.CaptureBootstrapEvent = .{
@@ -988,14 +988,14 @@ test "survival scaffold applies capture bootstrap payload state" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffold(replay);
+    const result = try runReplay(replay);
     try std.testing.expectEqual(@as(usize, 1), result.ticks);
     try std.testing.expectEqual(@as(i32, 321), result.player_experience);
     try std.testing.expectEqual(@as(i32, 5), result.player_level);
     try std.testing.expectEqual(@as(i32, 2), result.perk_pending_count);
 }
 
-test "survival scaffold applies terminal tick events" {
+test "survival run applies terminal tick events" {
     const allocator = std.testing.allocator;
 
     const with_terminal_event = try buildTestReplay(allocator, .{
@@ -1016,12 +1016,12 @@ test "survival scaffold applies terminal tick events" {
     });
     defer without_terminal_event.deinit(allocator);
 
-    const with_result = try runReplayScaffold(with_terminal_event);
-    const without_result = try runReplayScaffold(without_terminal_event);
+    const with_result = try runReplay(with_terminal_event);
+    const without_result = try runReplay(without_terminal_event);
     try std.testing.expect(with_result.wave_spawn_rng_state != without_result.wave_spawn_rng_state);
 }
 
-test "survival scaffold max ticks skips terminal tick events beyond clamp" {
+test "survival run max ticks skips terminal tick events beyond clamp" {
     const allocator = std.testing.allocator;
 
     const with_terminal_event = try buildTestReplay(allocator, .{
@@ -1042,17 +1042,17 @@ test "survival scaffold max ticks skips terminal tick events beyond clamp" {
     });
     defer without_terminal_event.deinit(allocator);
 
-    const with_result = try runReplayScaffoldWithOptions(with_terminal_event, .{
+    const with_result = try runReplayWithOptions(with_terminal_event, .{
         .max_ticks = 2,
     });
-    const without_result = try runReplayScaffoldWithOptions(without_terminal_event, .{
+    const without_result = try runReplayWithOptions(without_terminal_event, .{
         .max_ticks = 2,
     });
     try std.testing.expectEqual(@as(usize, 2), with_result.ticks);
     try std.testing.expectEqual(without_result.wave_spawn_rng_state, with_result.wave_spawn_rng_state);
 }
 
-test "survival scaffold bootstrap player shot cooldown blocks first-tick fire" {
+test "survival run bootstrap player shot cooldown blocks first-tick fire" {
     const allocator = std.testing.allocator;
 
     const run = struct {
@@ -1091,7 +1091,7 @@ test "survival scaffold bootstrap player shot cooldown blocks first-tick fire" {
             var trace: std.ArrayList(ReplayTickTrace) = .empty;
             defer trace.deinit(allocator_inner);
             defer deinitReplayTickTraceRows(allocator_inner, trace.items);
-            const result = try runReplayScaffoldWithTrace(
+            const result = try runReplayWithTrace(
                 allocator_inner,
                 replay,
                 &trace,
@@ -1113,7 +1113,7 @@ test "survival scaffold bootstrap player shot cooldown blocks first-tick fire" {
     try std.testing.expectEqual(f32Bits(12.0), with_cooldown.ammo_bits);
 }
 
-test "survival scaffold bootstrap perk counts enable alternate weapon swap" {
+test "survival run bootstrap perk counts enable alternate weapon swap" {
     const allocator = std.testing.allocator;
 
     const run = struct {
@@ -1157,7 +1157,7 @@ test "survival scaffold bootstrap perk counts enable alternate weapon swap" {
             });
             defer replay.deinit(allocator_inner);
 
-            const result = try runReplayScaffold(replay);
+            const result = try runReplay(replay);
             return result.player_weapon_id;
         }
     }.runCase;
@@ -1168,7 +1168,7 @@ test "survival scaffold bootstrap perk counts enable alternate weapon swap" {
     try std.testing.expectEqual(@as(i32, 1), with_counts);
 }
 
-test "survival scaffold bootstrap rejects invalid perk id in perk counts" {
+test "survival run bootstrap rejects invalid perk id in perk counts" {
     const allocator = std.testing.allocator;
 
     var bootstrap: replay_codec.CaptureBootstrapEvent = .{
@@ -1193,11 +1193,11 @@ test "survival scaffold bootstrap rejects invalid perk id in perk counts" {
 
     try std.testing.expectError(
         error.InvalidCaptureEnumValue,
-        runReplayScaffold(replay),
+        runReplay(replay),
     );
 }
 
-test "survival scaffold bootstrap rejects invalid perk id in choices" {
+test "survival run bootstrap rejects invalid perk id in choices" {
     const allocator = std.testing.allocator;
 
     var bootstrap: replay_codec.CaptureBootstrapEvent = .{
@@ -1219,7 +1219,7 @@ test "survival scaffold bootstrap rejects invalid perk id in choices" {
 
     try std.testing.expectError(
         error.InvalidCaptureEnumValue,
-        runReplayScaffold(replay),
+        runReplay(replay),
     );
 }
 
@@ -1260,7 +1260,7 @@ test "capture perk pending event sets pending without shifting rng in survival a
             });
             defer replay.deinit(allocator_inner);
 
-            const result = try runReplayScaffoldWithOptions(replay, .{
+            const result = try runReplayWithOptions(replay, .{
                 .quest_spawn_entries = if (game_mode_id == .quests) &.{} else null,
             });
             return .{
@@ -1285,7 +1285,7 @@ test "capture perk apply outside-before keeps rng anchored and consumes pending-
         fn runCase(
             allocator_inner: std.mem.Allocator,
             include_perk_apply: bool,
-        ) !ReplayScaffoldResult {
+        ) !ReplayRunResult {
             var bootstrap: replay_codec.CaptureBootstrapEvent = .{
                 .tick_index = 0,
             };
@@ -1322,7 +1322,7 @@ test "capture perk apply outside-before keeps rng anchored and consumes pending-
                     },
             });
             defer replay.deinit(allocator_inner);
-            return runReplayScaffold(replay);
+            return runReplay(replay);
         }
     }.runCase;
 
@@ -1333,7 +1333,7 @@ test "capture perk apply outside-before keeps rng anchored and consumes pending-
     try std.testing.expectEqual(@as(i32, 3), applied.perk_pending_count);
 }
 
-test "rush scaffold is deterministic and enforces assault rifle loadout" {
+test "rush run is deterministic and enforces assault rifle loadout" {
     const allocator = std.testing.allocator;
 
     const replay = try buildTestReplay(allocator, .{
@@ -1345,15 +1345,15 @@ test "rush scaffold is deterministic and enforces assault rifle loadout" {
     });
     defer replay.deinit(allocator);
 
-    const result0 = try runReplayScaffold(replay);
-    const result1 = try runReplayScaffold(replay);
+    const result0 = try runReplay(replay);
+    const result1 = try runReplay(replay);
     try std.testing.expectEqual(result0.wave_spawn_rng_state, result1.wave_spawn_rng_state);
     try std.testing.expectEqual(@as(usize, 10), result0.ticks);
     try std.testing.expectEqual(@intFromEnum(game_ids.WeaponId.assault_rifle), result0.player_weapon_id);
     try std.testing.expectEqual(@intFromEnum(game_ids.WeaponId.assault_rifle), result0.most_used_weapon_id);
 }
 
-test "rush scaffold consumes replay dt rows for elapsed_ms" {
+test "rush run consumes replay dt rows for elapsed_ms" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -1365,11 +1365,11 @@ test "rush scaffold consumes replay dt rows for elapsed_ms" {
     defer replay.deinit(allocator);
 
     replay.dt[0] = 0.5;
-    const result = try runReplayScaffoldWithOptions(replay, .{});
+    const result = try runReplayWithOptions(replay, .{});
     try std.testing.expectEqual(@as(i64, 500), result.elapsed_ms_sim);
 }
 
-test "rush scaffold spawn cadence uses raw frame dt, not sim dt" {
+test "rush run spawn cadence uses raw frame dt, not sim dt" {
     const allocator = std.testing.allocator;
 
     const inputs = [_]u32{0} ** 15;
@@ -1382,13 +1382,13 @@ test "rush scaffold spawn cadence uses raw frame dt, not sim dt" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffold(replay);
+    const result = try runReplay(replay);
     // Native rush cooldown arithmetic is float32; at 60 Hz nominal dt this yields a
     // second batch on tick 15 (0-indexed tick 14), so 4 total creatures in 15 ticks.
     try std.testing.expectEqual(@as(usize, 4), result.wave_spawn_count);
 }
 
-test "rush scaffold inter-tick rand draws shift rng deterministically" {
+test "rush run inter-tick rand draws shift rng deterministically" {
     const allocator = std.testing.allocator;
 
     const replay = try buildTestReplay(allocator, .{
@@ -1400,11 +1400,11 @@ test "rush scaffold inter-tick rand draws shift rng deterministically" {
     });
     defer replay.deinit(allocator);
 
-    const baseline = try runReplayScaffold(replay);
-    const shifted = try runReplayScaffoldWithOptions(replay, .{
+    const baseline = try runReplay(replay);
+    const shifted = try runReplayWithOptions(replay, .{
         .inter_tick_rand_draws = 1,
     });
-    const shifted_again = try runReplayScaffoldWithOptions(replay, .{
+    const shifted_again = try runReplayWithOptions(replay, .{
         .inter_tick_rand_draws = 1,
     });
 
@@ -1413,7 +1413,7 @@ test "rush scaffold inter-tick rand draws shift rng deterministically" {
     try std.testing.expect(shifted.wave_spawn_rng_state != baseline.wave_spawn_rng_state);
 }
 
-test "rush scaffold rejects replay events" {
+test "rush run rejects replay events" {
     const allocator = std.testing.allocator;
 
     const replay = try buildTestReplay(allocator, .{
@@ -1426,10 +1426,10 @@ test "rush scaffold rejects replay events" {
     });
     defer replay.deinit(allocator);
 
-    try std.testing.expectError(error.UnsupportedEventKind, runReplayScaffold(replay));
+    try std.testing.expectError(error.UnsupportedEventKind, runReplay(replay));
 }
 
-test "rush scaffold accepts capture bootstrap events" {
+test "rush run accepts capture bootstrap events" {
     const allocator = std.testing.allocator;
 
     var bootstrap: replay_codec.CaptureBootstrapEvent = .{
@@ -1457,7 +1457,7 @@ test "rush scaffold accepts capture bootstrap events" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffold(replay);
+    const result = try runReplay(replay);
     try std.testing.expectEqual(@as(usize, 1), result.ticks);
     try std.testing.expectEqual(@intFromEnum(game_ids.WeaponId.assault_rifle), result.player_weapon_id);
     try std.testing.expectEqual(@as(i32, 123), result.player_experience);
@@ -1479,7 +1479,7 @@ test "survival trace records authoritative rng rows and timing samples" {
     var trace: std.ArrayList(ReplayTickTrace) = .empty;
     defer trace.deinit(allocator);
     defer deinitReplayTickTraceRows(allocator, trace.items);
-    _ = try runReplayScaffoldWithTrace(
+    _ = try runReplayWithTrace(
         allocator,
         replay,
         &trace,
@@ -1503,7 +1503,7 @@ test "survival trace records authoritative rng rows and timing samples" {
     try std.testing.expectEqual(row.rng.rng_state, row.rng_rows[row.rng_rows.len - 1].state_after_u32);
 }
 
-test "rush scaffold original capture bootstrap keeps packed move vector behavior" {
+test "rush run original capture bootstrap keeps packed move vector behavior" {
     const allocator = std.testing.allocator;
 
     var bootstrap: replay_codec.CaptureBootstrapEvent = .{
@@ -1537,7 +1537,7 @@ test "rush scaffold original capture bootstrap keeps packed move vector behavior
     var trace: std.ArrayList(ReplayTickTrace) = .empty;
     defer trace.deinit(allocator);
     defer deinitReplayTickTraceRows(allocator, trace.items);
-    _ = try runReplayScaffoldWithTrace(
+    _ = try runReplayWithTrace(
         allocator,
         replay,
         &trace,
@@ -1547,7 +1547,7 @@ test "rush scaffold original capture bootstrap keeps packed move vector behavior
     try std.testing.expect(f32Bits(trace.items[0].player_state.pos.x) > f32Bits(512.0));
 }
 
-test "rush scaffold supports multiplayer replays" {
+test "rush run supports multiplayer replays" {
     const allocator = std.testing.allocator;
 
     const replay = try buildTestReplayMulti(allocator, .{
@@ -1564,13 +1564,13 @@ test "rush scaffold supports multiplayer replays" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffold(replay);
+    const result = try runReplay(replay);
     try std.testing.expectEqual(@as(usize, 3), result.ticks);
     try std.testing.expectEqual(@intFromEnum(game_ids.WeaponId.assault_rifle), result.player_weapon_id);
     try std.testing.expectEqual(@intFromEnum(game_ids.WeaponId.assault_rifle), result.most_used_weapon_id);
 }
 
-test "rush scaffold disables progression updates even above level threshold" {
+test "rush run disables progression updates even above level threshold" {
     const allocator = std.testing.allocator;
 
     var bootstrap: replay_codec.CaptureBootstrapEvent = .{
@@ -1596,13 +1596,13 @@ test "rush scaffold disables progression updates even above level threshold" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffold(replay);
+    const result = try runReplay(replay);
     try std.testing.expectEqual(@as(i32, 2060), result.player_experience);
     try std.testing.expectEqual(@as(i32, 1), result.player_level);
     try std.testing.expectEqual(@as(i32, 0), result.perk_pending_count);
 }
 
-test "survival scaffold supports player counts 1 through 4" {
+test "survival run supports player counts 1 through 4" {
     const allocator = std.testing.allocator;
 
     var player_count: i32 = 1;
@@ -1634,13 +1634,13 @@ test "survival scaffold supports player counts 1 through 4" {
         });
         defer replay.deinit(allocator);
 
-        const result = try runReplayScaffold(replay);
+        const result = try runReplay(replay);
         try std.testing.expectEqual(@as(usize, 2), result.ticks);
         try std.testing.expectEqual(@as(usize, 1), result.perk_menu_open_count);
     }
 }
 
-test "rush scaffold supports player counts 1 through 4" {
+test "rush run supports player counts 1 through 4" {
     const allocator = std.testing.allocator;
 
     var player_count: i32 = 1;
@@ -1664,14 +1664,14 @@ test "rush scaffold supports player counts 1 through 4" {
         });
         defer replay.deinit(allocator);
 
-        const result = try runReplayScaffold(replay);
+        const result = try runReplay(replay);
         try std.testing.expectEqual(@as(usize, 2), result.ticks);
         try std.testing.expectEqual(@intFromEnum(game_ids.WeaponId.assault_rifle), result.player_weapon_id);
         try std.testing.expectEqual(@intFromEnum(game_ids.WeaponId.assault_rifle), result.most_used_weapon_id);
     }
 }
 
-test "quest scaffold is deterministic with explicit spawn entries" {
+test "quest run is deterministic with explicit spawn entries" {
     const allocator = std.testing.allocator;
 
     const replay = try buildTestReplay(allocator, .{
@@ -1692,11 +1692,11 @@ test "quest scaffold is deterministic with explicit spawn entries" {
             .count = 1,
         },
     };
-    const result0 = try runReplayScaffoldWithOptions(replay, .{
+    const result0 = try runReplayWithOptions(replay, .{
         .quest_spawn_entries = quest_entries[0..],
         .quest_start_weapon_id = @intFromEnum(game_ids.WeaponId.pistol),
     });
-    const result1 = try runReplayScaffoldWithOptions(replay, .{
+    const result1 = try runReplayWithOptions(replay, .{
         .quest_spawn_entries = quest_entries[0..],
         .quest_start_weapon_id = @intFromEnum(game_ids.WeaponId.pistol),
     });
@@ -1704,7 +1704,7 @@ test "quest scaffold is deterministic with explicit spawn entries" {
     try std.testing.expectEqual(@as(usize, 10), result0.ticks);
 }
 
-test "quest scaffold timeline uses frame dt even when reflex boost is active" {
+test "quest run timeline uses frame dt even when reflex boost is active" {
     const allocator = std.testing.allocator;
 
     var bootstrap: replay_codec.CaptureBootstrapEvent = .{
@@ -1741,14 +1741,14 @@ test "quest scaffold timeline uses frame dt even when reflex boost is active" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffoldWithOptions(replay, .{
+    const result = try runReplayWithOptions(replay, .{
         .quest_spawn_entries = quest_entries[0..],
         .quest_start_weapon_id = @intFromEnum(game_ids.WeaponId.pistol),
     });
     try std.testing.expectEqual(@as(i64, 16), result.elapsed_ms_sim);
 }
 
-test "quest scaffold advances spawn timeline and fires entries" {
+test "quest run advances spawn timeline and fires entries" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -1770,7 +1770,7 @@ test "quest scaffold advances spawn timeline and fires entries" {
         },
     };
     replay.dt[0] = 0.5;
-    const result = try runReplayScaffoldWithOptions(replay, .{
+    const result = try runReplayWithOptions(replay, .{
         .quest_spawn_entries = quest_entries[0..],
     });
     try std.testing.expectEqual(@as(i64, 500), result.elapsed_ms_sim);
@@ -1778,7 +1778,7 @@ test "quest scaffold advances spawn timeline and fires entries" {
     try std.testing.expect(result.creature_active_count > 0);
 }
 
-test "quest scaffold supports multiplayer replays with explicit start weapon" {
+test "quest run supports multiplayer replays with explicit start weapon" {
     const allocator = std.testing.allocator;
 
     const replay = try buildTestReplayMulti(allocator, .{
@@ -1796,7 +1796,7 @@ test "quest scaffold supports multiplayer replays with explicit start weapon" {
     });
     defer replay.deinit(allocator);
 
-    const result = try runReplayScaffoldWithOptions(replay, .{
+    const result = try runReplayWithOptions(replay, .{
         .quest_start_weapon_id = @intFromEnum(game_ids.WeaponId.ion_cannon),
     });
     try std.testing.expectEqual(@as(usize, 2), result.ticks);
@@ -1804,7 +1804,7 @@ test "quest scaffold supports multiplayer replays with explicit start weapon" {
     try std.testing.expectEqual(@as(usize, 1), result.perk_menu_open_count);
 }
 
-test "quest scaffold resolves native quest preset and start weapon from replay header" {
+test "quest run resolves native quest preset and start weapon from replay header" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -1818,12 +1818,12 @@ test "quest scaffold resolves native quest preset and start weapon from replay h
     defer replay.deinit(allocator);
 
     replay.dt[0] = 3.0;
-    const result = try runReplayScaffoldWithOptions(replay, .{});
+    const result = try runReplayWithOptions(replay, .{});
     try std.testing.expectEqual(@as(i32, 6), result.player_weapon_id);
     try std.testing.expect(result.wave_spawn_count > 0);
 }
 
-test "quest scaffold supports dynamic quest seed variants when no spawn entries are provided" {
+test "quest run supports dynamic quest seed variants when no spawn entries are provided" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -1837,12 +1837,12 @@ test "quest scaffold supports dynamic quest seed variants when no spawn entries 
     defer replay.deinit(allocator);
 
     replay.dt[0] = 3.0;
-    const result = try runReplayScaffoldWithOptions(replay, .{});
+    const result = try runReplayWithOptions(replay, .{});
     try std.testing.expectEqual(@as(i32, 6), result.player_weapon_id);
     try std.testing.expect(result.wave_spawn_count > 0);
 }
 
-test "quest scaffold rejects unknown quest level when no spawn entries are provided" {
+test "quest run rejects unknown quest level when no spawn entries are provided" {
     const allocator = std.testing.allocator;
 
     const replay = try buildTestReplay(allocator, .{
@@ -1855,10 +1855,10 @@ test "quest scaffold rejects unknown quest level when no spawn entries are provi
     });
     defer replay.deinit(allocator);
 
-    try std.testing.expectError(error.UnsupportedQuestSpawnTable, runReplayScaffold(replay));
+    try std.testing.expectError(error.UnsupportedQuestSpawnTable, runReplay(replay));
 }
 
-test "quest scaffold supports player counts 1 through 4 across static and dynamic levels" {
+test "quest run supports player counts 1 through 4 across static and dynamic levels" {
     const allocator = std.testing.allocator;
     const level_cases = [_]struct {
         quest_level: []const u8,
@@ -1890,7 +1890,7 @@ test "quest scaffold supports player counts 1 through 4 across static and dynami
             defer replay.deinit(allocator);
 
             replay.dt[0] = 3.0;
-            const result = try runReplayScaffoldWithOptions(replay, .{});
+            const result = try runReplayWithOptions(replay, .{});
             try std.testing.expectEqual(@as(usize, 1), result.ticks);
             try std.testing.expectEqual(case.expected_start_weapon, result.player_weapon_id);
             try std.testing.expect(result.wave_spawn_count > 0);
@@ -1898,7 +1898,7 @@ test "quest scaffold supports player counts 1 through 4 across static and dynami
     }
 }
 
-test "quest scaffold applies capture bootstrap quest session timers" {
+test "quest run applies capture bootstrap quest session timers" {
     const allocator = std.testing.allocator;
 
     const inputs = [_]u32{0} ** 20;
@@ -1929,7 +1929,7 @@ test "quest scaffold applies capture bootstrap quest session timers" {
     var baseline_trace: std.ArrayList(ReplayTickTrace) = .empty;
     defer baseline_trace.deinit(allocator);
     defer deinitReplayTickTraceRows(allocator, baseline_trace.items);
-    _ = try runReplayScaffoldWithTrace(
+    _ = try runReplayWithTrace(
         allocator,
         replay_baseline,
         &baseline_trace,
@@ -1977,7 +1977,7 @@ test "quest scaffold applies capture bootstrap quest session timers" {
     var bootstrapped_trace: std.ArrayList(ReplayTickTrace) = .empty;
     defer bootstrapped_trace.deinit(allocator);
     defer deinitReplayTickTraceRows(allocator, bootstrapped_trace.items);
-    _ = try runReplayScaffoldWithTrace(
+    _ = try runReplayWithTrace(
         allocator,
         replay_bootstrapped,
         &bootstrapped_trace,
@@ -1989,7 +1989,7 @@ test "quest scaffold applies capture bootstrap quest session timers" {
     try std.testing.expect(bootstrapped_trace.items[19].summary.creature_count > 0);
 }
 
-test "quest scaffold disables runtime spawn slot ticks when capture spawns are authoritative" {
+test "quest run disables runtime spawn slot ticks when capture spawns are authoritative" {
     const allocator = std.testing.allocator;
 
     const inputs = [_]u32{0} ** 40;
@@ -2044,7 +2044,7 @@ test "quest scaffold disables runtime spawn slot ticks when capture spawns are a
     var trace: std.ArrayList(ReplayTickTrace) = .empty;
     defer trace.deinit(allocator);
     defer deinitReplayTickTraceRows(allocator, trace.items);
-    _ = try runReplayScaffoldWithTrace(
+    _ = try runReplayWithTrace(
         allocator,
         replay,
         &trace,
@@ -2201,7 +2201,7 @@ test "capture creature spawn event hard fails on invalid ai mode enum" {
     try std.testing.expectApproxEqAbs(heading_before, creatures.entries[0].heading, 1e-6);
 }
 
-test "quest scaffold resets run state on capture transition to terminal state" {
+test "quest run resets run state on capture transition to terminal state" {
     const allocator = std.testing.allocator;
 
     var replay = try buildTestReplay(allocator, .{
@@ -2256,7 +2256,7 @@ test "quest scaffold resets run state on capture transition to terminal state" {
     var trace: std.ArrayList(ReplayTickTrace) = .empty;
     defer trace.deinit(allocator);
     defer deinitReplayTickTraceRows(allocator, trace.items);
-    const result = try runReplayScaffoldWithTrace(
+    const result = try runReplayWithTrace(
         allocator,
         replay,
         &trace,
@@ -2295,7 +2295,7 @@ test "resolve quest level key ignores seed fallback outside i32 range" {
     try std.testing.expect(runtime_bootstrap.resolveQuestLevelKey(replay.header) == null);
 }
 
-test "quest scaffold rejects oversized quest spawn override table" {
+test "quest run rejects oversized quest spawn override table" {
     const allocator = std.testing.allocator;
     var replay = try buildTestReplay(allocator, .{
         .game_mode_id = @intFromEnum(GameModeId.quests),
@@ -2323,13 +2323,13 @@ test "quest scaffold rejects oversized quest spawn override table" {
 
     try std.testing.expectError(
         error.UnsupportedQuestSpawnTable,
-        runReplayScaffoldWithOptions(replay, .{
+        runReplayWithOptions(replay, .{
             .quest_spawn_entries = oversized,
         }),
     );
 }
 
-test "survival scaffold rejects world_size outside i32 range" {
+test "survival run rejects world_size outside i32 range" {
     const allocator = std.testing.allocator;
     var replay = try buildTestReplay(allocator, .{
         .tick_rate = 60,
@@ -2339,10 +2339,10 @@ test "survival scaffold rejects world_size outside i32 range" {
     defer replay.deinit(allocator);
 
     replay.header.world_size = 3_000_000_000.0;
-    try std.testing.expectError(error.InvalidHeaderValue, runReplayScaffold(replay));
+    try std.testing.expectError(error.InvalidHeaderValue, runReplay(replay));
 }
 
-test "quest scaffold disables world dt perk steps for original capture replays" {
+test "quest run disables world dt perk steps for original capture replays" {
     const allocator = std.testing.allocator;
 
     const bootstrap_event: replay_codec.ReplayEvent = .{
@@ -2398,7 +2398,7 @@ test "quest scaffold disables world dt perk steps for original capture replays" 
             var trace: std.ArrayList(ReplayTickTrace) = .empty;
             defer trace.deinit(allocator_inner);
             defer deinitReplayTickTraceRows(allocator_inner, trace.items);
-            _ = try runReplayScaffoldWithTrace(
+            _ = try runReplayWithTrace(
                 allocator_inner,
                 replay,
                 &trace,

--- a/crimson-zig/src/runtime/secondary_projectiles.zig
+++ b/crimson-zig/src/runtime/secondary_projectiles.zig
@@ -524,22 +524,3 @@ fn creatureFindNearestAlive(
     }
     return best_idx;
 }
-
-fn consumeExplosionBurstRng(
-    state: *state_mod.GameplayState,
-    detail_preset: i32,
-) void {
-    if (detail_preset > 3) {
-        for (0..2) |_| {
-            _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_puff_rotation) % 0x266;
-        }
-    }
-    const count: usize = if (detail_preset < 2) 1 else 3 + (if (detail_preset > 3) @as(usize, 1) else 0);
-    for (0..count) |_| {
-        _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_rotation) % 0x13A;
-        _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_vel_x) & 0x3F;
-        _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_vel_y) & 0x3F;
-        _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_scale_step);
-        _ = state.rng.randTagged(rng_callers.effect_spawn_explosion_burst_rotation_STEP);
-    }
-}

--- a/crimson-zig/src/runtime/weapons.zig
+++ b/crimson-zig/src/runtime/weapons.zig
@@ -845,26 +845,31 @@ fn applyPelletJitter(
     fire_bullets_active: bool,
     rule: fire_recipes.PelletJitterRule,
 ) f32 {
-    const caller = if (fire_bullets_active)
-        rng_callers.player_update_fire_bullets_pellet_jitter
-    else switch (weapon_id) {
-        .shotgun => rng_callers.player_update_shotgun_pellet_jitter,
-        .sawed_off_shotgun => rng_callers.player_update_sawed_off_shotgun_pellet_jitter,
-        .jackhammer => rng_callers.player_update_jackhammer_pellet_jitter,
-        .ion_shotgun => rng_callers.player_update_ion_shotgun_pellet_jitter,
-        .gauss_shotgun => rng_callers.player_update_gauss_shotgun_pellet_jitter,
-        .plasma_shotgun => rng_callers.player_update_plasma_shotgun_pellet_jitter,
-        else => unreachable,
-    };
     return switch (rule) {
         .none => shot_angle,
         .modulo_centered => |jitter| {
+            const caller: rng_callers.Caller = if (fire_bullets_active)
+                rng_callers.player_update_fire_bullets_pellet_jitter
+            else switch (weapon_id) {
+                .shotgun => rng_callers.player_update_shotgun_pellet_jitter,
+                .sawed_off_shotgun => rng_callers.player_update_sawed_off_shotgun_pellet_jitter,
+                .jackhammer => rng_callers.player_update_jackhammer_pellet_jitter,
+                .ion_shotgun => rng_callers.player_update_ion_shotgun_pellet_jitter,
+                .gauss_shotgun => rng_callers.player_update_gauss_shotgun_pellet_jitter,
+                else => unreachable,
+            };
             const jitter_roll = state.rng.randTagged(caller);
             return shot_angle + narrowF32(
                 @as(f32, @floatFromInt(@as(i32, @intCast(jitter_roll % jitter.modulo)) - jitter.center)) * jitter.step,
             );
         },
         .mask_centered => |jitter| {
+            const caller: rng_callers.Caller = if (fire_bullets_active)
+                rng_callers.player_update_fire_bullets_pellet_jitter
+            else switch (weapon_id) {
+                .plasma_shotgun => rng_callers.player_update_plasma_shotgun_pellet_jitter,
+                else => unreachable,
+            };
             const jitter_roll = state.rng.randTagged(caller);
             return shot_angle + narrowF32(
                 @as(f32, @floatFromInt(@as(i32, @intCast(jitter_roll & jitter.mask)) - jitter.center)) * jitter.step,
@@ -2056,6 +2061,19 @@ test "pistol fire consumes native casing+jitter+sfx rng draws" {
     player_runtime.weaponAssignPlayer(&player, game_ids.WeaponId.pistol);
     try std.testing.expect(try tryFireWeapon(&state, &player, &projectiles, &secondary_projectiles, &creatures, &particles));
     try std.testing.expect(projectiles.entries[0].active);
+}
+
+test "pellet jitter none does not require shotgun caller mapping" {
+    var state = state_mod.GameplayState.init(1);
+    const shot_angle: f32 = 1.25;
+    const angle = applyPelletJitter(
+        &state,
+        shot_angle,
+        .pistol,
+        false,
+        .none,
+    );
+    try expectFloatClose(shot_angle, angle);
 }
 
 test "fastshot scales shot cooldown" {

--- a/crimson-zig/src/verify_native.zig
+++ b/crimson-zig/src/verify_native.zig
@@ -224,9 +224,9 @@ fn runVerifyWithReplayBytes(
         tick_trace.deinit(allocator);
     };
 
-    const scaffold = blk: {
+    const run = blk: {
         if (trace_requested) {
-            const traced = replay_runner.runReplayScaffoldWithTrace(
+            const traced = replay_runner.runReplayWithTrace(
                 allocator,
                 replay,
                 &tick_trace,
@@ -263,7 +263,7 @@ fn runVerifyWithReplayBytes(
             break :blk traced;
         }
 
-        break :blk replay_runner.runReplayScaffoldWithOptions(replay, .{
+        break :blk replay_runner.runReplayWithOptions(replay, .{
             .max_ticks = request.max_ticks,
         }) catch |err| {
             return buildNotPortedOutputForReplayRunnerError(
@@ -280,14 +280,14 @@ fn runVerifyWithReplayBytes(
     const run_result: RunResult = .{
         .game_mode_id = header.game_mode_id,
         .tick_rate = header.tick_rate,
-        .ticks = @intCast(scaffold.ticks),
-        .elapsed_ms = scaffold.elapsed_ms_sim,
-        .score_xp = scaffold.player_experience,
-        .creature_kill_count = scaffold.creature_kill_count,
-        .most_used_weapon_id = scaffold.most_used_weapon_id,
-        .shots_fired = scaffold.shots_fired,
-        .shots_hit = scaffold.shots_hit,
-        .rng_state = scaffold.wave_spawn_rng_state,
+        .ticks = @intCast(run.ticks),
+        .elapsed_ms = run.elapsed_ms_sim,
+        .score_xp = run.player_experience,
+        .creature_kill_count = run.creature_kill_count,
+        .most_used_weapon_id = run.most_used_weapon_id,
+        .shots_fired = run.shots_fired,
+        .shots_hit = run.shots_hit,
+        .rng_state = run.wave_spawn_rng_state,
     };
     var header_claim_payload_storage: ?HeaderClaimPayload = null;
     defer if (header_claim_payload_storage) |payload| allocator.free(payload.mismatched_fields);
@@ -719,15 +719,15 @@ fn buildNotPortedOutputForReplayRunnerError(
     progress: ReplayRunnerProgressHint,
 ) !CommandOutput {
     const detail = switch (err) {
-        error.OutOfMemory => "replay simulation scaffold ran out of memory",
-        error.InvalidHeaderValue => "replay simulation scaffold received invalid header values",
-        error.UnsupportedGameMode => "replay simulation scaffold only supports survival/rush/quest modes",
-        error.UnsupportedPlayerCount => "replay simulation scaffold only supports 1-4 player replays",
-        error.UnsupportedInputQuantization => "replay simulation scaffold only supports f32 quantization",
-        error.UnsupportedDemoMode => "replay simulation scaffold does not support demo_mode_active=true",
+        error.OutOfMemory => "native replay run ran out of memory",
+        error.InvalidHeaderValue => "native replay run received invalid header values",
+        error.UnsupportedGameMode => "native replay run only supports survival/rush/quest modes",
+        error.UnsupportedPlayerCount => "native replay run only supports 1-4 player replays",
+        error.UnsupportedInputQuantization => "native replay run only supports f32 quantization",
+        error.UnsupportedDemoMode => "native replay run does not support demo_mode_active=true",
         error.UnsupportedEventOrdering => "replay events are not ordered in canonical tick order",
         error.UnsupportedEventKind => "replay events include kinds unsupported for this mode",
-        error.UnsupportedEventPlayerIndex => "replay simulation scaffold encountered an out-of-range player_index event",
+        error.UnsupportedEventPlayerIndex => "native replay run encountered an out-of-range player_index event",
         error.InvalidPerkPickEvent => "replay perk_pick event could not be applied in current perk state",
         error.InvalidCaptureEnumValue => "replay capture payload contains an invalid enum value",
         error.UnsupportedSpawnTemplate => "replay triggered survival template spawns not yet ported in native creature runtime",

--- a/crimson-zig/src/window_boot.zig
+++ b/crimson-zig/src/window_boot.zig
@@ -80,10 +80,6 @@ pub fn draw(state: *const State, runtime_assets: ?*const window_assets.RuntimeAs
         } else if (state.logo_active) {
             drawCompanyLogo(assets, state.boot_time - logo_time_offset);
         }
-    } else {
-        drawCenteredText("CRIMSON-ZIG", 144, 72, rl.Color.init(218, 80, 46, 255));
-        drawCenteredText("Desktop gameplay slice booting", 232, 24, rl.Color.init(245, 236, 225, 255));
-        drawCenteredText("raylib shell + live Zig runtime + archive-backed assets", 270, 18, rl.Color.init(171, 150, 132, 255));
     }
 }
 
@@ -151,9 +147,4 @@ fn drawSplash(runtime_assets: *const window_assets.RuntimeAssets, alpha: f32) vo
     window_ui.drawTextureFit(loading, rl.Rectangle.init(screen_w * 0.5 + 128.0, screen_h * 0.5 + 16.0, @floatFromInt(loading.width), @floatFromInt(loading.height)), window_ui.colorWithAlpha(rl.Color.white, alpha));
     const esrb = runtime_assets.texture(.logo_esrb);
     window_ui.drawTextureFit(esrb, rl.Rectangle.init(screen_w - @as(f32, @floatFromInt(esrb.width)) - 1.0, screen_h - @as(f32, @floatFromInt(esrb.height)) - 1.0, @floatFromInt(esrb.width), @floatFromInt(esrb.height)), window_ui.colorWithAlpha(rl.Color.white, alpha));
-}
-
-fn drawCenteredText(text: [:0]const u8, y: i32, font_size: i32, color: rl.Color) void {
-    const width = rl.measureText(text, font_size);
-    rl.drawText(text, @divTrunc(rl.getScreenWidth() - width, 2), y, font_size, color);
 }

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -993,9 +993,9 @@ fn drawAudioStatus(audio: *const live_audio.Bridge) void {
 fn drawStartupDiagnostics(app: *const App) void {
     switch (app.assets_state) {
         .loaded => {},
-        .unavailable => drawTextSlice("assets: no crimson.paq found; using primitive fallback", 28, 688, 18, muted_text),
+        .unavailable => drawTextSlice("assets: no crimson.paq found; desktop runtime cannot start", 28, 688, 18, muted_text),
         .failed => {
-            drawTextSlice("assets: load failed; using primitive fallback", 28, 668, 18, muted_text);
+            drawTextSlice("assets: load failed; desktop runtime cannot start", 28, 668, 18, muted_text);
             if (app.assets_message) |message| {
                 drawTextSlice(message, 28, 688, 18, rl.Color.orange);
             }

--- a/crimson-zig/src/window_menu.zig
+++ b/crimson-zig/src/window_menu.zig
@@ -99,6 +99,12 @@ pub fn update(state: *State, frame_dt: f32, runtime_assets: ?*const window_asset
         state.focus_timer_ms = @max(0, state.focus_timer_ms - dt_ms);
     }
 
+    if (runtime_assets == null) {
+        state.hovered_index = null;
+        updateHoverAmounts(state, dt_ms);
+        return .{};
+    }
+
     state.hovered_index = hoveredRootIndex(runtime_assets);
     if (state.hovered_index) |hovered_index| {
         if (rootEntryEnabled(hovered_index, state.timeline_ms)) {
@@ -138,22 +144,15 @@ pub fn update(state: *State, frame_dt: f32, runtime_assets: ?*const window_asset
 }
 
 pub fn draw(state: *const State, runtime_assets: ?*const window_assets.RuntimeAssets) void {
-    if (runtime_assets) |assets| {
-        drawMenuBackdrop(assets);
-        drawSign(state.timeline_ms, assets);
-        for (root_entries, 0..) |entry, idx| {
-            drawRootEntry(state, assets, entry, idx, idx == state.selection);
-        }
+    const assets = runtime_assets orelse {
+        rl.clearBackground(rl.Color.black);
         return;
-    }
+    };
 
-    rl.clearBackground(rl.Color.init(16, 12, 10, 255));
-    drawFallbackBackdrop();
-    drawCenteredText("CRIMSONLAND", 104, 64, rl.Color.init(218, 80, 46, 255));
-    const buttons = fallbackRootButtons();
-    for (buttons, 0..) |button, idx| {
-        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
-        window_ui.drawButton(button, idx == state.selection, hovered, null);
+    drawMenuBackdrop(assets);
+    drawSign(state.timeline_ms, assets);
+    for (root_entries, 0..) |entry, idx| {
+        drawRootEntry(state, assets, entry, idx, idx == state.selection);
     }
 }
 
@@ -283,14 +282,6 @@ pub fn drawPanelBackEntry(runtime_assets: *const window_assets.RuntimeAssets, ti
     rl.endBlendMode();
 }
 
-fn drawFallbackBackdrop() void {
-    const width = rl.getScreenWidth();
-    const height = rl.getScreenHeight();
-    rl.drawRectangleGradientV(0, 0, width, height, rl.Color.init(32, 18, 16, 255), rl.Color.init(16, 12, 10, 255));
-    rl.drawCircle(width - 180, 120, 200.0, rl.Color.init(93, 31, 22, 80));
-    rl.drawCircle(160, height - 80, 220.0, rl.Color.init(58, 23, 18, 90));
-}
-
 fn drawRootEntry(state: *const State, runtime_assets: *const window_assets.RuntimeAssets, entry: RootEntry, idx: usize, selected: bool) void {
     const item = runtime_assets.texture(.ui_menu_item);
     const labels = runtime_assets.texture(.ui_item_texts);
@@ -327,17 +318,10 @@ fn drawRootEntry(state: *const State, runtime_assets: *const window_assets.Runti
 
 fn hoveredRootIndex(runtime_assets: ?*const window_assets.RuntimeAssets) ?usize {
     const mouse = rl.getMousePosition();
-    if (runtime_assets) |assets| {
-        const item = assets.texture(.ui_menu_item);
-        for (root_entries, 0..) |entry, idx| {
-            if (rl.checkCollisionPointRec(mouse, rootButtonRect(entry.slot, item))) return idx;
-        }
-        return null;
-    }
-
-    const buttons = fallbackRootButtons();
-    for (buttons, 0..) |button, idx| {
-        if (rl.checkCollisionPointRec(mouse, button.rect)) return idx;
+    const assets = runtime_assets orelse return null;
+    const item = assets.texture(.ui_menu_item);
+    for (root_entries, 0..) |entry, idx| {
+        if (rl.checkCollisionPointRec(mouse, rootButtonRect(entry.slot, item))) return idx;
     }
     return null;
 }
@@ -432,21 +416,6 @@ fn menuItemScale(slot: usize) struct { scale: f32, local_y_shift: f32 } {
     return .{ .scale = 1.0, .local_y_shift = 0.0 };
 }
 
-fn fallbackRootButtons() [4]window_ui.UiButton {
-    const center_x = @as(f32, @floatFromInt(rl.getScreenWidth())) * 0.5;
-    return .{
-        .{ .label = "PLAY GAME", .rect = window_ui.centeredRect(center_x, 280.0, 300.0, 52.0) },
-        .{ .label = "OPTIONS", .rect = window_ui.centeredRect(center_x, 344.0, 300.0, 52.0) },
-        .{ .label = "STATISTICS", .rect = window_ui.centeredRect(center_x, 408.0, 300.0, 52.0) },
-        .{ .label = "QUIT", .rect = window_ui.centeredRect(center_x, 472.0, 300.0, 52.0) },
-    };
-}
-
 fn radiansToDegrees(radians: f32) f32 {
     return radians * (180.0 / std.math.pi);
-}
-
-fn drawCenteredText(text: [:0]const u8, y: i32, font_size: i32, color: rl.Color) void {
-    const width = rl.measureText(text, font_size);
-    rl.drawText(text, @divTrunc(rl.getScreenWidth() - width, 2), y, font_size, color);
 }


### PR DESCRIPTION
## Summary
- remove the remaining fallback menu and boot UI paths when assets are missing
- replace freeze pickup corpse cleanup RNG consumption with real freeze shard/shatter effects
- delete dead consume-only effect helpers and rename replay runner surfaces away from the old scaffold terminology

## Testing
- cd crimson-zig && zig build test
- cd crimson-zig && zig build window
- cd crimson-zig && zig build wasm
