### PR TITLE
feat(zig): port aim and menu cursors

### DIFF
--- a/crimson-zig/src/test_root.zig
+++ b/crimson-zig/src/test_root.zig
@@ -29,5 +29,6 @@ test {
     _ = cz.weapon_data;
     _ = cz.weapons;
     _ = cz.window_atlas;
+    _ = @import("window_cursor.zig");
     _ = @import("window_statistics.zig");
 }

--- a/crimson-zig/src/window_cursor.zig
+++ b/crimson-zig/src/window_cursor.zig
@@ -22,7 +22,7 @@ pub fn drawMenuCursor(runtime_assets: *const window_assets.RuntimeAssets, pulse_
     );
 }
 
-pub fn drawAimEnhancements(
+pub fn drawAimIndicators(
     runtime_assets: *const window_assets.RuntimeAssets,
     player: state_mod.PlayerState,
     zoom: f32,
@@ -47,7 +47,16 @@ pub fn drawAimEnhancements(
             drawClockGauge(runtime_assets, aim, ms, 1.0 / zoom, entity_alpha);
         }
     }
+}
 
+pub fn drawAimReticle(
+    runtime_assets: *const window_assets.RuntimeAssets,
+    player: state_mod.PlayerState,
+    zoom: f32,
+) void {
+    if (player.health <= 0.0) return;
+    if (!(zoom > 0.0)) return;
+    const aim = rl.Vector2.init(player.aim.x, player.aim.y);
     drawAimCursor(runtime_assets, aim, 1.0 / zoom);
 }
 

--- a/crimson-zig/src/window_cursor.zig
+++ b/crimson-zig/src/window_cursor.zig
@@ -1,0 +1,169 @@
+const std = @import("std");
+const rl = @import("raylib");
+
+const cz = @import("crimson_zig");
+const state_mod = cz.state;
+const window_atlas = cz.window_atlas;
+const window_assets = @import("window_assets.zig");
+const window_ui = @import("window_ui.zig");
+
+pub fn drawMenuCursor(runtime_assets: *const window_assets.RuntimeAssets, pulse_time: f32) void {
+    const mouse = rl.getMousePosition();
+    drawCursorGlow(runtime_assets, mouse, pulse_time);
+
+    const texture = runtime_assets.texture(.ui_cursor);
+    rl.drawTexturePro(
+        texture,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height)),
+        rl.Rectangle.init(mouse.x - 2.0, mouse.y - 2.0, 32.0, 32.0),
+        rl.Vector2.zero(),
+        0.0,
+        rl.Color.white,
+    );
+}
+
+pub fn drawAimEnhancements(
+    runtime_assets: *const window_assets.RuntimeAssets,
+    player: state_mod.PlayerState,
+    zoom: f32,
+    entity_alpha: f32,
+) void {
+    if (player.health <= 0.0) return;
+    if (!(zoom > 0.0)) return;
+    if (!(entity_alpha > 1e-3)) return;
+
+    const aim = rl.Vector2.init(player.aim.x, player.aim.y);
+    const dist = state_mod.Vec2.sub(player.aim, player.pos).length();
+    const radius = @max(6.0, dist * player.spread_heat * 0.5);
+    const screen_radius = @max(1.0, radius * zoom);
+    drawAimCircle(aim, screen_radius / zoom, entity_alpha);
+
+    const reload_timer = player.weapon.reload_timer;
+    const reload_timer_max = player.weapon.reload_timer_max;
+    if (reload_timer_max > 1e-6 and reload_timer > 1e-6) {
+        const progress = reload_timer / reload_timer_max;
+        if (progress > 0.0) {
+            const ms: i32 = @intFromFloat(progress * 60000.0);
+            drawClockGauge(runtime_assets, aim, ms, 1.0 / zoom, entity_alpha);
+        }
+    }
+
+    drawAimCursor(runtime_assets, aim, 1.0 / zoom);
+}
+
+fn drawCursorGlow(runtime_assets: *const window_assets.RuntimeAssets, pos: rl.Vector2, pulse_time: f32) void {
+    const particles = runtime_assets.texture(.particles);
+    const src_rect = window_atlas.effectRect(particles.width, particles.height, .glow) orelse return;
+    const alpha = clamp01((std.math.pow(f32, 2.0, std.math.sin(pulse_time)) + 2.0) * 0.32);
+    const tint = rl.Color.init(255, 255, 255, @intFromFloat(alpha * 255.0 + 0.5));
+
+    rl.beginBlendMode(.additive);
+    defer rl.endBlendMode();
+
+    const offsets = [_]struct { dx: f32, dy: f32, size: f32 }{
+        .{ .dx = -28.0, .dy = -28.0, .size = 64.0 },
+        .{ .dx = -10.0, .dy = -18.0, .size = 64.0 },
+        .{ .dx = -18.0, .dy = -10.0, .size = 64.0 },
+        .{ .dx = -48.0, .dy = -48.0, .size = 128.0 },
+    };
+    for (offsets) |item| {
+        rl.drawTexturePro(
+            particles,
+            rl.Rectangle.init(src_rect.x, src_rect.y, src_rect.width, src_rect.height),
+            rl.Rectangle.init(pos.x + item.dx, pos.y + item.dy, item.size, item.size),
+            rl.Vector2.zero(),
+            0.0,
+            tint,
+        );
+    }
+}
+
+fn drawAimCursor(runtime_assets: *const window_assets.RuntimeAssets, pos: rl.Vector2, world_scale: f32) void {
+    const particles = runtime_assets.texture(.particles);
+    if (window_atlas.effectRect(particles.width, particles.height, .glow)) |src_rect| {
+        rl.beginBlendMode(.additive);
+        rl.drawTexturePro(
+            particles,
+            rl.Rectangle.init(src_rect.x, src_rect.y, src_rect.width, src_rect.height),
+            rl.Rectangle.init(pos.x - 32.0 * world_scale, pos.y - 32.0 * world_scale, 64.0 * world_scale, 64.0 * world_scale),
+            rl.Vector2.zero(),
+            0.0,
+            rl.Color.white,
+        );
+        rl.endBlendMode();
+    }
+
+    const aim = runtime_assets.texture(.ui_aim);
+    rl.drawTexturePro(
+        aim,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(aim.width), @floatFromInt(aim.height)),
+        rl.Rectangle.init(pos.x - 10.0 * world_scale, pos.y - 10.0 * world_scale, 20.0 * world_scale, 20.0 * world_scale),
+        rl.Vector2.zero(),
+        0.0,
+        rl.Color.white,
+    );
+}
+
+fn grim2dCircleSegmentsFilled(radius: f32) i32 {
+    return @max(3, @as(i32, @intFromFloat(radius * 0.125 + 12.0)));
+}
+
+fn grim2dCircleSegmentsOutline(radius: f32) i32 {
+    return @max(3, @as(i32, @intFromFloat(radius * 0.2 + 14.0)));
+}
+
+fn drawAimCircle(center: rl.Vector2, radius: f32, alpha: f32) void {
+    if (!(radius > 1e-3)) return;
+    const clamped_alpha = clamp01(alpha);
+    if (!(clamped_alpha > 1e-3)) return;
+
+    const fill_alpha: u8 = @intFromFloat(77.0 * clamped_alpha + 0.5);
+    const outline_alpha: u8 = @intFromFloat(255.0 * 0.55 * clamped_alpha + 0.5);
+    const fill = rl.Color.init(0, 0, 26, fill_alpha);
+    const outline = rl.Color.init(255, 255, 255, outline_alpha);
+    const seg_fill = @max(grim2dCircleSegmentsFilled(radius), @max(@as(i32, 64), @as(i32, @intFromFloat(radius))));
+    const seg_outline = @max(grim2dCircleSegmentsOutline(radius), seg_fill);
+
+    rl.beginBlendMode(.alpha);
+    defer rl.endBlendMode();
+    rl.drawCircleSector(center, radius, 0.0, 360.0, seg_fill, fill);
+    rl.drawRing(center, radius, radius + 2.0, 0.0, 360.0, seg_outline, outline);
+}
+
+fn drawClockGauge(
+    runtime_assets: *const window_assets.RuntimeAssets,
+    pos: rl.Vector2,
+    ms: i32,
+    scale: f32,
+    alpha: f32,
+) void {
+    const size = 32.0 * scale;
+    if (!(size > 1e-3)) return;
+    const tint = window_ui.colorWithAlpha(rl.Color.white, alpha);
+    const half = size * 0.5;
+
+    const table = runtime_assets.texture(.ui_clock_table);
+    rl.drawTexturePro(
+        table,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(table.width), @floatFromInt(table.height)),
+        rl.Rectangle.init(pos.x, pos.y, size, size),
+        rl.Vector2.zero(),
+        0.0,
+        tint,
+    );
+
+    const pointer = runtime_assets.texture(.ui_clock_pointer);
+    const seconds = @divTrunc(ms, 1000);
+    rl.drawTexturePro(
+        pointer,
+        rl.Rectangle.init(0.0, 0.0, @floatFromInt(pointer.width), @floatFromInt(pointer.height)),
+        rl.Rectangle.init(pos.x + half, pos.y + half, size, size),
+        rl.Vector2.init(half, half),
+        @as(f32, @floatFromInt(seconds)) * 6.0,
+        tint,
+    );
+}
+
+fn clamp01(value: f32) f32 {
+    return std.math.clamp(value, @as(f32, 0.0), @as(f32, 1.0));
+}

--- a/crimson-zig/src/window_effects.zig
+++ b/crimson-zig/src/window_effects.zig
@@ -72,7 +72,7 @@ pub fn drawParticlePool(ctx: DrawCtx) void {
 
 pub fn drawSpriteEffectPool(ctx: DrawCtx) void {
     const texture = ctx.assets.texture(.particles);
-    const src = window_atlas.effectRectById(texture.width, texture.height, @intFromEnum(window_atlas.EffectId.explosion_puff)) orelse return;
+    const src = window_atlas.atlasRect(texture.width, texture.height, 4, 7);
 
     rl.beginBlendMode(.alpha);
     for (ctx.session.sprite_effects.entries) |entry| {

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -1673,7 +1673,10 @@ fn drawAimEnhancements(
     const assets = runtime_assets orelse return;
     const alpha: f32 = 1.0;
     for (runner.session.playersConst()) |player| {
-        window_cursor.drawAimEnhancements(assets, player, zoom, alpha);
+        window_cursor.drawAimIndicators(assets, player, zoom, alpha);
+    }
+    for (runner.session.playersConst()) |player| {
+        window_cursor.drawAimReticle(assets, player, zoom);
     }
 }
 

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -14,6 +14,7 @@ const live_audio = @import("audio/live_audio.zig");
 const window_assets = @import("window_assets.zig");
 const window_atlas = cz.window_atlas;
 const window_boot = @import("window_boot.zig");
+const window_cursor = @import("window_cursor.zig");
 const window_effects = @import("window_effects.zig");
 const window_ground = @import("window_ground.zig");
 const window_menu = @import("window_menu.zig");
@@ -256,6 +257,7 @@ const App = struct {
     assets_state: AssetsState = .unavailable,
     assets_message: ?[]u8 = null,
     next_seed_state: u32 = 0xC0FFEE,
+    cursor_pulse_time: f32 = 0.0,
     quit_requested: bool = false,
 
     fn init(allocator: std.mem.Allocator, runtime: app_runtime.DesktopRuntime) App {
@@ -306,6 +308,7 @@ const App = struct {
     }
 
     fn update(self: *App, frame_dt: f32) void {
+        self.tickCursorPulse(frame_dt);
         switch (self.screen) {
             .boot => self.updateBoot(frame_dt),
             .main_menu => self.updateMainMenu(frame_dt),
@@ -332,13 +335,41 @@ const App = struct {
             .options => self.drawOptions(),
             .controls => self.drawControls(),
         }
+        self.drawUiCursor();
+    }
+
+    fn setScreen(self: *App, screen: Screen) void {
+        if (self.screen != screen) self.cursor_pulse_time = 0.0;
+        self.screen = screen;
+    }
+
+    fn tickCursorPulse(self: *App, frame_dt: f32) void {
+        if (self.screen == .boot) return;
+        self.cursor_pulse_time += @min(@max(frame_dt, 0.0), 0.1) * 1.1;
+    }
+
+    fn drawUiCursor(self: *const App) void {
+        const assets = if (self.runtime_assets) |*runtime_assets| runtime_assets else return;
+        switch (self.screen) {
+            .boot => {},
+            .main_menu, .play_game_menu, .quests_menu, .statistics_menu, .results, .options, .controls => {
+                window_cursor.drawMenuCursor(assets, self.cursor_pulse_time);
+            },
+            .gameplay => {
+                if (self.gameplay) |gameplay| {
+                    if (gameplay.perk_ui.active()) {
+                        window_cursor.drawMenuCursor(assets, self.cursor_pulse_time);
+                    }
+                }
+            },
+        }
     }
 
     fn updateBoot(self: *App, frame_dt: f32) void {
         const result = window_boot.update(&self.boot, frame_dt);
         if (result.finished) {
             self.menu.openRoot();
-            self.screen = .main_menu;
+            self.setScreen(.main_menu);
             return;
         }
         self.audio.ensureIntroMusic();
@@ -362,15 +393,15 @@ const App = struct {
             switch (action) {
                 .open_play_game => {
                     self.play_game_menu.reset();
-                    self.screen = .play_game_menu;
+                    self.setScreen(.play_game_menu);
                 },
                 .open_options => {
                     self.options.reset();
-                    self.screen = .options;
+                    self.setScreen(.options);
                 },
                 .open_statistics => {
                     window_statistics.openRoot(&self.statistics_menu, self.allocator);
-                    self.screen = .statistics_menu;
+                    self.setScreen(.statistics_menu);
                 },
                 .quit => self.quit_requested = true,
             }
@@ -393,11 +424,11 @@ const App = struct {
             .start_tutorial => self.startNewRun(runConfigForLiveMode(.tutorial, null, &self.next_seed_state)),
             .open_quests => {
                 self.quests_menu.reset();
-                self.screen = .quests_menu;
+                self.setScreen(.quests_menu);
             },
             .back_to_menu => {
                 self.menu.openRoot();
-                self.screen = .main_menu;
+                self.setScreen(.main_menu);
             },
         };
     }
@@ -413,7 +444,7 @@ const App = struct {
         if (quest_update.play_button_click) self.audio.playUiButtonClick();
         if (quest_update.back_to_play_game) {
             self.play_game_menu.reset();
-            self.screen = .play_game_menu;
+            self.setScreen(.play_game_menu);
             return;
         }
         if (quest_update.start_level_key) |level_key| {
@@ -443,11 +474,11 @@ const App = struct {
             .none => {},
             .open_play_game => {
                 self.play_game_menu.reset();
-                self.screen = .play_game_menu;
+                self.setScreen(.play_game_menu);
             },
             .back_to_menu => {
                 self.menu.openRoot();
-                self.screen = .main_menu;
+                self.setScreen(.main_menu);
             },
         }
     }
@@ -537,7 +568,7 @@ const App = struct {
                 }
                 self.results = null;
                 self.menu.openRoot();
-                self.screen = .main_menu;
+                self.setScreen(.main_menu);
             },
             else => {},
         }
@@ -557,11 +588,11 @@ const App = struct {
             .none => {},
             .open_controls => {
                 self.controls.reset();
-                self.screen = .controls;
+                self.setScreen(.controls);
             },
             .back_to_menu => {
                 self.menu.openRoot();
-                self.screen = .main_menu;
+                self.setScreen(.main_menu);
             },
         }
     }
@@ -577,7 +608,7 @@ const App = struct {
         if (controls_update.play_button_click) self.audio.playUiButtonClick();
         switch (controls_update.action) {
             .none => {},
-            .back_to_options => self.screen = .options,
+            .back_to_options => self.setScreen(.options),
         }
     }
 
@@ -684,7 +715,7 @@ const App = struct {
                 .runtime_error = @errorName(err),
             };
             self.results_selection = 0;
-            self.screen = .results;
+            self.setScreen(.results);
             return;
         };
         const last_update = runner.stepFrame(0.0, .{}) catch unreachable;
@@ -714,7 +745,7 @@ const App = struct {
         }
         self.gameplay = gameplay;
         self.results = null;
-        self.screen = .gameplay;
+        self.setScreen(.gameplay);
     }
 
     fn reloadAudioConfig(self: *App) void {
@@ -747,7 +778,7 @@ const App = struct {
         gameplay.deinit();
         self.gameplay = null;
         self.results_selection = 0;
-        self.screen = .results;
+        self.setScreen(.results);
     }
 
     fn buildResultsHighscore(
@@ -859,12 +890,14 @@ const App = struct {
             drawProjectiles(runner, runtime_assets);
             drawWorldEffects(runner, runtime_assets);
             drawBonuses(runner, runtime_assets);
+            if (!gameplay.perk_ui.active()) {
+                drawAimEnhancements(runner, runtime_assets, camera.zoom);
+            }
             camera.end();
 
             if (gameplay.perk_ui.active()) {
                 if (runtime_assets) |assets| {
                     window_perk_menu.drawMenu(&gameplay.perk_ui, assets, &self.runtime.config, runner);
-                    window_perk_menu.drawCursor(assets);
                 }
             } else {
                 drawGameplayHud(gameplay, runtime_assets);
@@ -964,6 +997,8 @@ pub fn main() !void {
     });
     rl.initWindow(runtime.windowWidth(window_width), runtime.windowHeight(window_height), "crimson-zig");
     defer rl.closeWindow();
+    rl.hideCursor();
+    defer rl.showCursor();
 
     rl.setTargetFPS(60);
 
@@ -1627,6 +1662,18 @@ fn drawBonuses(runner: *const live_runner.LiveRunner, runtime_assets: ?*const wi
             },
             bonus_color,
         );
+    }
+}
+
+fn drawAimEnhancements(
+    runner: *const live_runner.LiveRunner,
+    runtime_assets: ?*const window_assets.RuntimeAssets,
+    zoom: f32,
+) void {
+    const assets = runtime_assets orelse return;
+    const alpha: f32 = 1.0;
+    for (runner.session.playersConst()) |player| {
+        window_cursor.drawAimEnhancements(assets, player, zoom, alpha);
     }
 }
 

--- a/crimson-zig/src/window_perk_menu.zig
+++ b/crimson-zig/src/window_perk_menu.zig
@@ -259,19 +259,6 @@ pub fn drawMenu(
     drawButton(runtime_assets, state.cancel_button, layout.cancel_pos);
 }
 
-pub fn drawCursor(runtime_assets: *const window_assets.RuntimeAssets) void {
-    const texture = runtime_assets.texture(.ui_cursor);
-    const mouse = rl.getMousePosition();
-    rl.drawTexturePro(
-        texture,
-        rl.Rectangle.init(0.0, 0.0, @floatFromInt(texture.width), @floatFromInt(texture.height)),
-        rl.Rectangle.init(mouse.x, mouse.y, 32.0, 32.0),
-        rl.Vector2.zero(),
-        0.0,
-        rl.Color.white,
-    );
-}
-
 fn updateMenuInput(
     state: *State,
     runtime_assets: ?*const window_assets.RuntimeAssets,


### PR DESCRIPTION
## Summary
- add a shared Zig cursor renderer for the menu cursor glow/sprite and world aim reticle
- hide the OS cursor at the app boundary and draw the correct custom cursor on menu, panel, results, and perk-overlay surfaces
- port the gameplay aim enhancement pass so players get the aim circle, reload gauge, and aim reticle at their world aim point

## Verification
- zig build test
- zig build window
- zig build wasm
