### PR TITLE
fix(zig): restore bonus pickup audio parity

### DIFF
--- a/crimson-zig/src/audio/live_audio.zig
+++ b/crimson-zig/src/audio/live_audio.zig
@@ -137,6 +137,10 @@ pub const Bridge = struct {
             }
         }
 
+        for (frame_audio.sfx_events[0..frame_audio.sfx_event_count]) |sfx_id| {
+            audio_mod.playSfx(state, runtimeSfxId(sfx_id), reflex_boost_timer);
+        }
+
         if (frame_audio.perk_menu_opened) {
             audio_mod.playSfx(state, .ui_levelup, 0.0);
         }
@@ -191,6 +195,16 @@ pub const Bridge = struct {
 fn weaponIdFromInt(value: i32) ?game_ids.WeaponId {
     if (value < 0 or value >= weapon_data.weapon_count_size) return null;
     return @enumFromInt(value);
+}
+
+fn runtimeSfxId(value: live_runner.RuntimeSfxId) sfx_map.SfxId {
+    return switch (value) {
+        .ui_bonus => .ui_bonus,
+        .shock_hit_01 => .shock_hit_01,
+        .explosion_medium => .explosion_medium,
+        .explosion_large => .explosion_large,
+        .shockwave => .shockwave,
+    };
 }
 
 fn weaponFireSfx(weapon_id: game_ids.WeaponId) ?sfx_map.SfxId {

--- a/crimson-zig/src/runtime/live_runner.zig
+++ b/crimson-zig/src/runtime/live_runner.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const game_ids = @import("../game_ids.zig");
 const rng_callers = @import("../rng_caller_static.zig");
 
+const bonuses_runtime = @import("bonuses.zig");
 const perks = @import("perks.zig");
 const player_runtime = @import("player.zig");
 const projectiles = @import("projectiles.zig");
@@ -52,6 +53,14 @@ pub const ShotAudioEvent = struct {
     fire_bullets_active: bool,
 };
 
+pub const RuntimeSfxId = enum(u8) {
+    ui_bonus,
+    shock_hit_01,
+    explosion_medium,
+    explosion_large,
+    shockwave,
+};
+
 pub const FrameAudioEvents = struct {
     shot_events: [8]ShotAudioEvent = [_]ShotAudioEvent{.{
         .weapon_id = 0,
@@ -62,6 +71,8 @@ pub const FrameAudioEvents = struct {
     reload_event_count: usize = 0,
     hit_events: [4]creatures.HitSfxPlan = [_]creatures.HitSfxPlan{.{}} ** 4,
     hit_event_count: usize = 0,
+    sfx_events: [16]RuntimeSfxId = [_]RuntimeSfxId{.ui_bonus} ** 16,
+    sfx_event_count: usize = 0,
     trigger_game_tune: bool = false,
     perk_menu_opened: bool = false,
     quest_play_hit_sfx: bool = false,
@@ -88,6 +99,28 @@ pub const FrameAudioEvents = struct {
         while (idx < tick_stats.hit_audio_event_count and self.hit_event_count < self.hit_events.len) : (idx += 1) {
             self.hit_events[self.hit_event_count] = tick_stats.hit_audio_events[idx];
             self.hit_event_count += 1;
+        }
+    }
+
+    fn appendSfx(self: *FrameAudioEvents, sfx_id: RuntimeSfxId) void {
+        if (self.sfx_event_count >= self.sfx_events.len) return;
+        self.sfx_events[self.sfx_event_count] = sfx_id;
+        self.sfx_event_count += 1;
+    }
+
+    fn appendBonusPickupSfx(self: *FrameAudioEvents, pickups: []const bonuses_runtime.BonusPickupRecord) void {
+        for (pickups) |pickup| {
+            self.appendSfx(.ui_bonus);
+            switch (pickup.bonus_id) {
+                .freeze => self.appendSfx(.shockwave),
+                .shock_chain => self.appendSfx(.shock_hit_01),
+                .fireblast => self.appendSfx(.explosion_medium),
+                .nuke => {
+                    self.appendSfx(.explosion_large);
+                    self.appendSfx(.shockwave);
+                },
+                else => {},
+            }
         }
     }
 };
@@ -284,6 +317,7 @@ pub const LiveRunner = struct {
                 frame_audio.perk_menu_opened = true;
             }
             frame_audio.appendHitPlans(step_result.projectile_tick_stats);
+            frame_audio.appendBonusPickupSfx(step_result.bonus_pickups.constSlice());
             frame_audio.quest_play_hit_sfx = frame_audio.quest_play_hit_sfx or
                 (!before_quest_hit_sfx and self.session.quest_play_hit_sfx);
             frame_audio.quest_play_completion_music = frame_audio.quest_play_completion_music or
@@ -529,4 +563,39 @@ test "live survival runner perk picks apply immediate creature effects" {
 
     try std.testing.expect(try runner.pickPerk(0, 0.25));
     try std.testing.expectApproxEqAbs(@as(f32, 4.75), runner.session.creatures.entries[0].lifecycle_stage, 1e-6);
+}
+
+test "live runner emits ui bonus pickup sfx" {
+    var runner = try LiveSurvivalRunner.init(.{});
+    const player_pos = runner.session.players()[0].pos;
+    runner.session.bonuses.entries[0] = .{
+        .bonus_id = .points,
+        .picked = false,
+        .time_left = 5.0,
+        .time_max = 5.0,
+        .pos = player_pos,
+        .amount = 100,
+    };
+
+    const update = try runner.stepFrame(runner.session.dt_nominal, .{});
+    try std.testing.expectEqual(@as(usize, 1), update.audio.sfx_event_count);
+    try std.testing.expectEqual(RuntimeSfxId.ui_bonus, update.audio.sfx_events[0]);
+}
+
+test "live runner emits bonus-specific apply sfx after pickup" {
+    var runner = try LiveSurvivalRunner.init(.{});
+    const player_pos = runner.session.players()[0].pos;
+    runner.session.bonuses.entries[0] = .{
+        .bonus_id = .fireblast,
+        .picked = false,
+        .time_left = 5.0,
+        .time_max = 5.0,
+        .pos = player_pos,
+        .amount = 1,
+    };
+
+    const update = try runner.stepFrame(runner.session.dt_nominal, .{});
+    try std.testing.expectEqual(@as(usize, 2), update.audio.sfx_event_count);
+    try std.testing.expectEqual(RuntimeSfxId.ui_bonus, update.audio.sfx_events[0]);
+    try std.testing.expectEqual(RuntimeSfxId.explosion_medium, update.audio.sfx_events[1]);
 }

--- a/crimson-zig/src/runtime/replay/step.zig
+++ b/crimson-zig/src/runtime/replay/step.zig
@@ -13,6 +13,7 @@ const diagnostic_trace_mod = @import("diagnostic_trace.zig");
 
 const bonus_runtime = @import("../bonuses.zig");
 const creatures_mod = @import("../creatures.zig");
+const effects_mod = @import("../effects.zig");
 const perks = @import("../perks.zig");
 const player_runtime = @import("../player.zig");
 const projectiles_mod = @import("../projectiles.zig");
@@ -95,6 +96,7 @@ pub const StepResult = struct {
     rng_after_spawns: u32,
     rng_after_bonus_update: u32,
     projectile_tick_stats: projectiles_mod.ProjectileTickStats,
+    bonus_pickups: bonus_runtime.BonusPickupBuffer,
     terrain_fx: terrain_fx_mod.TerrainFxBatch,
     rng_end: u32,
     pending_capture_state_reset: bool,
@@ -592,7 +594,14 @@ pub fn stepTick(
         &context.effects,
         context.detail_preset,
     );
-    if (context.state.debug_last_picked_bonus_id == game_ids.BonusId.freeze) {
+    var freeze_pickup_seen = false;
+    for (context.tick_bonus_pickups.constSlice()) |pickup| {
+        if (pickup.bonus_id == .freeze) {
+            freeze_pickup_seen = true;
+            break;
+        }
+    }
+    if (freeze_pickup_seen) {
         bonus_runtime.applyFreezePickupCorpseEffects(
             &context.state,
             &context.creatures,
@@ -667,6 +676,7 @@ pub fn stepTick(
         .rng_after_spawns = frame.rng_after_spawns,
         .rng_after_bonus_update = frame.rng_after_bonus_update,
         .projectile_tick_stats = frame.projectile_tick_stats,
+        .bonus_pickups = context.tick_bonus_pickups,
         .terrain_fx = context.terrain_fx.takeBatch(),
         .rng_end = context.state.rng.state,
         .pending_capture_state_reset = context.pending_capture_state_reset,
@@ -975,4 +985,62 @@ test "step tick accepts preserve bugs and keeps player zero perk targeting" {
 
     try std.testing.expectApproxEqAbs(@as(f32, 90.4), players[0].health, 1e-5);
     try std.testing.expectApproxEqAbs(@as(f32, 80.0), players[1].health, 1e-6);
+}
+
+test "step tick applies freeze corpse effects when freeze is not last pickup" {
+    const header = testHeader();
+    var context = try session_mod.DeterministicSession.initFromReplayHeader(header, .{});
+    context.rebindQuestSpawnEntries();
+
+    const player_pos = context.players()[0].pos;
+    context.creatures.entries[0] = .{
+        .active = true,
+        .type_id = 0,
+        .pos = player_pos,
+        .hp = 0.0,
+        .max_hp = 10.0,
+        .size = 48.0,
+        .lifecycle_stage = 0.0,
+    };
+    context.bonuses.entries[0] = .{
+        .bonus_id = .freeze,
+        .picked = false,
+        .time_left = 5.0,
+        .time_max = 5.0,
+        .pos = player_pos,
+        .amount = 5,
+    };
+    context.bonuses.entries[1] = .{
+        .bonus_id = .points,
+        .picked = false,
+        .time_left = 5.0,
+        .time_max = 5.0,
+        .pos = player_pos,
+        .amount = 100,
+    };
+
+    const result = try stepTick(
+        &context,
+        0,
+        &[_]player_runtime.GameInput{.{}},
+        &.{},
+        context.dt_nominal,
+        .{},
+    );
+
+    try std.testing.expectEqual(@as(usize, 2), result.bonus_pickups.len);
+    try std.testing.expect(!context.creatures.entries[0].active);
+
+    var freeze_fx_count: usize = 0;
+    for (context.effects.entries) |entry| {
+        if (entry.flags == 0) continue;
+        if (entry.effect_id == @intFromEnum(effects_mod.EffectId.freeze_shatter) or
+            entry.effect_id == @intFromEnum(effects_mod.EffectId.freeze_shard_0) or
+            entry.effect_id == @intFromEnum(effects_mod.EffectId.freeze_shard_1) or
+            entry.effect_id == @intFromEnum(effects_mod.EffectId.freeze_shard_2))
+        {
+            freeze_fx_count += 1;
+        }
+    }
+    try std.testing.expect(freeze_fx_count > 0);
 }


### PR DESCRIPTION
## Summary
- restore bonus pickup and bonus-apply SFX through the deterministic live-runner audio path
- key Freeze corpse pickup FX off the authoritative tick pickup list instead of `debug_last_picked_bonus_id`
- add regression coverage for pickup audio events and multi-pickup Freeze corpse FX

## Verification
- `cd crimson-zig && zig build test`
- `cd crimson-zig && zig build window`
- `cd crimson-zig && zig build wasm`
- push hooks: `zig-test`, `zig-release`, `zig-wasm`
