### PR TITLE
feat(zig): port demo trial shell

### DIFF
--- a/crimson-zig/build.zig
+++ b/crimson-zig/build.zig
@@ -76,6 +76,9 @@ pub fn build(b: *std.Build) void {
     const run_window_step = b.step("run-window", "Run raylib desktop playable slice");
     const run_window_cmd = b.addRunArtifact(window_exe);
     run_window_step.dependOn(&run_window_cmd.step);
+    if (b.args) |args| {
+        run_window_cmd.addArgs(args);
+    }
 
     const asset_smoke_exe = b.addExecutable(.{
         .name = "crimson-zig-asset-smoke",

--- a/crimson-zig/src/audio/live_audio.zig
+++ b/crimson-zig/src/audio/live_audio.zig
@@ -81,6 +81,10 @@ pub const Bridge = struct {
         self.playMusic("crimson_theme");
     }
 
+    pub fn ensureMenuThemeForDemo(self: *Bridge, demo_enabled: bool) void {
+        self.playMusic(if (demo_enabled) "crimsonquest" else "crimson_theme");
+    }
+
     pub fn ensureStatisticsTheme(self: *Bridge) void {
         self.playMusic("shortie_monk");
     }

--- a/crimson-zig/src/demo_trial.zig
+++ b/crimson-zig/src/demo_trial.zig
@@ -1,0 +1,174 @@
+const std = @import("std");
+const game_ids = @import("game_ids.zig");
+
+pub const demo_total_play_time_ms: i32 = 2_400_000;
+pub const demo_quest_grace_time_ms: i32 = 300_000;
+
+pub const OverlayKind = enum {
+    none,
+    quest_tier_limit,
+    quest_grace_left,
+    time_up,
+};
+
+pub const OverlayInfo = struct {
+    visible: bool = false,
+    kind: OverlayKind = .none,
+    remaining_ms: i32 = 0,
+    show_remaining_line: bool = false,
+};
+
+pub const TimerTickResult = struct {
+    global_playtime_ms: u32,
+    quest_grace_elapsed_ms: i32,
+};
+
+pub fn formatDemoTrialTime(ms: i32, buf: []u8) []const u8 {
+    var value = ms;
+    if (value < 0) value = 0;
+    const minutes = @divTrunc(value, 60_000);
+    const seconds = @mod(@divTrunc(value, 1_000), 60);
+    const centiseconds = @divTrunc(@mod(value, 1_000), 10);
+    return std.fmt.bufPrint(buf, "{d}:{d:0>2}.{d:0>2}", .{ minutes, seconds, centiseconds }) catch "0:00.00";
+}
+
+pub fn tickDemoTrialTimers(
+    demo_build: bool,
+    game_mode_id: game_ids.GameModeId,
+    overlay_visible: bool,
+    global_playtime_ms: u32,
+    quest_grace_elapsed_ms: i32,
+    dt_ms: i32,
+) TimerTickResult {
+    if (!demo_build) {
+        return .{
+            .global_playtime_ms = global_playtime_ms,
+            .quest_grace_elapsed_ms = quest_grace_elapsed_ms,
+        };
+    }
+
+    if (game_mode_id == .tutorial) {
+        return .{
+            .global_playtime_ms = global_playtime_ms,
+            .quest_grace_elapsed_ms = quest_grace_elapsed_ms,
+        };
+    }
+
+    var used_ms: i32 = @intCast(global_playtime_ms);
+    if (used_ms < 0) used_ms = 0;
+    var grace_ms: i32 = quest_grace_elapsed_ms;
+    if (grace_ms < 0) grace_ms = 0;
+    if (used_ms >= demo_total_play_time_ms and grace_ms < 1) grace_ms = 1;
+    if (used_ms > demo_total_play_time_ms) used_ms = demo_total_play_time_ms;
+
+    if (overlay_visible or dt_ms <= 0) {
+        return .{
+            .global_playtime_ms = @intCast(used_ms),
+            .quest_grace_elapsed_ms = grace_ms,
+        };
+    }
+
+    used_ms += dt_ms;
+    if (used_ms > demo_total_play_time_ms) used_ms = demo_total_play_time_ms;
+    if (used_ms >= demo_total_play_time_ms and grace_ms < 1) grace_ms = 1;
+    if (grace_ms > 0 and game_mode_id == .quests) {
+        grace_ms += dt_ms;
+    }
+
+    return .{
+        .global_playtime_ms = @intCast(used_ms),
+        .quest_grace_elapsed_ms = grace_ms,
+    };
+}
+
+pub fn demoTrialOverlayInfo(
+    demo_build: bool,
+    game_mode_id: game_ids.GameModeId,
+    global_playtime_ms: u32,
+    quest_grace_elapsed_ms: i32,
+    quest_level_key: ?i32,
+) OverlayInfo {
+    if (!demo_build or game_mode_id == .tutorial) return .{};
+
+    const used_ms: i32 = @intCast(global_playtime_ms);
+    const grace_ms = @max(quest_grace_elapsed_ms, 0);
+    const global_remaining_ms = @max(@as(i32, 0), demo_total_play_time_ms - used_ms);
+    const grace_remaining_ms = @max(@as(i32, 0), demo_quest_grace_time_ms - grace_ms);
+
+    const tier_locked = blk: {
+        if (game_mode_id != .quests) break :blk false;
+        const level_key = quest_level_key orelse break :blk false;
+        const major = @divTrunc(level_key, 100);
+        const minor = @mod(level_key, 100);
+        break :blk major > 1 or minor > 10;
+    };
+
+    if (grace_ms > 0) {
+        if (grace_remaining_ms <= 0) {
+            return .{
+                .visible = true,
+                .kind = .time_up,
+            };
+        }
+        if (tier_locked) {
+            return .{
+                .visible = true,
+                .kind = .quest_tier_limit,
+                .remaining_ms = grace_remaining_ms,
+            };
+        }
+        if (game_mode_id != .quests) {
+            return .{
+                .visible = true,
+                .kind = .quest_grace_left,
+                .remaining_ms = grace_remaining_ms,
+            };
+        }
+        return .{
+            .visible = false,
+            .kind = .none,
+            .remaining_ms = grace_remaining_ms,
+        };
+    }
+
+    if (global_remaining_ms <= 0) {
+        return .{
+            .visible = true,
+            .kind = .time_up,
+        };
+    }
+
+    if (tier_locked) {
+        return .{
+            .visible = true,
+            .kind = .quest_tier_limit,
+            .remaining_ms = global_remaining_ms,
+            .show_remaining_line = true,
+        };
+    }
+
+    return .{
+        .visible = false,
+        .kind = .none,
+        .remaining_ms = global_remaining_ms,
+    };
+}
+
+test "demo trial timers stop while overlay visible" {
+    const result = tickDemoTrialTimers(true, .survival, true, 1000, 0, 500);
+    try std.testing.expectEqual(@as(u32, 1000), result.global_playtime_ms);
+    try std.testing.expectEqual(@as(i32, 0), result.quest_grace_elapsed_ms);
+}
+
+test "demo trial overlay blocks quest grace left on non-quest modes" {
+    const info = demoTrialOverlayInfo(true, .survival, demo_total_play_time_ms, 1, null);
+    try std.testing.expect(info.visible);
+    try std.testing.expectEqual(OverlayKind.quest_grace_left, info.kind);
+}
+
+test "demo trial overlay blocks later quest tiers in demo" {
+    const info = demoTrialOverlayInfo(true, .quests, 1000, 0, 201);
+    try std.testing.expect(info.visible);
+    try std.testing.expectEqual(OverlayKind.quest_tier_limit, info.kind);
+    try std.testing.expect(info.show_remaining_line);
+}

--- a/crimson-zig/src/root.zig
+++ b/crimson-zig/src/root.zig
@@ -32,6 +32,7 @@ pub const typo_names = @import("typo/names.zig");
 pub const formats = @import("formats/mod.zig");
 pub const persistence = @import("persistence/mod.zig");
 pub const local_input = @import("local_input.zig");
+pub const demo_trial = @import("demo_trial.zig");
 pub const window_atlas = @import("window_atlas.zig");
 
 pub const version = "0.1.0-dev";

--- a/crimson-zig/src/test_root.zig
+++ b/crimson-zig/src/test_root.zig
@@ -8,6 +8,7 @@ test {
     _ = cz.creatures;
     _ = cz.effects;
     _ = cz.terrain_fx;
+    _ = cz.demo_trial;
     _ = cz.hash;
     _ = cz.formats;
     _ = cz.helpers;
@@ -30,5 +31,6 @@ test {
     _ = cz.weapons;
     _ = cz.window_atlas;
     _ = @import("window_cursor.zig");
+    _ = @import("window_demo_trial.zig");
     _ = @import("window_statistics.zig");
 }

--- a/crimson-zig/src/window_demo_trial.zig
+++ b/crimson-zig/src/window_demo_trial.zig
@@ -1,0 +1,181 @@
+const std = @import("std");
+const rl = @import("raylib");
+
+const cz = @import("crimson_zig");
+
+const demo_trial = cz.demo_trial;
+const window_assets = @import("window_assets.zig");
+const window_cursor = @import("window_cursor.zig");
+const window_ui = @import("window_ui.zig");
+
+pub const demo_purchase_url = "http://buy.crimsonland.com";
+
+const demo_header_text = "You've been playing the Demo version of";
+const quest_completed_text = "You've completed all Quest mode levels available in the Demo version.";
+const quest_limit_remaining_text = "However, you still have {s} time left to play Survival and Rush game modes.";
+const quest_grace_used_up_text = "You have used up your play time in this game mode. However, you still";
+const quest_grace_remaining_text = "have {s} time left to play Quest mode levels only.";
+const upgrade_all_features_text = "If you would like to have unlimited play time and access to all features,";
+const upgrade_features_line_text = "The full version features unrestricted access to all 3";
+const upgrade_buy_full_text = "Buy the full version to gain unrestricted access to all 3";
+const upgrade_buy_line_text = "game modes and be able to post your scores on the Internet. Why not buy";
+const upgrade_trailer_text = "it now? You'll have a great time!";
+const upgrade_please_text = "please upgrade to the full version of Crimsonland.";
+const upgrade_process_text = "please upgrade to the full version of Crimsonland.  The process is very easy";
+const upgrade_process_cont_text = "and takes just minutes. ";
+const upgrade_easy_text = "is very easy and takes just minutes.";
+const time_up_text = "Trial time is up. If you would like to have unlimited play time and access to";
+const time_up_all_features_text = "all features, please upgrade to the full version of Crimsonland.  The process";
+
+pub const Action = enum {
+    none,
+    purchase,
+    maybe_later,
+};
+
+pub const State = struct {
+    cursor_pulse_time: f32 = 0.0,
+    selection: usize = 0,
+
+    pub fn reset(self: *State) void {
+        self.* = .{};
+    }
+};
+
+pub fn update(state: *State, dt_ms: i32) Action {
+    state.cursor_pulse_time += @as(f32, @floatFromInt(@max(dt_ms, 0))) * 0.001 * 1.1;
+    const buttons = overlayButtons();
+    window_ui.updateSelectionFromPointer(&state.selection, buttons[0..]);
+    if (rl.isKeyPressed(.left) or rl.isKeyPressed(.a)) {
+        state.selection = if (state.selection == 0) buttons.len - 1 else state.selection - 1;
+    }
+    if (rl.isKeyPressed(.right) or rl.isKeyPressed(.d)) {
+        state.selection = (state.selection + 1) % buttons.len;
+    }
+    if (rl.isKeyPressed(.escape)) return .maybe_later;
+    if (!window_ui.buttonActivated(buttons[0..], state.selection)) return .none;
+    return if (state.selection == 0) .purchase else .maybe_later;
+}
+
+pub fn draw(state: *const State, assets: *const window_assets.RuntimeAssets, info: demo_trial.OverlayInfo) void {
+    if (!info.visible) return;
+
+    const panel = panelRect();
+    rl.drawRectangle(
+        @intFromFloat(panel.x),
+        @intFromFloat(panel.y),
+        @intFromFloat(panel.width),
+        @intFromFloat(panel.height),
+        rl.Color.init(18, 18, 22, 230),
+    );
+    rl.drawRectangleLines(
+        @intFromFloat(panel.x),
+        @intFromFloat(panel.y),
+        @intFromFloat(panel.width),
+        @intFromFloat(panel.height),
+        rl.Color.white,
+    );
+
+    const logo = assets.texture(.cl_logo);
+    window_ui.drawTextureFit(
+        logo,
+        rl.Rectangle.init(panel.x + 72.0, panel.y + 22.0, 371.2, 46.4),
+        rl.Color.white,
+    );
+    window_ui.drawSmallText(assets, demo_header_text, panel.x + 131.0, panel.y + 9.0, rl.Color.init(220, 220, 220, 255));
+
+    var remaining_buf: [16]u8 = undefined;
+    const remaining = demo_trial.formatDemoTrialTime(info.remaining_ms, remaining_buf[0..]);
+    drawBodyLines(assets, panel, info, remaining);
+
+    const buttons = overlayButtons();
+    for (buttons, 0..) |button, idx| {
+        const hovered = rl.checkCollisionPointRec(rl.getMousePosition(), button.rect);
+        window_ui.drawButton(button, idx == state.selection, hovered, assets);
+    }
+    window_cursor.drawMenuCursor(assets, state.cursor_pulse_time);
+}
+
+fn drawBodyLines(
+    assets: *const window_assets.RuntimeAssets,
+    panel: rl.Rectangle,
+    info: demo_trial.OverlayInfo,
+    remaining: []const u8,
+) void {
+    const body_x = panel.x + 26.0;
+    const body_color = rl.Color.init(220, 220, 220, 255);
+    switch (info.kind) {
+        .quest_tier_limit => {
+            if (info.show_remaining_line) {
+                drawLine(assets, body_x, panel.y + 74.0, quest_completed_text, body_color);
+                drawFmtLine(assets, body_x, panel.y + 92.0, quest_limit_remaining_text, remaining, body_color);
+                drawLine(assets, body_x, panel.y + 124.0, upgrade_all_features_text, body_color);
+                drawLine(assets, body_x, panel.y + 142.0, upgrade_please_text, body_color);
+                drawLine(assets, body_x, panel.y + 164.0, upgrade_features_line_text, body_color);
+                drawLine(assets, body_x, panel.y + 182.0, upgrade_buy_line_text, body_color);
+                drawLine(assets, body_x, panel.y + 200.0, upgrade_trailer_text, body_color);
+                return;
+            }
+            drawLine(assets, body_x, panel.y + 86.0, quest_completed_text, body_color);
+            drawLine(assets, body_x, panel.y + 104.0, upgrade_all_features_text, body_color);
+            drawLine(assets, body_x, panel.y + 122.0, upgrade_please_text, body_color);
+            drawLine(assets, body_x, panel.y + 144.0, upgrade_features_line_text, body_color);
+            drawLine(assets, body_x, panel.y + 162.0, upgrade_buy_line_text, body_color);
+            drawLine(assets, body_x, panel.y + 180.0, upgrade_trailer_text, body_color);
+        },
+        .quest_grace_left => {
+            drawLine(assets, body_x, panel.y + 73.0, quest_grace_used_up_text, body_color);
+            drawFmtLine(assets, body_x, panel.y + 89.0, quest_grace_remaining_text, remaining, body_color);
+            drawLine(assets, body_x, panel.y + 111.0, upgrade_all_features_text, body_color);
+            drawLine(assets, body_x, panel.y + 127.0, upgrade_process_text, body_color);
+            drawLine(assets, body_x, panel.y + 143.0, upgrade_process_cont_text, body_color);
+            drawLine(assets, body_x, panel.y + 165.0, upgrade_buy_full_text, body_color);
+            drawLine(assets, body_x, panel.y + 181.0, upgrade_buy_line_text, body_color);
+            drawLine(assets, body_x, panel.y + 197.0, upgrade_trailer_text, body_color);
+        },
+        .time_up, .none => {
+            drawLine(assets, body_x, panel.y + 80.0, time_up_text, body_color);
+            drawLine(assets, body_x, panel.y + 98.0, time_up_all_features_text, body_color);
+            drawLine(assets, body_x, panel.y + 116.0, upgrade_easy_text, body_color);
+            drawLine(assets, body_x, panel.y + 140.0, upgrade_buy_full_text, body_color);
+            drawLine(assets, body_x, panel.y + 158.0, upgrade_buy_line_text, body_color);
+            drawLine(assets, body_x, panel.y + 176.0, upgrade_trailer_text, body_color);
+        },
+    }
+}
+
+fn drawLine(assets: *const window_assets.RuntimeAssets, x: f32, y: f32, text: []const u8, color: rl.Color) void {
+    window_ui.drawSmallText(assets, text, x, y, color);
+}
+
+fn drawFmtLine(
+    comptime fmt: []const u8,
+    assets: *const window_assets.RuntimeAssets,
+    x: f32,
+    y: f32,
+    remaining: []const u8,
+    color: rl.Color,
+) void {
+    var buf: [192]u8 = undefined;
+    const line = std.fmt.bufPrint(buf[0..], fmt, .{remaining}) catch return;
+    window_ui.drawSmallText(assets, line, x, y, color);
+}
+
+fn panelRect() rl.Rectangle {
+    const screen_w = @as(f32, @floatFromInt(rl.getScreenWidth()));
+    const screen_h = @as(f32, @floatFromInt(rl.getScreenHeight()));
+    return rl.Rectangle.init(screen_w * 0.5 - 256.0, screen_h * 0.5 - 128.0, 512.0, 256.0);
+}
+
+fn overlayButtons() [2]window_ui.UiButton {
+    const panel = panelRect();
+    const button_w: f32 = 145.0;
+    const gap: f32 = 20.0;
+    const row_w = button_w * 2.0 + gap;
+    const x = panel.x + 256.0 - row_w * 0.5;
+    const y = panel.y + 214.0;
+    return .{
+        .{ .label = "Purchase", .rect = rl.Rectangle.init(x, y, button_w, window_ui.button_plate_height) },
+        .{ .label = "Maybe later", .rect = rl.Rectangle.init(x + button_w + gap, y, button_w, window_ui.button_plate_height) },
+    };
+}

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const rl = @import("raylib");
 
 const cz = @import("crimson_zig");
@@ -8,6 +9,7 @@ const runtime_anim = cz.anim;
 const weapon_data = cz.weapon_data;
 const app_runtime = @import("app_runtime.zig");
 const audio_mod = @import("audio/audio.zig");
+const demo_trial = cz.demo_trial;
 const input_codes = @import("input_codes.zig");
 const local_input = cz.local_input;
 const live_audio = @import("audio/live_audio.zig");
@@ -16,6 +18,7 @@ const window_assets = @import("window_assets.zig");
 const window_atlas = cz.window_atlas;
 const window_boot = @import("window_boot.zig");
 const window_cursor = @import("window_cursor.zig");
+const window_demo_trial = @import("window_demo_trial.zig");
 const window_effects = @import("window_effects.zig");
 const window_ground = @import("window_ground.zig");
 const window_menu = @import("window_menu.zig");
@@ -310,13 +313,18 @@ const App = struct {
     assets_message: ?[]u8 = null,
     next_seed_state: u32 = 0xC0FFEE,
     cursor_pulse_time: f32 = 0.0,
+    demo_enabled: bool = false,
+    demo_trial_elapsed_ms: i32 = 0,
+    demo_trial_info: demo_trial.OverlayInfo = .{},
+    demo_trial_ui: window_demo_trial.State = .{},
     quit_requested: bool = false,
 
-    fn init(allocator: std.mem.Allocator, runtime: app_runtime.DesktopRuntime) App {
+    fn init(allocator: std.mem.Allocator, runtime: app_runtime.DesktopRuntime, demo_enabled: bool) App {
         var app: App = .{
             .allocator = allocator,
             .runtime = runtime,
             .audio = live_audio.Bridge.init(allocator, audio_mod.audioConfigFromCrimsonCfg(runtime.config), null),
+            .demo_enabled = demo_enabled,
         };
         app.boot.reset();
         app.menu.reset();
@@ -465,7 +473,7 @@ const App = struct {
     }
 
     fn updateMainMenu(self: *App, frame_dt: f32) void {
-        self.audio.ensureMenuTheme();
+        self.audio.ensureMenuThemeForDemo(self.demo_enabled);
         const menu_update = window_menu.update(
             &self.menu,
             frame_dt,
@@ -508,8 +516,8 @@ const App = struct {
     }
 
     fn updatePlayGameMenu(self: *App, frame_dt: f32) void {
-        self.audio.ensureMenuTheme();
-        const play_game_update = window_menu_panels.updatePlayGame(&self.play_game_menu, frame_dt, &self.runtime.config, self.runtime.status, if (self.runtime_assets) |*assets| assets else null);
+        self.audio.ensureMenuThemeForDemo(self.demo_enabled);
+        const play_game_update = window_menu_panels.updatePlayGame(&self.play_game_menu, frame_dt, &self.runtime.config, self.runtime.status, if (self.runtime_assets) |*assets| assets else null, self.demo_enabled);
         if (play_game_update.config_dirty) self.runtime.config_dirty = true;
         if (play_game_update.play_panel_click and !self.play_game_menu.panel.panel_open_sfx_played) {
             self.audio.playUiPanelClick();
@@ -533,8 +541,8 @@ const App = struct {
     }
 
     fn updateQuestsMenu(self: *App, frame_dt: f32) void {
-        self.audio.ensureMenuTheme();
-        const quest_update = window_menu_panels.updateQuests(&self.quests_menu, frame_dt, &self.runtime.config, self.runtime.status);
+        self.audio.ensureMenuThemeForDemo(self.demo_enabled);
+        const quest_update = window_menu_panels.updateQuests(&self.quests_menu, frame_dt, &self.runtime.config, self.runtime.status, self.demo_enabled);
         if (quest_update.config_dirty) self.runtime.config_dirty = true;
         if (quest_update.play_panel_click and !self.quests_menu.panel.panel_open_sfx_played) {
             self.audio.playUiPanelClick();
@@ -585,6 +593,43 @@ const App = struct {
     fn updateGameplay(self: *App, frame_dt: f32) void {
         if (self.gameplay) |*gameplay| {
             gameplay.render_time_s += @max(frame_dt, 0.0);
+            const dt_ms = @as(i32, @intFromFloat(@min(@max(frame_dt, 0.0), 0.1) * 1000.0));
+            if (self.demo_enabled) {
+                const current_demo_info = self.currentDemoTrialInfo(gameplay);
+                const timer_tick = demo_trial.tickDemoTrialTimers(
+                    true,
+                    gameplay.runner.session.game_mode,
+                    current_demo_info.visible,
+                    self.runtime.status.game_sequence_id,
+                    self.demo_trial_elapsed_ms,
+                    dt_ms,
+                );
+                if (timer_tick.global_playtime_ms != self.runtime.status.game_sequence_id) {
+                    self.runtime.status.game_sequence_id = timer_tick.global_playtime_ms;
+                    self.runtime.status_dirty = true;
+                }
+                self.demo_trial_elapsed_ms = timer_tick.quest_grace_elapsed_ms;
+                self.demo_trial_info = self.currentDemoTrialInfo(gameplay);
+
+                if (self.demo_trial_info.visible) {
+                    switch (window_demo_trial.update(&self.demo_trial_ui, dt_ms)) {
+                        .none => {},
+                        .maybe_later => {
+                            self.closeGameplayToMenu(gameplay);
+                            return;
+                        },
+                        .purchase => {
+                            _ = openDemoPurchaseUrl(self.allocator);
+                            self.quit_requested = true;
+                            return;
+                        },
+                    }
+                    return;
+                }
+            } else {
+                self.demo_trial_info = .{};
+            }
+
             if (!gameplay.perk_ui.active() and rl.isKeyPressed(.escape)) {
                 gameplay.pause_menu.reset();
                 self.setScreen(.pause);
@@ -597,7 +642,9 @@ const App = struct {
                 gameplay.camera,
                 gameplay.runner.session.state.camera_shake_offset,
             );
-            self.runtime.recordGameplayFrame(frame_dt);
+            if (!self.demo_enabled) {
+                self.runtime.recordGameplayFrame(frame_dt);
+            }
             var input = collectGameplayInput(&gameplay.input_interpreter, &gameplay.runner, camera, &self.runtime, frame_dt);
             if (gameplay.runner.session.game_mode == .tutorial and
                 gameplay.runner.perkPendingCount() > 0 and
@@ -696,7 +743,7 @@ const App = struct {
     }
 
     fn updateModsMenu(self: *App, frame_dt: f32) void {
-        self.audio.ensureMenuTheme();
+        self.audio.ensureMenuThemeForDemo(self.demo_enabled);
         const panel_update = window_misc_panels.updateMods(&self.mods_menu, frame_dt, if (self.runtime_assets) |*assets| assets else null);
         if (panel_update.play_panel_click and !self.mods_menu.panel.panel_open_sfx_played) {
             self.audio.playUiPanelClick();
@@ -710,7 +757,7 @@ const App = struct {
     }
 
     fn updateOtherGamesMenu(self: *App, frame_dt: f32) void {
-        self.audio.ensureMenuTheme();
+        self.audio.ensureMenuThemeForDemo(self.demo_enabled);
         const panel_update = window_misc_panels.updateOtherGames(&self.other_games_menu, frame_dt, if (self.runtime_assets) |*assets| assets else null);
         if (panel_update.play_panel_click and !self.other_games_menu.panel.panel_open_sfx_played) {
             self.audio.playUiPanelClick();
@@ -813,6 +860,26 @@ const App = struct {
         }
     }
 
+    fn currentDemoTrialInfo(self: *const App, gameplay: *const GameplayScreen) demo_trial.OverlayInfo {
+        return demo_trial.demoTrialOverlayInfo(
+            self.demo_enabled,
+            gameplay.runner.session.game_mode,
+            self.runtime.status.game_sequence_id,
+            self.demo_trial_elapsed_ms,
+            gameplay.run_config.quest_level_key,
+        );
+    }
+
+    fn closeGameplayToMenu(self: *App, gameplay: *GameplayScreen) void {
+        self.audio.stopGameplayMusic();
+        gameplay.deinit();
+        self.gameplay = null;
+        self.demo_trial_info = .{};
+        self.demo_trial_ui.reset();
+        self.menu.openRoot();
+        self.setScreen(.main_menu);
+    }
+
     fn openResultsHighScores(self: *App, results: *const ResultsScreen) void {
         self.runtime.config.game_mode = @intCast(@intFromEnum(results.run_config.game_mode));
         self.runtime.config_dirty = true;
@@ -831,7 +898,7 @@ const App = struct {
     }
 
     fn updateOptions(self: *App, frame_dt: f32) void {
-        self.audio.ensureMenuTheme();
+        self.audio.ensureMenuThemeForDemo(self.demo_enabled);
         const options_update = window_options.updateOptions(&self.options, frame_dt, &self.runtime.config, if (self.runtime_assets) |*assets| assets else null);
         if (options_update.config_dirty) self.runtime.config_dirty = true;
         if (options_update.reload_audio) self.reloadAudioConfig();
@@ -854,7 +921,7 @@ const App = struct {
     }
 
     fn updateControls(self: *App, frame_dt: f32) void {
-        self.audio.ensureMenuTheme();
+        self.audio.ensureMenuThemeForDemo(self.demo_enabled);
         const controls_update = window_options.updateControls(&self.controls, frame_dt, &self.runtime.config, if (self.runtime_assets) |*assets| assets else null);
         if (controls_update.config_dirty) self.runtime.config_dirty = true;
         if (controls_update.play_panel_click and !self.controls.panel_open_sfx_played) {
@@ -962,6 +1029,7 @@ const App = struct {
         configured_run.status_quest_unlock_index = @intCast(self.runtime.status.quest_unlock_index);
         configured_run.status_quest_unlock_index_full = @intCast(self.runtime.status.quest_unlock_index_full);
         configured_run.status_weapon_usage_counts = statusWeaponUsageCounts(self.runtime.status);
+        configured_run.demo_mode_active = self.demo_enabled and (configured_run.game_mode == .quests or configured_run.game_mode == .tutorial);
 
         self.runtime.recordModeStart(configured_run.game_mode);
         if (configured_run.game_mode == .quests) {
@@ -1191,6 +1259,7 @@ const App = struct {
             if (self.runtime_assets) |*assets| assets else null,
             self.runtime.status,
             self.runtime.config.player_count,
+            self.demo_enabled,
         );
     }
 
@@ -1281,6 +1350,12 @@ const App = struct {
                         drawTutorialOverlay(gameplay, assets);
                     }
                     window_perk_menu.drawPrompt(&gameplay.perk_ui, assets, &self.runtime.config, runner.perkPendingCount());
+                }
+            }
+
+            if (self.demo_trial_info.visible) {
+                if (runtime_assets) |assets| {
+                    window_demo_trial.draw(&self.demo_trial_ui, assets, self.demo_trial_info);
                 }
             }
         }
@@ -1386,10 +1461,15 @@ const App = struct {
     }
 };
 
+const WindowArgs = struct {
+    demo_enabled: bool = false,
+};
+
 pub fn main() !void {
     var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
     defer _ = gpa.deinit();
 
+    const args = try parseWindowArgs(gpa.allocator());
     var runtime = try app_runtime.DesktopRuntime.init(gpa.allocator());
 
     rl.setConfigFlags(.{
@@ -1402,7 +1482,7 @@ pub fn main() !void {
 
     rl.setTargetFPS(60);
 
-    var app = App.init(gpa.allocator(), runtime);
+    var app = App.init(gpa.allocator(), runtime, args.demo_enabled);
     defer app.deinit();
 
     while (!rl.windowShouldClose() and !app.quit_requested) {
@@ -1416,6 +1496,40 @@ pub fn main() !void {
     }
 
     try app.saveAllIfDirty();
+}
+
+fn parseWindowArgs(allocator: std.mem.Allocator) !WindowArgs {
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    var parsed: WindowArgs = .{};
+    for (args[1..]) |arg| {
+        if (std.mem.eql(u8, arg, "--demo")) {
+            parsed.demo_enabled = true;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "--help")) {
+            std.debug.print("usage: crimson-zig-window [--demo]\n", .{});
+            std.process.exit(0);
+        }
+        return error.InvalidArgs;
+    }
+    return parsed;
+}
+
+fn openDemoPurchaseUrl(allocator: std.mem.Allocator) bool {
+    const argv: []const []const u8 = switch (builtin.os.tag) {
+        .macos => &.{ "open", window_demo_trial.demo_purchase_url },
+        .linux => &.{ "xdg-open", window_demo_trial.demo_purchase_url },
+        .windows => &.{ "rundll32", "url.dll,FileProtocolHandler", window_demo_trial.demo_purchase_url },
+        else => return false,
+    };
+    var child = std.process.Child.init(argv, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Ignore;
+    child.spawn() catch return false;
+    return true;
 }
 
 fn drawBackdrop() void {

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -214,7 +214,7 @@ const quest_list_hover_top_pad: f32 = 2.0;
 const quest_list_hover_bottom_pad: f32 = 18.0;
 const quest_hardcore_unlock_index: u32 = 40;
 
-pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, runtime_assets: ?*const window_assets.RuntimeAssets) PlayGameResult {
+pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, runtime_assets: ?*const window_assets.RuntimeAssets, demo_enabled: bool) PlayGameResult {
     const dt_ms = frameDeltaMs(frame_dt);
     if (state.closing) {
         if (dt_ms > 0) state.panel.timeline_ms -= dt_ms;
@@ -237,11 +237,11 @@ pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.cri
     }
 
     if (state.player_list_open) {
-        return updatePlayGamePlayerList(state, config, status, dt_ms, state.panel.timeline_ms);
+        return updatePlayGamePlayerList(state, config, status, dt_ms, state.panel.timeline_ms, demo_enabled);
     }
 
-    const entries = playGameEntries(config, status);
-    const layout = playGameLayout(config, status, state.panel.timeline_ms);
+    const entries = playGameEntries(config, status, demo_enabled);
+    const layout = playGameLayout(config, status, state.panel.timeline_ms, demo_enabled);
     const hovered = hoveredPlayGameEntry(entries[0..], layout);
     updatePlayGameTooltipTimers(state, entries[0..], hovered, dt_ms);
     const back_hovered = if (runtime_assets) |assets|
@@ -282,9 +282,9 @@ pub fn updatePlayGame(state: *PlayGameState, frame_dt: f32, config: *formats.cri
     };
 }
 
-fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, dt_ms: i32, timeline_ms: i32) PlayGameResult {
+fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, dt_ms: i32, timeline_ms: i32, demo_enabled: bool) PlayGameResult {
     _ = dt_ms;
-    const layout = playGameLayout(config, status, timeline_ms);
+    const layout = playGameLayout(config, status, timeline_ms, demo_enabled);
     if (rl.isKeyPressed(.escape)) {
         state.player_list_open = false;
         return .{};
@@ -318,20 +318,20 @@ fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.
     return .{};
 }
 
-pub fn drawPlayGame(state: *const PlayGameState, runtime_assets: ?*const window_assets.RuntimeAssets, status: formats.game_cfg.Status, player_count_raw: u32) void {
+pub fn drawPlayGame(state: *const PlayGameState, runtime_assets: ?*const window_assets.RuntimeAssets, status: formats.game_cfg.Status, player_count_raw: u32, demo_enabled: bool) void {
     if (runtime_assets) |assets| {
-        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, playGameLayoutFromPlayerCount(player_count_raw, status, state.panel.timeline_ms).panel_rect);
-        drawPlayGameContent(state, assets, status, player_count_raw);
+        drawMenuPanelShellNoTitle(state.panel.timeline_ms, assets, playGameLayoutFromPlayerCount(player_count_raw, status, state.panel.timeline_ms, demo_enabled).panel_rect);
+        drawPlayGameContent(state, assets, status, player_count_raw, demo_enabled);
         window_menu.drawPanelBackEntry(assets, state.panel.timeline_ms, state.back_hover_amount);
         return;
     }
     rl.clearBackground(panel_color);
 }
 
-fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const window_assets.RuntimeAssets, status: formats.game_cfg.Status, player_count_raw: u32) void {
+fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const window_assets.RuntimeAssets, status: formats.game_cfg.Status, player_count_raw: u32, demo_enabled: bool) void {
     const clamped_player_count = std.math.clamp(player_count_raw, @as(u32, 1), @as(u32, 4));
-    const layout = playGameLayoutFromPlayerCount(clamped_player_count, status, state.panel.timeline_ms);
-    const entries = playGameEntriesFromPlayerCount(clamped_player_count, status);
+    const layout = playGameLayoutFromPlayerCount(clamped_player_count, status, state.panel.timeline_ms, demo_enabled);
+    const entries = playGameEntriesFromPlayerCount(clamped_player_count, status, demo_enabled);
     const show_counts = rl.isKeyDown(.f1);
 
     drawAtlasLabelAt(runtime_assets, layout.title_pos.x, layout.title_pos.y, window_menu.label_row_play_game, rl.Color.white);
@@ -351,14 +351,14 @@ fn drawPlayGameContent(state: *const PlayGameState, runtime_assets: *const windo
     drawPlayGameTooltips(state, runtime_assets, entries[0..], layout);
 }
 
-fn playGameEntries(config: *const formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) []const PlayGameEntry {
-    return playGameEntriesFromPlayerCount(config.player_count, status);
+fn playGameEntries(config: *const formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, demo_enabled: bool) []const PlayGameEntry {
+    return playGameEntriesFromPlayerCount(config.player_count, status, demo_enabled);
 }
 
-fn playGameEntriesFromPlayerCount(player_count_raw: u32, status: formats.game_cfg.Status) []const PlayGameEntry {
+fn playGameEntriesFromPlayerCount(player_count_raw: u32, status: formats.game_cfg.Status, demo_enabled: bool) []const PlayGameEntry {
     const player_count = std.math.clamp(player_count_raw, @as(u32, 1), @as(u32, 4));
     const main_total = questTotalPlayed(status) + status.mode_play_rush + status.mode_play_survival;
-    const has_typo = player_count == 1 and status.quest_unlock_index >= 40;
+    const has_typo = !demo_enabled and player_count == 1 and status.quest_unlock_index >= 40;
     const tutorial_first = player_count == 1 and main_total == 0;
     if (player_count != 1) return play_game_entries_multi[0..];
     if (has_typo and tutorial_first) return play_game_entries_single_typo_tutorial_first[0..];
@@ -367,12 +367,12 @@ fn playGameEntriesFromPlayerCount(player_count_raw: u32, status: formats.game_cf
     return play_game_entries_single[0..];
 }
 
-fn playGameLayout(config: *const formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, timeline_ms: i32) PlayGameLayout {
-    return playGameLayoutFromPlayerCount(config.player_count, status, timeline_ms);
+fn playGameLayout(config: *const formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, timeline_ms: i32, demo_enabled: bool) PlayGameLayout {
+    return playGameLayoutFromPlayerCount(config.player_count, status, timeline_ms, demo_enabled);
 }
 
-fn playGameLayoutFromPlayerCount(player_count_raw: u32, status: formats.game_cfg.Status, timeline_ms: i32) PlayGameLayout {
-    const entries = playGameEntriesFromPlayerCount(player_count_raw, status);
+fn playGameLayoutFromPlayerCount(player_count_raw: u32, status: formats.game_cfg.Status, timeline_ms: i32, demo_enabled: bool) PlayGameLayout {
+    const entries = playGameEntriesFromPlayerCount(player_count_raw, status, demo_enabled);
     const player_count = std.math.clamp(player_count_raw, @as(u32, 1), @as(u32, 4));
     const tight_spacing = player_count == 1 and status.quest_unlock_index >= 40;
     const y_step: f32 = if (tight_spacing) 28.0 else 32.0;
@@ -572,8 +572,9 @@ pub const QuestResult = struct {
     config_dirty: bool = false,
 };
 
-pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status) QuestResult {
+pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_cfg.CrimsonCfg, status: formats.game_cfg.Status, demo_enabled: bool) QuestResult {
     const dt_ms = frameDeltaMs(frame_dt);
+    var config_dirty = false;
     if (state.closing) {
         if (dt_ms > 0) state.panel.timeline_ms -= dt_ms;
         if (state.panel.timeline_ms < 0) {
@@ -591,6 +592,10 @@ pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_
         return .{};
     }
     if (dt_ms > 0) state.panel.timeline_ms = @min(panel_timeline_max_ms, state.panel.timeline_ms + dt_ms);
+    if (demo_enabled and config.hardcore_flag != 0) {
+        config.hardcore_flag = 0;
+        config_dirty = true;
+    }
     if (rl.isKeyPressed(.escape)) {
         beginCloseQuestBack(state);
         return .{ .play_button_click = true };
@@ -617,6 +622,7 @@ pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_
         const hardcore_rect = hardcoreCheckRect(layout);
         if (rl.checkCollisionPointRec(rl.getMousePosition(), hardcore_rect) and rl.isMouseButtonPressed(.left)) {
             config.hardcore_flag = if (config.hardcore_flag == 0) 1 else 0;
+            if (demo_enabled) config.hardcore_flag = 0;
             return .{ .play_button_click = true, .config_dirty = true };
         }
     }
@@ -634,6 +640,7 @@ pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_
 
     return .{
         .play_panel_click = dt_ms > 0 and state.panel.timeline_ms >= panel_timeline_max_ms and !state.panel.panel_open_sfx_played,
+        .config_dirty = config_dirty,
     };
 }
 


### PR DESCRIPTION
## Summary
- port the Python demo/trial shell into the Zig desktop app
- add app-level `--demo` boot flow, menu/theme restrictions, and in-game demo timers
- render the purchase/maybe-later trial overlay instead of leaving demo mode as a low-level runtime flag only

## Testing
- cd crimson-zig && zig build test
- cd crimson-zig && zig build window
- cd crimson-zig && zig build wasm
- cd crimson-zig && zig build run-window -- --help
