### PR TITLE
fix(zig): accept keypad enter on buttons

### DIFF
--- a/crimson-zig/src/window_ui.zig
+++ b/crimson-zig/src/window_ui.zig
@@ -32,7 +32,7 @@ pub fn updateSelectionFromPointer(selection: *usize, buttons: []const UiButton) 
 }
 
 pub fn buttonActivated(buttons: []const UiButton, selection: usize) bool {
-    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space)) return true;
+    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.kp_enter) or rl.isKeyPressed(.space)) return true;
 
     if (!rl.isMouseButtonPressed(.left)) return false;
     const mouse = rl.getMousePosition();


### PR DESCRIPTION
## Summary

- accept keypad Enter in the shared Zig UI button activation path
- keep mouse and Space/Enter behavior unchanged

## Validation

- `zig build test --summary all`
- `just check-zig`
