### PR TITLE
fix(zig): accept keypad enter across shell controls

### DIFF
--- a/crimson-zig/src/window_menu.zig
+++ b/crimson-zig/src/window_menu.zig
@@ -345,7 +345,7 @@ fn hoveredRootIndex(runtime_assets: ?*const window_assets.RuntimeAssets, root_en
 
 fn activateRootSelection(state: *State, selected_slot: usize) bool {
     if (!rootEntryEnabled(selected_slot, state.timeline_ms)) return false;
-    return if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space))
+    return if (window_ui.confirmPressed())
         true
     else if (!rl.isMouseButtonPressed(.left))
         false

--- a/crimson-zig/src/window_menu_panels.zig
+++ b/crimson-zig/src/window_menu_panels.zig
@@ -305,7 +305,7 @@ fn updatePlayGamePlayerList(state: *PlayGameState, config: *formats.crimson_cfg.
         }
     }
 
-    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space)) {
+    if (window_ui.confirmPressed()) {
         config.player_count = @intCast(state.player_count_selection + 1);
         state.player_list_open = false;
         return .{ .play_button_click = true, .config_dirty = true };
@@ -628,7 +628,7 @@ pub fn updateQuests(state: *QuestState, frame_dt: f32, config: *formats.crimson_
     }
 
     if (hovered_row) |row| {
-        if (rl.isMouseButtonPressed(.left) or rl.isKeyPressed(.enter)) {
+        if (rl.isMouseButtonPressed(.left) or window_ui.confirmPressed()) {
             return tryStartQuest(state, config, status, state.stage, row);
         }
     }

--- a/crimson-zig/src/window_misc_panels.zig
+++ b/crimson-zig/src/window_misc_panels.zig
@@ -174,7 +174,7 @@ fn updatePanel(state: *PanelState, frame_dt: f32, runtime_assets: ?*const window
         state.back_hover_amount = std.math.clamp(state.back_hover_amount - dt_ms * 2, 0, 1000);
     }
 
-    if (rl.isKeyPressed(.escape) or rl.isKeyPressed(.enter) or rl.isKeyPressed(.space) or (back_hovered and rl.isMouseButtonPressed(.left))) {
+    if (rl.isKeyPressed(.escape) or window_ui.confirmPressed() or (back_hovered and rl.isMouseButtonPressed(.left))) {
         return .{ .action = .back_to_menu, .play_button_click = true };
     }
 

--- a/crimson-zig/src/window_options.zig
+++ b/crimson-zig/src/window_options.zig
@@ -152,7 +152,7 @@ pub fn updateOptions(state: *OptionsState, frame_dt: f32, config: *formats.crims
         state.back_hover_amount = std.math.clamp(state.back_hover_amount - dt_ms * 2, 0, 1000);
     }
 
-    if (rl.isKeyPressed(.escape) or rl.isKeyPressed(.enter) or rl.isKeyPressed(.space) or (back_hovered and click)) {
+    if (rl.isKeyPressed(.escape) or window_ui.confirmPressed() or (back_hovered and click)) {
         state.active_slider = .none;
         return .{ .action = .back_to_menu, .play_button_click = true };
     }
@@ -231,7 +231,7 @@ pub fn updateControls(state: *ControlsState, frame_dt: f32, config: *formats.cri
         return updateControlsRebinding(state, config);
     }
 
-    if (rl.isKeyPressed(.escape) or rl.isKeyPressed(.enter) or rl.isKeyPressed(.space) or (back_hovered and rl.isMouseButtonPressed(.left))) {
+    if (rl.isKeyPressed(.escape) or window_ui.confirmPressed() or (back_hovered and rl.isMouseButtonPressed(.left))) {
         if (state.open_dropdown != .none) {
             state.open_dropdown = .none;
             return .{};
@@ -274,7 +274,7 @@ pub fn updateControls(state: *ControlsState, frame_dt: f32, config: *formats.cri
     var result: ControlsUpdate = .{
         .play_panel_click = dt_ms > 0 and state.timeline_ms >= panel_timeline_max_ms and !state.panel_open_sfx_played,
     };
-    const activated = rl.isKeyPressed(.enter) or rl.isKeyPressed(.space) or rl.isMouseButtonPressed(.left);
+    const activated = window_ui.confirmPressed() or rl.isMouseButtonPressed(.left);
 
     if (state.focus_right and rebind_rows.len > 0) {
         if (!activated) return result;
@@ -609,7 +609,7 @@ fn updateControlsDropdown(state: *ControlsState, config: *formats.crimson_cfg.Cr
         }
     }
 
-    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space)) {
+    if (window_ui.confirmPressed()) {
         return applyControlsDropdownSelection(state, config, items[state.dropdown_selection].value);
     }
     if (rl.isMouseButtonPressed(.left) and !rl.checkCollisionPointRec(mouse, base_rect)) {

--- a/crimson-zig/src/window_pause_menu.zig
+++ b/crimson-zig/src/window_pause_menu.zig
@@ -3,6 +3,7 @@ const rl = @import("raylib");
 
 const window_assets = @import("window_assets.zig");
 const window_menu = @import("window_menu.zig");
+const window_ui = @import("window_ui.zig");
 
 const menu_label_width: f32 = 122.0;
 const menu_label_height: f32 = 28.0;
@@ -159,7 +160,7 @@ fn hoveredIndex(runtime_assets: ?*const window_assets.RuntimeAssets) ?usize {
 
 fn activateSelection(state: *State) bool {
     if (!entryEnabled(state.selection, state.timeline_ms)) return false;
-    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space)) return true;
+    if (window_ui.confirmPressed()) return true;
     if (!rl.isMouseButtonPressed(.left)) return false;
     const hovered = state.hovered_index orelse return false;
     return hovered == state.selection;

--- a/crimson-zig/src/window_perk_menu.zig
+++ b/crimson-zig/src/window_perk_menu.zig
@@ -306,7 +306,7 @@ fn updateMenuInput(
         return result;
     }
 
-    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.space)) {
+    if (window_ui.confirmPressed()) {
         closeMenu(state, runner.perkPendingCount());
         result.perk_choice_index = @intCast(state.selected_index);
         result.play_button_click = true;

--- a/crimson-zig/src/window_ui.zig
+++ b/crimson-zig/src/window_ui.zig
@@ -31,8 +31,12 @@ pub fn updateSelectionFromPointer(selection: *usize, buttons: []const UiButton) 
     }
 }
 
+pub fn confirmPressed() bool {
+    return rl.isKeyPressed(.enter) or rl.isKeyPressed(.kp_enter) or rl.isKeyPressed(.space);
+}
+
 pub fn buttonActivated(buttons: []const UiButton, selection: usize) bool {
-    if (rl.isKeyPressed(.enter) or rl.isKeyPressed(.kp_enter) or rl.isKeyPressed(.space)) return true;
+    if (confirmPressed()) return true;
 
     if (!rl.isMouseButtonPressed(.left)) return false;
     const mouse = rl.getMousePosition();


### PR DESCRIPTION
## Summary

- add a shared Zig UI confirm-key helper for Enter, keypad Enter, and Space
- use it across root menu, panels, options/controls, pause menu, and perk menu
- keep mouse activation behavior unchanged

## Validation

- `zig build test --summary all`
- `just check-zig`
