### PR TITLE
fix(zig): format result screen scores

### DIFF
--- a/crimson-zig/src/root.zig
+++ b/crimson-zig/src/root.zig
@@ -28,6 +28,7 @@ pub const session_builders = @import("runtime/session_builders.zig");
 pub const live_runner = @import("runtime/live_runner.zig");
 pub const tutorial_runtime = @import("tutorial/runtime.zig");
 pub const typo_names = @import("typo/names.zig");
+pub const ui_formatting = @import("ui_formatting.zig");
 
 pub const formats = @import("formats/mod.zig");
 pub const persistence = @import("persistence/mod.zig");

--- a/crimson-zig/src/test_root.zig
+++ b/crimson-zig/src/test_root.zig
@@ -27,6 +27,7 @@ test {
     _ = cz.session_builders;
     _ = cz.spawn;
     _ = cz.state;
+    _ = cz.ui_formatting;
     _ = cz.weapon_data;
     _ = cz.weapons;
     _ = cz.window_atlas;

--- a/crimson-zig/src/ui_formatting.zig
+++ b/crimson-zig/src/ui_formatting.zig
@@ -1,0 +1,44 @@
+const std = @import("std");
+
+pub fn formatOrdinal(buf: []u8, value_1_based: i32) []const u8 {
+    const value = value_1_based;
+    const abs_value = @abs(value);
+    const suffix = if (@mod(abs_value, 100) >= 11 and @mod(abs_value, 100) <= 13)
+        "th"
+    else switch (@mod(abs_value, 10)) {
+        1 => "st",
+        2 => "nd",
+        3 => "rd",
+        else => "th",
+    };
+    return std.fmt.bufPrint(buf, "{d}{s}", .{ value, suffix }) catch "";
+}
+
+pub fn formatTimeMmSs(buf: []u8, ms: i32) []const u8 {
+    const total_s = @divFloor(@max(0, ms), 1000);
+    const minutes = @divFloor(total_s, 60);
+    const seconds = @mod(total_s, 60);
+    return std.fmt.bufPrint(buf, "{d}:{d:0>2}", .{ minutes, seconds }) catch "";
+}
+
+test "format ordinal matches python result helpers" {
+    var buf: [16]u8 = undefined;
+    try std.testing.expectEqualStrings("1st", formatOrdinal(&buf, 1));
+    try std.testing.expectEqualStrings("2nd", formatOrdinal(&buf, 2));
+    try std.testing.expectEqualStrings("3rd", formatOrdinal(&buf, 3));
+    try std.testing.expectEqualStrings("4th", formatOrdinal(&buf, 4));
+    try std.testing.expectEqualStrings("11th", formatOrdinal(&buf, 11));
+    try std.testing.expectEqualStrings("12th", formatOrdinal(&buf, 12));
+    try std.testing.expectEqualStrings("13th", formatOrdinal(&buf, 13));
+    try std.testing.expectEqualStrings("21st", formatOrdinal(&buf, 21));
+    try std.testing.expectEqualStrings("112th", formatOrdinal(&buf, 112));
+}
+
+test "format time clamps to zero and uses m:ss" {
+    var buf: [16]u8 = undefined;
+    try std.testing.expectEqualStrings("0:00", formatTimeMmSs(&buf, -1));
+    try std.testing.expectEqualStrings("0:00", formatTimeMmSs(&buf, 999));
+    try std.testing.expectEqualStrings("0:01", formatTimeMmSs(&buf, 1000));
+    try std.testing.expectEqualStrings("1:01", formatTimeMmSs(&buf, 61_999));
+    try std.testing.expectEqualStrings("12:20", formatTimeMmSs(&buf, 740_000));
+}

--- a/crimson-zig/src/window_main.zig
+++ b/crimson-zig/src/window_main.zig
@@ -43,6 +43,7 @@ const state_mod = cz.state;
 const terrain_fx_mod = cz.terrain_fx;
 const tutorial_runtime = cz.tutorial_runtime;
 const typo_names = cz.typo_names;
+const ui_formatting = cz.ui_formatting;
 
 const window_width = 1024;
 const window_height = 768;
@@ -1405,7 +1406,8 @@ const App = struct {
                 drawSmallText(runtime_assets, "WEAPON", 370.0, 342.0, HudTextColor.dim);
                 drawSmallText(runtime_assets, "HP", 370.0, 370.0, HudTextColor.dim);
                 const elapsed_ms = if (results.quest_final_time) |breakdown| breakdown.final_time_ms else @as(i32, @intCast(results.summary.elapsed_ms_sim));
-                drawSmallTextFmt("{d} ms", runtime_assets, .{elapsed_ms}, 510.0, 258.0, HudTextColor.primary);
+                var elapsed_buf: [16]u8 = undefined;
+                drawSmallText(runtime_assets, ui_formatting.formatTimeMmSs(&elapsed_buf, elapsed_ms), 510.0, 258.0, HudTextColor.primary);
                 drawSmallTextFmt("{d}", runtime_assets, .{results.summary.player_experience}, 510.0, 286.0, HudTextColor.primary);
                 drawSmallTextFmt("{d}", runtime_assets, .{results.summary.player_level}, 510.0, 314.0, HudTextColor.primary);
                 drawSmallText(runtime_assets, weaponName(results.summary.player_weapon_id), 510.0, 342.0, HudTextColor.primary);
@@ -1416,10 +1418,14 @@ const App = struct {
                     drawSmallText(runtime_assets, "LIFE BONUS", 690.0, 286.0, HudTextColor.dim);
                     drawSmallText(runtime_assets, "PERK BONUS", 690.0, 314.0, HudTextColor.dim);
                     drawSmallText(runtime_assets, "FINAL", 690.0, 342.0, HudTextColor.dim);
-                    drawSmallTextFmt("{d} ms", runtime_assets, .{breakdown.base_time_ms}, 846.0, 258.0, HudTextColor.primary);
-                    drawSmallTextFmt("-{d} ms", runtime_assets, .{breakdown.life_bonus_ms}, 846.0, 286.0, HudTextColor.primary);
-                    drawSmallTextFmt("-{d} ms", runtime_assets, .{breakdown.unpicked_perk_bonus_ms}, 846.0, 314.0, HudTextColor.primary);
-                    drawSmallTextFmt("{d} ms", runtime_assets, .{breakdown.final_time_ms}, 846.0, 342.0, HudTextColor.accent);
+                    var base_buf: [16]u8 = undefined;
+                    var life_buf: [16]u8 = undefined;
+                    var perk_buf: [16]u8 = undefined;
+                    var final_buf: [16]u8 = undefined;
+                    drawSmallText(runtime_assets, ui_formatting.formatTimeMmSs(&base_buf, breakdown.base_time_ms), 846.0, 258.0, HudTextColor.primary);
+                    drawSmallTextFmt("-{s}", runtime_assets, .{ui_formatting.formatTimeMmSs(&life_buf, breakdown.life_bonus_ms)}, 846.0, 286.0, HudTextColor.primary);
+                    drawSmallTextFmt("-{s}", runtime_assets, .{ui_formatting.formatTimeMmSs(&perk_buf, breakdown.unpicked_perk_bonus_ms)}, 846.0, 314.0, HudTextColor.primary);
+                    drawSmallText(runtime_assets, ui_formatting.formatTimeMmSs(&final_buf, breakdown.final_time_ms), 846.0, 342.0, HudTextColor.accent);
                 }
 
                 if (results.runtime_error) |runtime_error| {
@@ -2663,9 +2669,11 @@ fn drawResultsHighscore(
     highscore: *const ResultsHighscoreState,
 ) void {
     const prompt_y = 452.0;
+    var rank_buf: [16]u8 = undefined;
+    const rank_text = ui_formatting.formatOrdinal(&rank_buf, @intCast(highscore.rank_index + 1));
     if (highscore.promptActive()) {
         drawSmallTextCentered(runtime_assets, "NEW HIGH SCORE", prompt_y, HudTextColor.accent);
-        drawSmallTextFmt("RANK #{d}", runtime_assets, .{highscore.rank_index + 1}, 420.0, prompt_y + 28.0, HudTextColor.primary);
+        drawSmallTextFmt("RANK {s}", runtime_assets, .{rank_text}, 420.0, prompt_y + 28.0, HudTextColor.primary);
         drawSmallTextCentered(runtime_assets, "ENTER YOUR NAME TO SAVE THIS RUN", prompt_y + 56.0, HudTextColor.dim);
 
         rl.drawRectangleRounded(
@@ -2691,7 +2699,7 @@ fn drawResultsHighscore(
         }
     } else {
         drawSmallTextCentered(runtime_assets, "SCORE SAVED", prompt_y, HudTextColor.accent);
-        drawSmallTextFmt("RANK #{d}  NAME {s}", runtime_assets, .{ highscore.rank_index + 1, highscore.record.name() }, 330.0, prompt_y + 28.0, HudTextColor.primary);
+        drawSmallTextFmt("RANK {s}  NAME {s}", runtime_assets, .{ rank_text, highscore.record.name() }, 330.0, prompt_y + 28.0, HudTextColor.primary);
     }
 }
 


### PR DESCRIPTION
## Summary

- add shared UI formatting helpers for result ordinals and m:ss times
- show result screen elapsed/final times in m:ss format
- show high-score result ranks as ordinal labels

## Validation

- `zig build test --summary all`
- `just check-zig`
