### PR TITLE
refactor: clarify deterministic presentation plan

### DIFF
--- a/docs/rewrite/deterministic-step-pipeline.md
+++ b/docs/rewrite/deterministic-step-pipeline.md
@@ -75,8 +75,8 @@ At the runtime boundary, one deterministic tick is one `ResolvedTick`:
 
 - `tick_index`
 - `dt_seconds`
-- `inputs`
-- `commands`
+- `inputs`: canonical tuple of per-player `PlayerInput` values in slot order
+- `commands`: canonical tuple of per-tick game commands
 
 Live/LAN paths receive it through `InputProvider.pull_tick(...) -> TickSupply`.
 Replay paths synthesize the same shape inside `PlaybackDriver.step_tick(...)`.
@@ -92,9 +92,14 @@ whose `step` is a `DeterministicStepResult` with:
 
 - `dt_sim`: effective dt after deterministic scaling
 - `events`: deterministic sim events
-- `presentation`: deterministic presentation commands
-- `post_apply_sfx_keys`: post-apply presentation reactions triggered by successful command effects
+- `presentation`: a `DeterministicPresentationPlan` envelope for deterministic native-parity outputs
 - optional RNG trace data when replay trace mode is enabled
+
+`DeterministicPresentationPlan` intentionally remains part of deterministic
+stepping. Native hit audio and terrain decals consume the authoritative RNG
+stream, so headless verification still builds the plan even when no renderer or
+audio backend is present. Sinks are optional consumers of that plan; the plan is
+not optional for parity.
 
 ```mermaid
 flowchart LR
@@ -133,6 +138,9 @@ Shared helpers own the bookkeeping around that sequence:
 
 This keeps live gameplay, replay playback, headless verification, and runtime
 harnesses close to the same deterministic contract even when their outer loops differ.
+`apply_presentation_outputs()` consumes the outer runtime's presentation
+capabilities for audio, terrain, and camera effects; deterministic stepping
+only emits the plan.
 
 ```mermaid
 sequenceDiagram
@@ -151,6 +159,13 @@ sequenceDiagram
     Outer->>Apply: build/apply post-apply reactions
     Outer->>Hooks: optional checkpoints / replay info / LAN sync
 ```
+
+## Deferred TODOs
+
+- Rollback restore is intentionally deferred here. The current runtime can
+  signal rollback/resync, but true rollback should restore a deterministic
+  snapshot at the requested tick and replay corrected inputs through the shared
+  tick pipeline before it is treated as a verification path.
 
 ### Timer Ownership
 

--- a/src/crimson/modes/base_gameplay_mode.py
+++ b/src/crimson/modes/base_gameplay_mode.py
@@ -190,7 +190,7 @@ class _LanRuntimeInputProvider:
             return TickSupply(status=InputStatus.STALLED, tick=None)
         frame_tick_index = int(frame.tick_index)
         frame_inputs = tuple(list(packed) for packed in frame.frame_inputs)
-        player_inputs = [unpack_player_input(packed) for packed in frame_inputs]
+        player_inputs = tuple(unpack_player_input(packed) for packed in frame_inputs)
         self._samples_by_runner_tick[int(tick_index)] = LanFrameSample(
             frame_tick_index=int(frame_tick_index),
             frame_inputs=tuple(frame_inputs),
@@ -202,7 +202,7 @@ class _LanRuntimeInputProvider:
                 tick_index=int(tick_index),
                 dt_seconds=float(default_dt_seconds),
                 inputs=player_inputs,
-                commands=list(frame.commands),
+                commands=tuple(frame.commands),
             ),
         )
 
@@ -1709,7 +1709,7 @@ class BaseGameplayMode:
         sim_ms = (time.perf_counter_ns() - sim_ns_start) / 1_000_000.0
         self._sim_ms += float(sim_ms)
         self._presentation_plan_ms += float(
-            sum(max(0.0, float(row.payload.step.presentation_plan_ms)) for row in batch.completed_results),
+            sum(max(0.0, float(row.payload.presentation_plan_ms)) for row in batch.completed_results),
         )
 
         ticks_applied = 0
@@ -1781,18 +1781,13 @@ class BaseGameplayMode:
         }
         apply_presentation_outputs(
             outputs=outputs,
-            sync_audio_bridge_state=self._world_runtime.sync_audio_bridge_state,
-            apply_audio_plan=lambda plan, should_apply_audio: self._world_runtime.audio_bridge.apply_plan(
-                plan=plan,
-                apply_audio=bool(should_apply_audio),
-            ),
-            apply_terrain_fx=self.render_resources.consume_terrain_fx_batch,
-            update_camera=self._world_runtime.update_camera if bool(update_camera) else None,
+            runtime=self._world_runtime,
             on_output_applied=lambda output: self._apply_tick_post_apply_reaction(
                 reaction_by_tick.get(int(output.tick_index), PostApplyReaction()),
                 dt_seconds=float(output.dt_sim),
             ),
             apply_audio=bool(apply_audio),
+            update_camera=bool(update_camera),
         )
 
     def _build_tick_post_apply_reaction(self, *, tick_result: TickResult) -> PostApplyReaction:
@@ -1827,7 +1822,7 @@ class BaseGameplayMode:
                 replay_tick_index = int(
                     recorder.record_tick(
                         list(tick_result.source_tick.inputs),
-                        commands=tick_result.source_tick.commands,
+                        commands=list(tick_result.source_tick.commands),
                     ),
                 )
                 tick_result.replay_tick_index = replay_tick_index
@@ -1941,7 +1936,7 @@ class BaseGameplayMode:
         batch = advance.batch
         self._sim_ms = float((time.perf_counter_ns() - sim_ns_start) / 1_000_000.0)
         self._presentation_plan_ms = float(
-            sum(max(0.0, float(row.payload.step.presentation_plan_ms)) for row in batch.completed_results),
+            sum(max(0.0, float(row.payload.presentation_plan_ms)) for row in batch.completed_results),
         )
 
         apply_ns_start = time.perf_counter_ns()

--- a/src/crimson/modes/replay_playback_mode.py
+++ b/src/crimson/modes/replay_playback_mode.py
@@ -500,13 +500,7 @@ class ReplayPlaybackMode:
         if advance.outputs:
             apply_presentation_outputs(
                 outputs=advance.outputs,
-                sync_audio_bridge_state=runtime.sync_audio_bridge_state,
-                apply_audio_plan=lambda plan, should_apply_audio: runtime.audio_bridge.apply_plan(
-                    plan=plan,
-                    apply_audio=bool(should_apply_audio),
-                ),
-                apply_terrain_fx=runtime.render_resources.consume_terrain_fx_batch,
-                update_camera=runtime.update_camera,
+                runtime=runtime,
                 on_output_applied=_on_output_applied,
                 apply_audio=True,
             )

--- a/src/crimson/replay/driver/playback_driver.py
+++ b/src/crimson/replay/driver/playback_driver.py
@@ -425,8 +425,8 @@ class PlaybackDriver:
             source_tick = ResolvedTick(
                 tick_index=int(tick_index),
                 dt_seconds=float(dt_tick),
-                inputs=list(inputs),
-                commands=list(commands),
+                inputs=tuple(inputs),
+                commands=tuple(commands),
             )
 
             session_tick = self.session.step_tick(

--- a/src/crimson/replay/driver/playback_pump.py
+++ b/src/crimson/replay/driver/playback_pump.py
@@ -98,7 +98,6 @@ def advance_playback_frame(
             tick_index=int(tick_result.source_tick.tick_index),
             dt_sim=float(tick_result.payload.step.dt_sim),
             presentation=tick_result.payload.step.presentation,
-            terrain_fx=tick_result.payload.step.terrain_fx,
         ))
 
     return PlaybackFrameAdvance(

--- a/src/crimson/replay/driver/replay_info.py
+++ b/src/crimson/replay/driver/replay_info.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Sequence
 from typing import Literal, TypeAlias
 
 import msgspec
@@ -125,7 +126,7 @@ def _append_event(
 
 def _append_extra_replay_commands(
     *,
-    commands: list[GameCommand],
+    commands: Sequence[GameCommand],
     tick_index: int,
     elapsed_ms: int,
     timeline: list[ReplayInfoTimelineEvent],

--- a/src/crimson/replay/recorder.py
+++ b/src/crimson/replay/recorder.py
@@ -42,7 +42,7 @@ class ReplayRecorder:
         self,
         inputs: Sequence[PlayerInput],
         *,
-        commands: list[GameCommand] | None = None,
+        commands: Sequence[GameCommand] | None = None,
         dt: float | None = None,
     ) -> int:
         """Record a single simulation tick worth of inputs.

--- a/src/crimson/sim/batch_apply.py
+++ b/src/crimson/sim/batch_apply.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 from .hooks import TickResult
-from .presentation_step import PresentationStepCommands
+from .presentation_step import DeterministicPresentationPlan
 from .step_pipeline import DeterministicStepResult
-from .terrain_fx import TerrainFxBatch
 from .world_state import WorldEvents
 
 
@@ -16,7 +15,7 @@ class SimMetadataSink(Protocol):
         self,
         *,
         events: WorldEvents,
-        presentation: PresentationStepCommands,
+        presentation: DeterministicPresentationPlan,
         dt_sim: float,
         game_tune_started: bool,
     ) -> None: ...
@@ -26,8 +25,7 @@ class SimMetadataSink(Protocol):
 class PresentationTickOutput:
     tick_index: int
     dt_sim: float
-    presentation: PresentationStepCommands | None
-    terrain_fx: TerrainFxBatch = TerrainFxBatch()
+    presentation: DeterministicPresentationPlan | None
 
 
 def apply_sim_metadata_tick_result(
@@ -47,7 +45,6 @@ def apply_sim_metadata_tick_result(
         tick_index=int(tick_result.source_tick.tick_index),
         dt_sim=float(step.dt_sim),
         presentation=step.presentation,
-        terrain_fx=step.terrain_fx,
     )
 
 
@@ -84,23 +81,22 @@ def apply_sim_metadata_batch(
 def apply_presentation_outputs(
     *,
     outputs: Sequence[PresentationTickOutput],
-    sync_audio_bridge_state: Callable[[], None],
-    apply_audio_plan: Callable[[PresentationStepCommands, bool], None],
-    apply_terrain_fx: Callable[[TerrainFxBatch], None] | None,
-    update_camera: Callable[[float], None] | None,
+    runtime: Any,
     on_output_applied: Callable[[PresentationTickOutput], None] | None = None,
     apply_audio: bool,
+    update_camera: bool = True,
 ) -> None:
     if not outputs:
         return
 
-    sync_audio_bridge_state()
+    runtime.sync_audio_bridge_state()
     for output in outputs:
         if output.presentation is not None:
-            apply_audio_plan(output.presentation, bool(apply_audio))
-            if update_camera is not None:
-                update_camera(float(output.dt_sim))
-        if apply_terrain_fx is not None and not output.terrain_fx.is_empty():
-            apply_terrain_fx(output.terrain_fx)
+            runtime.audio_bridge.apply_plan(plan=output.presentation, apply_audio=bool(apply_audio))
+            if bool(update_camera):
+                runtime.update_camera(float(output.dt_sim))
+            terrain_fx = output.presentation.terrain_fx
+            if not terrain_fx.is_empty():
+                runtime.render_resources.consume_terrain_fx_batch(terrain_fx)
         if on_output_applied is not None:
             on_output_applied(output)

--- a/src/crimson/sim/input_providers.py
+++ b/src/crimson/sim/input_providers.py
@@ -61,8 +61,8 @@ class InputStatus(str, Enum):
 class ResolvedTick(msgspec.Struct, frozen=True):
     tick_index: int
     dt_seconds: float
-    inputs: list[PlayerInput] = msgspec.field(default_factory=list)
-    commands: list[GameCommand] = msgspec.field(default_factory=list)
+    inputs: tuple[PlayerInput, ...] = ()
+    commands: tuple[GameCommand, ...] = ()
 
 
 class TickSupply(msgspec.Struct, frozen=True):
@@ -122,8 +122,8 @@ class LocalInputProvider:
                 tick=ResolvedTick(
                     tick_index=tick_index,
                     dt_seconds=dt_seconds,
-                    inputs=inputs,
-                    commands=commands,
+                    inputs=tuple(inputs),
+                    commands=tuple(commands),
                 ),
             )
         inputs = [] if self._player_count <= 0 else list(self._edge_inputs)
@@ -132,8 +132,8 @@ class LocalInputProvider:
             tick=ResolvedTick(
                 tick_index=tick_index,
                 dt_seconds=dt_seconds,
-                inputs=inputs,
-                commands=[],
+                inputs=tuple(inputs),
+                commands=(),
             ),
         )
 

--- a/src/crimson/sim/presentation_reactions.py
+++ b/src/crimson/sim/presentation_reactions.py
@@ -28,10 +28,10 @@ def build_post_apply_reaction(
 ) -> PostApplyReaction:
     if quest_state is None:
         return PostApplyReaction(
-            sfx=tuple(tick_result.payload.step.post_apply_sfx),
+            sfx=tuple(tick_result.payload.step.presentation.post_apply_sfx),
         )
     return PostApplyReaction(
-        sfx=tuple(tick_result.payload.step.post_apply_sfx),
+        sfx=tuple(tick_result.payload.step.presentation.post_apply_sfx),
         quest=QuestPresentationReaction(
             play_hit_sfx=bool(quest_state.play_hit_sfx),
             play_completion_music=bool(quest_state.play_completion_music),

--- a/src/crimson/sim/presentation_step.py
+++ b/src/crimson/sim/presentation_step.py
@@ -20,6 +20,7 @@ from ..projectiles.types import ProjectileHit, ProjectileTemplateId
 from ..rng_caller_static import RngCallerStatic
 from ..weapons import WEAPON_BY_ID, WeaponId, weapon_entry_for_projectile_type_id
 from .state_types import BonusPickupEvent, GameplayState, PlayerState
+from .terrain_fx import TerrainFxBatch
 from .world_defs import BEAM_TYPES
 
 _MAX_HIT_SFX_PER_FRAME = 4
@@ -33,9 +34,13 @@ _BULLET_HIT_SFX = (
 )
 
 
-class PresentationStepCommands(msgspec.Struct):
+class DeterministicPresentationPlan(msgspec.Struct):
+    """Deterministic native-parity presentation effects emitted by one sim tick."""
+
     trigger_game_tune: bool = False
     sfx: list[SfxId] = msgspec.field(default_factory=list)
+    terrain_fx: TerrainFxBatch = TerrainFxBatch()
+    post_apply_sfx: tuple[SfxId, ...] = ()
 
 
 class PresentationAudioSink(Protocol):
@@ -331,8 +336,8 @@ def plan_world_presentation_step(
     game_tune_started: bool,
     trigger_game_tune: bool | None = None,
     hit_sfx: Sequence[SfxId] | None = None,
-) -> PresentationStepCommands:
-    commands = PresentationStepCommands()
+) -> DeterministicPresentationPlan:
+    commands = DeterministicPresentationPlan()
     if perk_progression_enabled and int(state.perk_selection.pending_count) > int(prev_perk_pending):
         commands.sfx.append(SfxId.UI_LEVELUP)
     if trigger_game_tune is None and hit_sfx is None:
@@ -383,7 +388,7 @@ def plan_world_presentation_step(
 
 def apply_presentation_plan(
     *,
-    plan: PresentationStepCommands,
+    plan: DeterministicPresentationPlan,
     audio_sink: PresentationAudioSink | None,
     apply_audio: bool = True,
 ) -> None:

--- a/src/crimson/sim/sessions.py
+++ b/src/crimson/sim/sessions.py
@@ -51,6 +51,7 @@ class DeterministicSessionTick(msgspec.Struct):
     step: DeterministicStepResult
     elapsed_ms: float
     creature_count_world_step: int
+    presentation_plan_ms: float = 0.0
 
 
 
@@ -388,20 +389,18 @@ class DeterministicSession(msgspec.Struct):
         if recording_rng is not None:
             presentation_trace.draws_total = int(recording_rng.calls)
 
+        presentation = msgspec.structs.replace(
+            presentation,
+            terrain_fx=self.terrain_fx.take_batch(),
+            post_apply_sfx=tuple(post_apply_sfx),
+        )
         step = DeterministicStepResult(
             dt_sim=timing.dt_sim,
             timing=timing,
             events=events,
             presentation=presentation,
-            presentation_plan_ms=presentation_plan_ms,
             presentation_rng_trace=presentation_trace,
-            terrain_fx=self.terrain_fx.take_batch(),
         )
-        if post_apply_sfx:
-            step = msgspec.structs.replace(
-                step,
-                post_apply_sfx=tuple(post_apply_sfx),
-            )
         if step.presentation.trigger_game_tune:
             self.game_tune_started = True
 
@@ -428,4 +427,5 @@ class DeterministicSession(msgspec.Struct):
             step=step,
             elapsed_ms=self.elapsed_ms,
             creature_count_world_step=creature_count_world_step,
+            presentation_plan_ms=float(presentation_plan_ms),
         )

--- a/src/crimson/sim/step_pipeline.py
+++ b/src/crimson/sim/step_pipeline.py
@@ -2,11 +2,8 @@ from __future__ import annotations
 
 import msgspec
 
-from grim.sfx_map import SfxId
-
 from ..math_parity import f32
-from .presentation_step import PresentationStepCommands
-from .terrain_fx import TerrainFxBatch
+from .presentation_step import DeterministicPresentationPlan
 from .timing import FrameTiming
 from .world_state import WorldEvents
 
@@ -19,11 +16,8 @@ class DeterministicStepResult(msgspec.Struct):
     dt_sim: float
     timing: FrameTiming
     events: WorldEvents
-    presentation: PresentationStepCommands
-    presentation_plan_ms: float
+    presentation: DeterministicPresentationPlan
     presentation_rng_trace: PresentationRngTrace
-    terrain_fx: TerrainFxBatch = TerrainFxBatch()
-    post_apply_sfx: tuple[SfxId, ...] = ()
 
 
 def time_scale_reflex_boost_bonus(

--- a/src/crimson/sim/tick_runner.py
+++ b/src/crimson/sim/tick_runner.py
@@ -118,6 +118,6 @@ class TickRunner:
         return ResolvedTick(
             tick_index=int(source_tick.tick_index),
             dt_seconds=dt_seconds,
-            inputs=list(source_tick.inputs),
-            commands=list(source_tick.commands),
+            inputs=tuple(source_tick.inputs),
+            commands=tuple(source_tick.commands),
         )

--- a/src/crimson/world/audio_bridge.py
+++ b/src/crimson/world/audio_bridge.py
@@ -9,7 +9,7 @@ from grim.audio import AudioState
 from grim.rand import Crand
 
 from ..audio_router import AudioRouter
-from ..sim.presentation_step import PresentationStepCommands, apply_presentation_plan
+from ..sim.presentation_step import DeterministicPresentationPlan, apply_presentation_plan
 
 
 def _zero_reflex_boost() -> float:
@@ -45,7 +45,7 @@ class AudioBridge(msgspec.Struct):
         self.router.audio_rng = audio_rng
         self.router.demo_mode_active = bool(demo_mode_active)
 
-    def apply_plan(self, *, plan: PresentationStepCommands, apply_audio: bool = True) -> None:
+    def apply_plan(self, *, plan: DeterministicPresentationPlan, apply_audio: bool = True) -> None:
         apply_presentation_plan(
             plan=plan,
             audio_sink=self.router,

--- a/src/crimson/world/sim_world_state.py
+++ b/src/crimson/world/sim_world_state.py
@@ -10,7 +10,7 @@ from grim.geom import Vec2
 from ..creatures.runtime import CreaturePool
 from ..creatures.spawn import SpawnEnv
 from ..gameplay import GameplayState
-from ..sim.presentation_step import PresentationStepCommands
+from ..sim.presentation_step import DeterministicPresentationPlan
 from ..sim.state_types import PlayerState
 from ..sim.world_state import WorldEvents, WorldState
 from ..weapon_runtime import init_default_alt_weapon, weapon_assign_player
@@ -76,7 +76,7 @@ class SimWorldState(msgspec.Struct):
     last_events: WorldEvents = msgspec.field(
         default_factory=lambda: WorldEvents(hits=[], deaths=(), pickups=[], sfx=[]),
     )
-    last_presentation: PresentationStepCommands = msgspec.field(default_factory=PresentationStepCommands)
+    last_presentation: DeterministicPresentationPlan = msgspec.field(default_factory=DeterministicPresentationPlan)
     def __post_init__(self) -> None:
         self.reset(seed=0xBEEF, player_count=1)
 
@@ -101,7 +101,7 @@ class SimWorldState(msgspec.Struct):
         self.state.rng.srand(int(seed))
 
         self.last_events = WorldEvents(hits=[], deaths=(), pickups=[], sfx=[])
-        self.last_presentation = PresentationStepCommands()
+        self.last_presentation = DeterministicPresentationPlan()
 
         self.presentation_elapsed_ms = 0.0
         self.bonus_anim_phase = 0.0
@@ -122,14 +122,14 @@ class SimWorldState(msgspec.Struct):
         self.players = self.world_state.players
         self.creatures = self.world_state.creatures
         self.last_events = WorldEvents(hits=[], deaths=(), pickups=[], sfx=[])
-        self.last_presentation = PresentationStepCommands()
+        self.last_presentation = DeterministicPresentationPlan()
 
 
     def apply_step_metadata(
         self,
         *,
         events: WorldEvents,
-        presentation: PresentationStepCommands,
+        presentation: DeterministicPresentationPlan,
         dt_sim: float,
         game_tune_started: bool,
     ) -> None:
@@ -144,6 +144,6 @@ class SimWorldState(msgspec.Struct):
 
     def close_session(self) -> None:
         self.last_events = WorldEvents(hits=[], deaths=(), pickups=[], sfx=[])
-        self.last_presentation = PresentationStepCommands()
+        self.last_presentation = DeterministicPresentationPlan()
 
         self.game_tune_started = False

--- a/src/crimson/world/standalone_tick_harness.py
+++ b/src/crimson/world/standalone_tick_harness.py
@@ -121,13 +121,7 @@ class StandaloneTickHarness:
         }
         apply_presentation_outputs(
             outputs=outputs,
-            sync_audio_bridge_state=runtime.sync_audio_bridge_state,
-            apply_audio_plan=lambda plan, should_apply_audio: runtime.audio_bridge.apply_plan(
-                plan=plan,
-                apply_audio=bool(should_apply_audio),
-            ),
-            apply_terrain_fx=runtime.render_resources.consume_terrain_fx_batch,
-            update_camera=runtime.update_camera,
+            runtime=runtime,
             on_output_applied=lambda output: apply_post_apply_reaction(
                 reaction=reactions.get(int(output.tick_index), PostApplyReaction()),
                 play_sfx=runtime.audio_bridge.router.play_sfx,

--- a/tests/contracts/test_architecture_contracts.py
+++ b/tests/contracts/test_architecture_contracts.py
@@ -29,7 +29,7 @@ from crimson.sim.input_providers import (
     PerkPickCommand,
     ResolvedTick,
 )
-from crimson.sim.presentation_step import PresentationStepCommands
+from crimson.sim.presentation_step import DeterministicPresentationPlan
 from crimson.sim.sessions import DeterministicSession, DeterministicSessionTick
 from crimson.sim.tick_runner import TickBatchResult, TickRunner, TickRunnerConfig
 from crimson.world.audio_bridge import AudioBridge
@@ -139,7 +139,7 @@ def test_contract_1_pure_headless_execution_no_render_or_audio_dependencies(mock
         assert result.payload is not None
         payload = result.payload
         assert isinstance(payload, DeterministicSessionTick)
-        assert isinstance(payload.step.presentation, PresentationStepCommands)
+        assert isinstance(payload.step.presentation, DeterministicPresentationPlan)
         assert payload.step is not None
 
 
@@ -150,8 +150,8 @@ def test_contract_3_lockstep_command_propagation_over_network_provider() -> None
         resolve_tick=lambda tick, dt: ResolvedTick(
             tick_index=int(tick),
             dt_seconds=float(dt),
-            inputs=list(tick_input),
-            commands=runtime.pull_commands(peer="host", tick_index=int(tick)),
+            inputs=tuple(tick_input),
+            commands=tuple(runtime.pull_commands(peer="host", tick_index=int(tick))),
         ),
         submit_command=runtime.submit_local_command,
     )
@@ -159,8 +159,8 @@ def test_contract_3_lockstep_command_propagation_over_network_provider() -> None
         resolve_tick=lambda tick, dt: ResolvedTick(
             tick_index=int(tick),
             dt_seconds=float(dt),
-            inputs=list(tick_input),
-            commands=runtime.pull_commands(peer="client", tick_index=int(tick)),
+            inputs=tuple(tick_input),
+            commands=tuple(runtime.pull_commands(peer="client", tick_index=int(tick))),
         ),
     )
     host_session, _ = make_session(seed=42)
@@ -207,8 +207,8 @@ def test_contract_3_lockstep_command_propagation_over_network_provider() -> None
     )
 
     # Commands propagated through runner to both host and client
-    assert host_batch.completed_results[0].source_tick.commands == [command]
-    assert client_batch.completed_results[0].source_tick.commands == [command]
+    assert host_batch.completed_results[0].source_tick.commands == (command,)
+    assert client_batch.completed_results[0].source_tick.commands == (command,)
 
 
 def test_contract_4_live_to_replay_uses_survival_session_and_matches_ticks(
@@ -394,14 +394,13 @@ def test_contract_6_shared_batch_apply_separates_deterministic_and_output_phases
     deterministic_apply_source = inspect.getsource(batch_apply_module.apply_tick_to_sim)
     output_source = inspect.getsource(batch_apply_module.apply_presentation_outputs)
 
-    assert "apply_audio_plan" not in deterministic_batch_source
     assert "update_camera" not in deterministic_batch_source
-    assert "apply_audio_plan" not in deterministic_tick_source
     assert "update_camera" not in deterministic_tick_source
-    assert "apply_audio_plan" not in deterministic_apply_source
     assert "update_camera" not in deterministic_apply_source
     assert "apply_step_metadata" not in output_source
     assert output_source.count("sync_audio_bridge_state()") == 1
+    assert "runtime.audio_bridge.apply_plan" in output_source
+    assert "runtime.render_resources.consume_terrain_fx_batch" in output_source
 
 
 def test_contract_7_live_frame_advancement_uses_shared_helper() -> None:

--- a/tests/gameplay/test_game_world_audio.py
+++ b/tests/gameplay/test_game_world_audio.py
@@ -193,8 +193,8 @@ def test_world_runtime_apply_tick_batch_applies_post_apply_bonus_sfx(mocker) -> 
                 source_tick=ResolvedTick(
                     tick_index=0,
                     dt_seconds=1.0 / 60.0,
-                    inputs=[],
-                    commands=[],
+                    inputs=(),
+                    commands=(),
                 ),
                 payload=make_tick_payload(post_apply_sfx=(SfxId.UI_BONUS,)),
             ),

--- a/tests/regressions/test_runner_presentation_regressions.py
+++ b/tests/regressions/test_runner_presentation_regressions.py
@@ -66,7 +66,7 @@ def _apply_batch(
             apply_audio=True,
         )
         world.update_camera(float(step.dt_sim))
-        world.render_resources.consume_terrain_fx_batch(step.terrain_fx)
+        world.render_resources.consume_terrain_fx_batch(step.presentation.terrain_fx)
         applied_ticks.append(int(result.source_tick.tick_index))
     return applied_ticks
 
@@ -136,11 +136,11 @@ def test_runner_path_projectile_hits_enqueue_decals() -> None:
             frame_index=frame_index,
             dt_seconds=1.0 / 60.0,
         )
-        if any(not result.payload.step.terrain_fx.is_empty() for result in batch.completed_results):
+        if any(not result.payload.step.presentation.terrain_fx.is_empty() for result in batch.completed_results):
             break
         _apply_batch(world, session=session, batch=batch)
 
-    assert any(not result.payload.step.terrain_fx.is_empty() for result in batch.completed_results)
+    assert any(not result.payload.step.presentation.terrain_fx.is_empty() for result in batch.completed_results)
 
 
 def test_runner_multi_tick_batch_apply_order_is_deterministic() -> None:

--- a/tests/replay/test_playback_pump.py
+++ b/tests/replay/test_playback_pump.py
@@ -8,7 +8,7 @@ import pytest
 import crimson.replay.driver.playback_pump as playback_pump_module
 from crimson.replay.driver.playback_pump import advance_playback_frame
 from crimson.sim.clock import FixedStepClock
-from crimson.sim.presentation_step import PresentationStepCommands
+from crimson.sim.presentation_step import DeterministicPresentationPlan
 from crimson.sim.world_state import WorldEvents
 from tests.support.builders import FakePlaybackDriver
 
@@ -21,7 +21,7 @@ class _SimWorldStub:
         self,
         *,
         events: WorldEvents,
-        presentation: PresentationStepCommands,
+        presentation: DeterministicPresentationPlan,
         dt_sim: float,
         game_tune_started: bool,
     ) -> None:

--- a/tests/sim/test_input_normalization_contract.py
+++ b/tests/sim/test_input_normalization_contract.py
@@ -22,8 +22,8 @@ def test_network_provider_uses_runtime_resolved_order_without_remerge() -> None:
         resolve_tick=lambda tick, dt: ResolvedTick(
             tick_index=int(tick),
             dt_seconds=float(dt),
-            inputs=list(runtime_resolved),
-            commands=[],
+            inputs=tuple(runtime_resolved),
+            commands=(),
         ),
     )
 

--- a/tests/sim/test_input_provider_semantics.py
+++ b/tests/sim/test_input_provider_semantics.py
@@ -9,6 +9,7 @@ from crimson.sim.input_providers import (
     InputProvider,
     InputStatus,
     LocalInputProvider,
+    PerkMenuOpenCommand,
     ResolvedTick,
     TickSupply,
 )
@@ -49,7 +50,7 @@ def test_local_provider_allows_empty_inputs_for_zero_players() -> None:
     tick0 = provider.pull_tick(0, _FRAME_CTX.tick_dt_seconds)
     assert tick0.status is InputStatus.READY
     assert tick0.tick is not None
-    assert tick0.tick.inputs == []
+    assert tick0.tick.inputs == ()
 
 
 def test_network_provider_returns_stalled_when_no_inputs() -> None:
@@ -66,8 +67,8 @@ def test_network_provider_returns_resolved_tick_inline() -> None:
         resolve_tick=lambda tick, dt: ResolvedTick(
             tick_index=int(tick),
             dt_seconds=float(dt),
-            inputs=[PlayerInput()],
-            commands=[],
+            inputs=(PlayerInput(),),
+            commands=(),
         ),
     )
     provider.begin_frame(_FRAME_CTX)
@@ -77,6 +78,22 @@ def test_network_provider_returns_resolved_tick_inline() -> None:
     assert tick0.status is InputStatus.READY
     assert tick0.tick is not None
     assert tick0.tick.tick_index == 0
+    assert tick0.tick.inputs == (PlayerInput(),)
+    assert tick0.tick.commands == ()
+
+
+def test_resolved_tick_schema_uses_tuple_inputs_and_commands() -> None:
+    command = PerkMenuOpenCommand(player_index=0)
+    tick = ResolvedTick(
+        tick_index=3,
+        dt_seconds=1.0 / 60.0,
+        inputs=(PlayerInput(fire_down=True),),
+        commands=(command,),
+    )
+
+    assert tick.tick_index == 3
+    assert tick.inputs == (PlayerInput(fire_down=True),)
+    assert tick.commands == (command,)
 
 
 class _SingleSupplyProvider(InputProvider):
@@ -105,8 +122,8 @@ def test_runner_uses_resolved_tick_dt_instead_of_default_tick_dt() -> None:
             tick=ResolvedTick(
                 tick_index=0,
                 dt_seconds=1.0 / 30.0,
-                inputs=[PlayerInput()],
-                commands=[],
+                inputs=(PlayerInput(),),
+                commands=(),
             ),
         ),
     )
@@ -136,8 +153,8 @@ def test_runner_rejects_non_ready_supply_with_resolved_tick(status: InputStatus)
             tick=ResolvedTick(
                 tick_index=0,
                 dt_seconds=1.0 / 60.0,
-                inputs=[PlayerInput()],
-                commands=[],
+                inputs=(PlayerInput(),),
+                commands=(),
             ),
         ),
     )
@@ -155,8 +172,8 @@ def test_runner_rejects_mismatched_resolved_tick_index() -> None:
             tick=ResolvedTick(
                 tick_index=1,
                 dt_seconds=1.0 / 60.0,
-                inputs=[PlayerInput()],
-                commands=[],
+                inputs=(PlayerInput(),),
+                commands=(),
             ),
         ),
     )

--- a/tests/sim/test_presentation_reactions.py
+++ b/tests/sim/test_presentation_reactions.py
@@ -21,7 +21,7 @@ def test_session_step_tick_adds_bonus_post_apply_sfx_for_successful_perk_pick() 
         commands=[PerkPickCommand(player_index=0, choice_index=0)],
     )
 
-    assert tick.step.post_apply_sfx == (SfxId.UI_BONUS,)
+    assert tick.step.presentation.post_apply_sfx == (SfxId.UI_BONUS,)
 
 
 def test_session_step_tick_skips_bonus_post_apply_sfx_for_stale_perk_pick() -> None:
@@ -33,7 +33,7 @@ def test_session_step_tick_skips_bonus_post_apply_sfx_for_stale_perk_pick() -> N
         commands=[PerkPickCommand(player_index=0, choice_index=0)],
     )
 
-    assert tick.step.post_apply_sfx == ()
+    assert tick.step.presentation.post_apply_sfx == ()
 
 
 def test_quest_presentation_reaction_tracks_audio_flags() -> None:

--- a/tests/sim/test_presentation_step.py
+++ b/tests/sim/test_presentation_step.py
@@ -8,7 +8,7 @@ from crimson.perks import PerkId
 from crimson.projectiles.types import ProjectileHit, ProjectileTemplateId
 from crimson.rng_caller_static import RngCallerStatic
 from crimson.sim.presentation_step import (
-    PresentationStepCommands,
+    DeterministicPresentationPlan,
     apply_presentation_plan,
     plan_hit_sfx,
     plan_world_presentation_step,
@@ -506,7 +506,7 @@ def test_apply_presentation_plan_dispatches_audio_in_order() -> None:
 
     sink = _Sink()
     apply_presentation_plan(
-        plan=PresentationStepCommands(trigger_game_tune=True, sfx=[SfxId.UI_BONUS, SfxId.UI_LEVELUP]),
+        plan=DeterministicPresentationPlan(trigger_game_tune=True, sfx=[SfxId.UI_BONUS, SfxId.UI_LEVELUP]),
         audio_sink=sink,
         apply_audio=True,
     )
@@ -529,7 +529,7 @@ def test_apply_presentation_plan_skips_when_audio_disabled() -> None:
 
     sink = _Sink()
     apply_presentation_plan(
-        plan=PresentationStepCommands(trigger_game_tune=True, sfx=[SfxId.UI_BONUS]),
+        plan=DeterministicPresentationPlan(trigger_game_tune=True, sfx=[SfxId.UI_BONUS]),
         audio_sink=sink,
         apply_audio=False,
     )

--- a/tests/sim/test_runtime_pump_ownership.py
+++ b/tests/sim/test_runtime_pump_ownership.py
@@ -108,8 +108,8 @@ def test_lan_tick_consumption_drives_runner_until_stall(mocker, make_mode_config
                         source_tick=ResolvedTick(
                             tick_index=0,
                             dt_seconds=1.0 / 60.0,
-                            inputs=[],
-                            commands=[],
+                            inputs=(),
+                            commands=(),
                         ),
                         payload=tick_payload,
                         lan_sync=LanTickSync(
@@ -184,8 +184,8 @@ def test_lan_tick_consumption_does_not_emit_sync_for_stop_before_finalize(mocker
             source_tick=ResolvedTick(
                 tick_index=0,
                 dt_seconds=1.0 / 60.0,
-                inputs=[],
-                commands=[],
+                inputs=(),
+                commands=(),
             ),
             payload=make_tick_payload(elapsed_ms=16.67),
         ),
@@ -193,8 +193,8 @@ def test_lan_tick_consumption_does_not_emit_sync_for_stop_before_finalize(mocker
             source_tick=ResolvedTick(
                 tick_index=1,
                 dt_seconds=1.0 / 60.0,
-                inputs=[],
-                commands=[],
+                inputs=(),
+                commands=(),
             ),
             payload=make_tick_payload(elapsed_ms=33.33),
         ),
@@ -264,8 +264,8 @@ def test_lan_tick_consumption_broadcasts_tick_frame_commands(mocker, make_mode_c
         source_tick=ResolvedTick(
             tick_index=0,
             dt_seconds=1.0 / 60.0,
-            inputs=[],
-            commands=[command],
+            inputs=(),
+            commands=(command,),
         ),
         payload=make_tick_payload(elapsed_ms=16.67),
     )

--- a/tests/sim/test_step_pipeline_parity.py
+++ b/tests/sim/test_step_pipeline_parity.py
@@ -104,7 +104,7 @@ def _live_runtime_checkpoints(
         )
         world.sync_audio_bridge_state()
         world.audio_bridge.apply_plan(plan=step.presentation, apply_audio=False)
-        world.render_resources.consume_terrain_fx_batch(step.terrain_fx)
+        world.render_resources.consume_terrain_fx_batch(step.presentation.terrain_fx)
 
         checkpoints.append(
             build_checkpoint(
@@ -181,7 +181,7 @@ def test_runtime_playback_driver_matches_verify_terrain_fx_output() -> None:
     runtime_tick = runtime_driver.step_tick(0)
     verify_tick = verify_driver.step_tick(0)
 
-    assert runtime_tick.payload.step.terrain_fx == verify_tick.payload.step.terrain_fx
+    assert runtime_tick.payload.step.presentation.terrain_fx == verify_tick.payload.step.presentation.terrain_fx
 
 
 def test_quest_live_vs_headless_tick_pipeline() -> None:

--- a/tests/sim/test_terrain_fx_batch.py
+++ b/tests/sim/test_terrain_fx_batch.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from crimson.sim.batch_apply import PresentationTickOutput, apply_presentation_outputs
-from crimson.sim.presentation_step import PresentationStepCommands
+from crimson.sim.presentation_step import DeterministicPresentationPlan
 from crimson.sim.terrain_fx import TerrainCorpseFx, TerrainDecalFx, TerrainFxBatch, TerrainFxScratch
 from grim.color import RGBA
 from grim.geom import Vec2
@@ -29,6 +29,38 @@ def _terrain_batch() -> TerrainFxBatch:
             ),
         ),
     )
+
+
+class _PresentationAudioBridge:
+    def __init__(self, calls: list[tuple[str, int | None]]) -> None:
+        self._calls = calls
+
+    def apply_plan(self, *, plan: DeterministicPresentationPlan, apply_audio: bool = True) -> None:
+        _ = plan, apply_audio
+        self._calls.append(("audio", 1))
+
+
+class _PresentationRenderResources:
+    def __init__(self, calls: list[tuple[str, int | None]]) -> None:
+        self._calls = calls
+
+    def consume_terrain_fx_batch(self, batch: TerrainFxBatch) -> None:
+        _ = batch
+        self._calls.append(("terrain", 1))
+
+
+class _PresentationRuntime:
+    def __init__(self, calls: list[tuple[str, int | None]]) -> None:
+        self._calls = calls
+        self.audio_bridge = _PresentationAudioBridge(calls)
+        self.render_resources = _PresentationRenderResources(calls)
+
+    def sync_audio_bridge_state(self) -> None:
+        self._calls.append(("sync", None))
+
+    def update_camera(self, dt: float) -> None:
+        _ = dt
+        self._calls.append(("camera", 1))
 
 
 def test_terrain_fx_scratch_take_batch_copies_active_entries_and_clears() -> None:
@@ -62,23 +94,18 @@ def test_apply_presentation_outputs_applies_terrain_fx_in_output_order() -> None
         PresentationTickOutput(
             tick_index=1,
             dt_sim=1.0 / 60.0,
-            presentation=PresentationStepCommands(),
-            terrain_fx=_terrain_batch(),
+            presentation=DeterministicPresentationPlan(terrain_fx=_terrain_batch()),
         ),
         PresentationTickOutput(
             tick_index=2,
             dt_sim=1.0 / 60.0,
-            presentation=None,
-            terrain_fx=_terrain_batch(),
+            presentation=DeterministicPresentationPlan(terrain_fx=_terrain_batch()),
         ),
     )
 
     apply_presentation_outputs(
         outputs=outputs,
-        sync_audio_bridge_state=lambda: calls.append(("sync", None)),
-        apply_audio_plan=lambda _plan, _apply_audio: calls.append(("audio", 1)),
-        apply_terrain_fx=lambda _batch: calls.append(("terrain", 1)),
-        update_camera=lambda _dt: calls.append(("camera", 1)),
+        runtime=_PresentationRuntime(calls),
         on_output_applied=lambda output: calls.append(("done", int(output.tick_index))),
         apply_audio=True,
     )
@@ -89,6 +116,8 @@ def test_apply_presentation_outputs_applies_terrain_fx_in_output_order() -> None
         ("camera", 1),
         ("terrain", 1),
         ("done", 1),
+        ("audio", 1),
+        ("camera", 1),
         ("terrain", 1),
         ("done", 2),
     ]

--- a/tests/support/builders/input_providers.py
+++ b/tests/support/builders/input_providers.py
@@ -66,8 +66,8 @@ class StallableInputProvider(InputProvider):
             tick=ResolvedTick(
                 tick_index=int(tick_index),
                 dt_seconds=float(default_dt_seconds),
-                inputs=list(row),
-                commands=[],
+                inputs=tuple(row),
+                commands=(),
             ),
         )
 
@@ -91,8 +91,8 @@ class EOSInputProvider(InputProvider):
                 tick=ResolvedTick(
                     tick_index=int(tick_index),
                     dt_seconds=float(default_dt_seconds),
-                    inputs=[PlayerInput()],
-                    commands=[],
+                    inputs=(PlayerInput(),),
+                    commands=(),
                 ),
             )
         return TickSupply(status=InputStatus.EOS, tick=None)

--- a/tests/support/builders/runners.py
+++ b/tests/support/builders/runners.py
@@ -42,8 +42,8 @@ class FakeRunner:
                 source_tick=ResolvedTick(
                     tick_index=int(start_tick + i),
                     dt_seconds=float(tick_dt),
-                    inputs=[],
-                    commands=[],
+                    inputs=(),
+                    commands=(),
                 ),
                 payload=make_tick_payload(),
             )

--- a/tests/support/builders/tick_payload.py
+++ b/tests/support/builders/tick_payload.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from crimson.sim.presentation_step import PresentationStepCommands
+from crimson.sim.presentation_step import DeterministicPresentationPlan
 from crimson.sim.sessions import DeterministicSessionTick
 from crimson.sim.step_pipeline import DeterministicStepResult, PresentationRngTrace
 from crimson.sim.terrain_fx import TerrainFxBatch
@@ -29,14 +29,15 @@ def make_tick_payload(
         dt_sim=dt_sim,
         timing=timing,
         events=WorldEvents(hits=[], deaths=(), pickups=[], sfx=[]),
-        presentation=PresentationStepCommands(),
-        presentation_plan_ms=float(presentation_plan_ms),
+        presentation=DeterministicPresentationPlan(
+            terrain_fx=terrain_fx,
+            post_apply_sfx=tuple(post_apply_sfx),
+        ),
         presentation_rng_trace=PresentationRngTrace(),
-        terrain_fx=terrain_fx,
-        post_apply_sfx=tuple(post_apply_sfx),
     )
     return DeterministicSessionTick(
         step=step,
         elapsed_ms=elapsed_ms,
         creature_count_world_step=creature_count,
+        presentation_plan_ms=float(presentation_plan_ms),
     )

--- a/tests/support/builders/tick_result.py
+++ b/tests/support/builders/tick_result.py
@@ -20,8 +20,8 @@ def make_tick_result(
         source_tick=ResolvedTick(
             tick_index=int(tick_index),
             dt_seconds=float(dt_sim),
-            inputs=[],
-            commands=[],
+            inputs=(),
+            commands=(),
         ),
         payload=payload,
         replay_tick_index=(int(tick_index) if replay_tick_index is None else int(replay_tick_index)),

--- a/tests/support/world_runtime.py
+++ b/tests/support/world_runtime.py
@@ -305,15 +305,15 @@ class WorldRuntimeHost:
             apply_audio=bool(apply_audio),
         )
         self.update_camera(float(tick.step.dt_sim))
-        self.render_resources.consume_terrain_fx_batch(tick.step.terrain_fx)
+        self.render_resources.consume_terrain_fx_batch(tick.step.presentation.terrain_fx)
         apply_post_apply_reaction(
             reaction=build_post_apply_reaction(
                 tick_result=TickResult(
                     source_tick=ResolvedTick(
                         tick_index=0,
                         dt_seconds=float(dt),
-                        inputs=[] if tick_inputs is None else list(tick_inputs),
-                        commands=[],
+                        inputs=() if tick_inputs is None else tuple(tick_inputs),
+                        commands=(),
                     ),
                     payload=tick,
                 ),


### PR DESCRIPTION
## Summary

- replace `PresentationStepCommands` with `DeterministicPresentationPlan` as the deterministic native-parity presentation envelope
- move terrain FX and post-apply SFX into that plan so replay/live apply paths consume one output shape
- keep presentation planning time as tick telemetry
- apply presentation through the outer runtime object instead of loose callback bundles
- make `ResolvedTick` inputs and commands canonical tuples at the source boundary
- document rollback snapshot restore + replay as a deferred TODO

## Validation

- `uv run pytest tests/sim/test_presentation_step.py tests/sim/test_presentation_reactions.py tests/sim/test_terrain_fx_batch.py tests/sim/test_step_pipeline_parity.py tests/replay/test_playback_pump.py tests/render/test_render_backend_sink_contract.py tests/contracts/test_architecture_contracts.py`
- `uv run pytest tests/sim tests/replay tests/gameplay/test_game_world_audio.py tests/regressions/test_runner_presentation_regressions.py tests/contracts/test_architecture_contracts.py`
- `uv run ruff check src/crimson/sim src/crimson/modes/base_gameplay_mode.py src/crimson/replay/driver/playback_pump.py src/crimson/world src/crimson/modes/replay_playback_mode.py tests/sim tests/replay tests/gameplay/test_game_world_audio.py tests/regressions/test_runner_presentation_regressions.py tests/contracts/test_architecture_contracts.py`
- `uv run ty check src tests`
- `uv run scripts/check_docs.py`
- `git diff --check`
- `uv run pytest --no-cov`
- commit hook: `py-ruff`, `py-import-lints`, `py-types`, `docs-check`, `sg-scan`, `py-pytest`
- pre-push hook: `py-pytest`, `py-build`

## Follow-up cleanups

- Rollback still needs real snapshot restore plus replay, beyond the current rollback signal/resync handling. This is now tracked in `docs/rewrite/deterministic-step-pipeline.md`.
