### PR TITLE
refactor: pass world step damage runtime explicitly

### DIFF
--- a/src/crimson/bonuses/apply.py
+++ b/src/crimson/bonuses/apply.py
@@ -7,6 +7,7 @@ from grim.geom import Vec2
 
 from ..perks import PerkId
 from ..perks.helpers import perk_count_get
+from ..projectiles.types import CreatureDamageApplier
 from ..sim.state_types import GameplayState, PlayerState
 from .apply_context import BonusApplyCtx, BonusApplyHandler
 from .double_experience import apply_double_experience
@@ -58,6 +59,7 @@ def bonus_apply(
     detail_preset: int = 5,
     defer_freeze_corpse_fx: bool = False,
     freeze_corpse_indices: set[int] | None = None,
+    apply_creature_damage: CreatureDamageApplier | None = None,
 ) -> None:
     """Apply a bonus to player + global timers (subset of `bonus_apply`)."""
 
@@ -84,6 +86,7 @@ def bonus_apply(
         icon_id=int(icon_id),
         defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
         freeze_corpse_indices=freeze_corpse_indices,
+        apply_creature_damage=apply_creature_damage,
     )
     handler = _BONUS_APPLY_HANDLERS.get(bonus_id)
     if handler is not None:

--- a/src/crimson/bonuses/apply_context.py
+++ b/src/crimson/bonuses/apply_context.py
@@ -7,6 +7,7 @@ import msgspec
 
 from grim.geom import Vec2
 
+from ..projectiles.types import CreatureDamageApplier
 from ..sim.state_types import GameplayState, PlayerState
 from .hud import _TimerRef
 from .ids import BONUS_BY_ID, BonusId
@@ -29,6 +30,7 @@ class BonusApplyCtx(msgspec.Struct):
     icon_id: int
     defer_freeze_corpse_fx: bool = False
     freeze_corpse_indices: set[int] | None = None
+    apply_creature_damage: CreatureDamageApplier | None = None
 
     def register_global(self, timer_key: str) -> None:
         self.state.bonus_hud.register(

--- a/src/crimson/bonuses/nuke.py
+++ b/src/crimson/bonuses/nuke.py
@@ -69,7 +69,7 @@ def apply_nuke(ctx: BonusApplyCtx) -> None:
 
     creatures = ctx.creatures
     if creatures:
-        apply_creature_damage = ctx.state.bonus_pool.creature_damage_applier
+        apply_creature_damage = ctx.apply_creature_damage
         prev_guard = bool(ctx.state.bonus_spawn_guard)
         ctx.state.bonus_spawn_guard = True
         for idx, creature in enumerate(creatures):

--- a/src/crimson/bonuses/pool.py
+++ b/src/crimson/bonuses/pool.py
@@ -371,6 +371,7 @@ class BonusPool:
         detail_preset: int = 5,
         defer_freeze_corpse_fx: bool = False,
         freeze_corpse_indices: set[int] | None = None,
+        apply_creature_damage: CreatureDamageApplier | None = None,
     ) -> list[BonusPickupEvent]:
         if dt <= 0.0:
             return []
@@ -411,6 +412,11 @@ class BonusPool:
                         detail_preset=int(detail_preset),
                         defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
                         freeze_corpse_indices=freeze_corpse_indices,
+                        apply_creature_damage=(
+                            apply_creature_damage
+                            if apply_creature_damage is not None
+                            else self._creature_damage_applier
+                        ),
                     )
                     entry.picked = True
                     entry.time_left = BONUS_PICKUP_LINGER

--- a/src/crimson/bonuses/update.py
+++ b/src/crimson/bonuses/update.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from ..math_parity import f32
 from ..perks.helpers import perk_active
+from ..projectiles.types import CreatureDamageApplier
 from ..sim.state_types import BonusPickupEvent, GameplayState, PlayerState
 from .apply import bonus_apply
 from .hud import bonus_hud_update
@@ -26,6 +27,7 @@ def bonus_telekinetic_update(
     detail_preset: int = 5,
     defer_freeze_corpse_fx: bool = False,
     freeze_corpse_indices: set[int] | None = None,
+    apply_creature_damage: CreatureDamageApplier | None = None,
 ) -> list[BonusPickupEvent]:
     """Allow Telekinetic perk owners to pick up bonuses by aiming at them."""
     from ..perks import PerkId
@@ -68,6 +70,7 @@ def bonus_telekinetic_update(
             detail_preset=int(detail_preset),
             defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
             freeze_corpse_indices=freeze_corpse_indices,
+            apply_creature_damage=apply_creature_damage,
         )
         entry.picked = True
         entry.time_left = BONUS_PICKUP_LINGER
@@ -98,6 +101,7 @@ def bonus_update(
     detail_preset: int = 5,
     defer_freeze_corpse_fx: bool = False,
     freeze_corpse_indices: set[int] | None = None,
+    apply_creature_damage: CreatureDamageApplier | None = None,
 ) -> list[BonusPickupEvent]:
     """Advance world bonuses and global timers (subset of `bonus_update`)."""
 
@@ -109,6 +113,7 @@ def bonus_update(
         detail_preset=int(detail_preset),
         defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
         freeze_corpse_indices=freeze_corpse_indices,
+        apply_creature_damage=apply_creature_damage,
     )
     pickups.extend(
         state.bonus_pool.update(
@@ -119,6 +124,7 @@ def bonus_update(
             detail_preset=int(detail_preset),
             defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
             freeze_corpse_indices=freeze_corpse_indices,
+            apply_creature_damage=apply_creature_damage,
         ),
     )
 

--- a/src/crimson/projectiles/runtime/behaviors.py
+++ b/src/crimson/projectiles/runtime/behaviors.py
@@ -25,6 +25,7 @@ from ..effects import (
     _spawn_splitter_hit_effects,
 )
 from ..types import (
+    CreatureDamageApplier,
     Projectile,
     ProjectileTemplateId,
 )
@@ -46,6 +47,7 @@ class _ProjectileUpdateCtx(msgspec.Struct):
     runtime_state: GameplayState | None
     effects: EffectPool | None
     sfx_queue: MutableSequence[SfxId] | None
+    apply_creature_damage: CreatureDamageApplier | None = None
 
 
 class _ProjectileHitInfo(msgspec.Struct):
@@ -116,7 +118,7 @@ def _linger_ion_aoe(
                 damage_type=CreatureDamageType.ION,
                 impulse=Vec2(),
                 owner=proj.owner,
-                apply_creature_damage=ctx.pool.creature_damage_applier,
+                apply_creature_damage=ctx.apply_creature_damage,
             )
 
 
@@ -298,7 +300,7 @@ def _post_hit_shrinkifier(ctx: _ProjectileUpdateCtx, hit: _ProjectileHitInfo) ->
             damage_type=CreatureDamageType.BULLET,
             impulse=Vec2(),
             owner=hit.proj.owner,
-            apply_creature_damage=ctx.pool.creature_damage_applier,
+            apply_creature_damage=ctx.apply_creature_damage,
         )
     hit.proj.life_timer = 0.25
 

--- a/src/crimson/projectiles/runtime/projectile_pool.py
+++ b/src/crimson/projectiles/runtime/projectile_pool.py
@@ -49,6 +49,7 @@ class ProjectileUpdateOptions(msgspec.Struct, frozen=True):
     runtime_state: GameplayState
     players: Sequence[PlayerState]
     apply_player_damage: Callable[[int, float], None]
+    apply_creature_damage: CreatureDamageApplier | None = None
     ion_aoe_scale: float = 1.0
     detail_preset: int = 5
     on_hit: Callable[[ProjectileHit], object] | None = None
@@ -170,7 +171,11 @@ class ProjectilePool:
         runtime_state = options.runtime_state
         players = options.players
         apply_player_damage = options.apply_player_damage
-        apply_creature_damage = self._creature_damage_applier
+        apply_creature_damage = (
+            options.apply_creature_damage
+            if options.apply_creature_damage is not None
+            else self._creature_damage_applier
+        )
         on_hit = options.on_hit
         on_hit_post = options.on_hit_post
 
@@ -252,6 +257,7 @@ class ProjectilePool:
             runtime_state=runtime_state,
             effects=effects,
             sfx_queue=sfx_queue,
+            apply_creature_damage=apply_creature_damage,
         )
 
         def _reset_shock_chain_if_owner(index: int) -> None:

--- a/src/crimson/projectiles/runtime/secondary_pool.py
+++ b/src/crimson/projectiles/runtime/secondary_pool.py
@@ -73,6 +73,7 @@ class SecondaryStepCtx(msgspec.Struct, frozen=True):
     runtime_state: GameplayState | None = None
     fx_queue: FxQueue | None = None
     detail_preset: int = 5
+    apply_creature_damage: CreatureDamageApplier | None = None
     on_detonation_kill: SecondaryDetonationKillHandler | None = None
 
 
@@ -168,6 +169,11 @@ class SecondaryProjectilePool:
         runtime_state = ctx.runtime_state
         fx_queue = ctx.fx_queue
         detail_preset = int(ctx.detail_preset)
+        apply_creature_damage = (
+            ctx.apply_creature_damage
+            if ctx.apply_creature_damage is not None
+            else self._creature_damage_applier
+        )
         on_detonation_kill = ctx.on_detonation_kill
 
         if dt <= 0.0:
@@ -187,7 +193,7 @@ class SecondaryProjectilePool:
                 damage_type=CreatureDamageType.EXPLOSION,
                 impulse=impulse,
                 owner=owner,
-                apply_creature_damage=self._creature_damage_applier,
+                apply_creature_damage=apply_creature_damage,
             )
 
         rng = Crand(0)

--- a/src/crimson/sim/world_state.py
+++ b/src/crimson/sim/world_state.py
@@ -54,6 +54,150 @@ class WorldEvents(msgspec.Struct):
 _WORLD_DT_STEPS = WORLD_DT_STEPS
 _PLAYER_DEATH_HOOKS = PLAYER_DEATH_HOOKS
 
+
+class _WorldStepRuntime(msgspec.Struct):
+    world: WorldState
+    dt: float
+    world_size: float
+    detail_preset: int
+    violence_disabled: int
+    fx_queue: FxQueue
+    game_mode: GameMode
+    hit_audio_game_tune_started: bool
+    deaths: list[CreatureDeath]
+    sfx: list[SfxId]
+    trigger_game_tune: bool = False
+    hit_sfx: list[SfxId] = msgspec.field(default_factory=list)
+
+    def apply_player_projectile_damage(self, player_index: int, damage: float) -> None:
+        idx = int(player_index)
+        if not (0 <= idx < len(self.world.players)):
+            return
+        player_take_projectile_damage(self.world.state, self.world.players[idx], float(damage))
+
+    def apply_creature_damage(
+        self,
+        creature_index: int,
+        damage: float,
+        damage_type: int,
+        impulse: Vec2,
+        owner: OwnerRef,
+    ) -> None:
+        idx = int(creature_index)
+        if not (0 <= idx < len(self.world.creatures.entries)):
+            return
+        creature = self.world.creatures.entries[idx]
+        if not creature.active:
+            return
+        creature_apply_damage_with_lethal_followup(
+            creature,
+            damage_amount=float(damage),
+            damage_type=int(damage_type),
+            impulse=impulse,
+            owner=owner,
+            dt=float(self.dt),
+            players=self.world.players,
+            rng=self.world.state.rng,
+            preserve_bugs=bool(self.world.state.preserve_bugs),
+            effects=self.world.state.effects,
+            detail_preset=int(self.detail_preset),
+            on_lethal=lambda death_sfx: self.world._record_creature_death(
+                creature_index=idx,
+                dt=float(self.dt),
+                detail_preset=int(self.detail_preset),
+                world_size=float(self.world_size),
+                fx_queue=self.fx_queue,
+                deaths=self.deaths,
+                sfx=self.sfx,
+                death_sfx=death_sfx,
+            ),
+        )
+
+    def on_secondary_detonation_kill(self, creature_index: int) -> None:
+        idx = int(creature_index)
+        if not (0 <= idx < len(self.world.creatures.entries)) or float(self.world.creatures.entries[idx].hp) > 0.0:
+            return
+        # Native detonation follow-up re-enters creature death handling but does
+        # not run a second death-SFX random pick (`creature_apply_damage` only
+        # does that on the original killing hit).
+        self.world._record_creature_death(
+            creature_index=idx,
+            dt=float(self.dt),
+            detail_preset=int(self.detail_preset),
+            world_size=float(self.world_size),
+            fx_queue=self.fx_queue,
+            deaths=self.deaths,
+            sfx=self.sfx,
+        )
+
+    def prepare_projectile_hit_presentation(self, hit: ProjectileHit) -> ProjectileDecalPostCtx:
+        return self.world._prepare_projectile_hit_presentation(
+            hit=hit,
+            fx_queue=self.fx_queue,
+            detail_preset=int(self.detail_preset),
+            violence_disabled=int(self.violence_disabled),
+        )
+
+    def finalize_projectile_hit_presentation(self, hit: ProjectileHit, post_ctx: ProjectileDecalPostCtx) -> None:
+        self.world._finalize_projectile_hit_presentation(
+            post_ctx=post_ctx,
+            fx_queue=self.fx_queue,
+        )
+        hit_trigger, keys = plan_hit_sfx(
+            [hit],
+            game_mode=self.game_mode,
+            demo_mode_active=self.world.state.demo_mode_active,
+            game_tune_started=self.hit_audio_game_tune_started,
+            rng=self.world.state.rng,
+        )
+        if hit_trigger:
+            self.trigger_game_tune = True
+            self.hit_audio_game_tune_started = True
+        if keys:
+            self.hit_sfx.extend(keys)
+
+    def kill_creature_no_corpse(self, creature_index: int, owner: OwnerRef) -> None:
+        idx = int(creature_index)
+        if not (0 <= idx < len(self.world.creatures.entries)):
+            return
+        creature = self.world.creatures.entries[idx]
+        if not creature.active:
+            return
+        if float(creature.hp) <= 0.0:
+            return
+        creature.last_hit_owner = owner
+        self.world._record_creature_death(
+            creature_index=idx,
+            dt=float(self.dt),
+            detail_preset=int(self.detail_preset),
+            world_size=float(self.world_size),
+            fx_queue=self.fx_queue,
+            deaths=self.deaths,
+            sfx=self.sfx,
+            keep_corpse=False,
+        )
+
+    def on_player_lethal(self, player: PlayerState, *, dt: float) -> None:
+        self.world._run_player_death_hooks(
+            player=player,
+            dt=float(dt),
+            world_size=float(self.world_size),
+            detail_preset=int(self.detail_preset),
+            fx_queue=self.fx_queue,
+            deaths=self.deaths,
+        )
+
+    def build_events(self, *, hits: list[ProjectileHit], pickups: list[BonusPickupEvent]) -> WorldEvents:
+        return WorldEvents(
+            hits=hits,
+            deaths=tuple(self.deaths),
+            pickups=pickups,
+            sfx=self.sfx,
+            trigger_game_tune=bool(self.trigger_game_tune),
+            hit_sfx=self.hit_sfx,
+        )
+
+
 class WorldState(msgspec.Struct):
     spawn_env: SpawnEnv
     state: GameplayState
@@ -130,12 +274,6 @@ class WorldState(msgspec.Struct):
         # `effects_update` runs early in the native frame loop, before creature/projectile updates.
         self.state.effects.update(dt, fx_queue=fx_queue)
 
-        def _apply_projectile_damage_to_player(player_index: int, damage: float) -> None:
-            idx = int(player_index)
-            if not (0 <= idx < len(self.players)):
-                return
-            player_take_projectile_damage(self.state, self.players[idx], float(damage))
-
         creature_result = self.creatures.update(
             dt,
             options=CreatureUpdateOptions(
@@ -151,95 +289,18 @@ class WorldState(msgspec.Struct):
                 violence_disabled=int(violence_disabled),
             ),
         )
-        deaths = list(creature_result.deaths)
-        sfx = list(creature_result.sfx)
-        trigger_game_tune = False
-        hit_sfx: list[SfxId] = []
-        hit_audio_game_tune_started = game_tune_started
-
-        def _apply_projectile_damage_to_creature(
-            creature_index: int,
-            damage: float,
-            damage_type: int,
-            impulse: Vec2,
-            owner: OwnerRef,
-        ) -> None:
-            idx = int(creature_index)
-            if not (0 <= idx < len(self.creatures.entries)):
-                return
-            creature = self.creatures.entries[idx]
-            if not creature.active:
-                return
-            creature_apply_damage_with_lethal_followup(
-                creature,
-                damage_amount=float(damage),
-                damage_type=int(damage_type),
-                impulse=impulse,
-                owner=owner,
-                dt=float(dt),
-                players=self.players,
-                rng=self.state.rng,
-                preserve_bugs=bool(self.state.preserve_bugs),
-                effects=self.state.effects,
-                detail_preset=int(detail_preset),
-                on_lethal=lambda death_sfx: self._record_creature_death(
-                    creature_index=idx,
-                    dt=float(dt),
-                    detail_preset=int(detail_preset),
-                    world_size=float(world_size),
-                    fx_queue=fx_queue,
-                    deaths=deaths,
-                    sfx=sfx,
-                    death_sfx=death_sfx,
-                ),
-            )
-
-        prev_creature_damage_appliers = self._set_creature_damage_appliers(_apply_projectile_damage_to_creature)
-
-        def _on_secondary_detonation_kill(creature_index: int) -> None:
-            idx = int(creature_index)
-            if not (0 <= idx < len(self.creatures.entries)) or float(self.creatures.entries[idx].hp) > 0.0:
-                return
-            # Native detonation follow-up re-enters creature death handling but does
-            # not run a second death-SFX random pick (`creature_apply_damage` only
-            # does that on the original killing hit).
-            self._record_creature_death(
-                creature_index=idx,
-                dt=float(dt),
-                detail_preset=int(detail_preset),
-                world_size=float(world_size),
-                fx_queue=fx_queue,
-                deaths=deaths,
-                sfx=sfx,
-            )
-
-        def _on_projectile_hit_pre(hit: ProjectileHit) -> ProjectileDecalPostCtx:
-            return self._prepare_projectile_hit_presentation(
-                hit=hit,
-                fx_queue=fx_queue,
-                detail_preset=int(detail_preset),
-                violence_disabled=int(violence_disabled),
-            )
-
-        def _on_projectile_hit_post(_hit: ProjectileHit, post_ctx: ProjectileDecalPostCtx) -> None:
-            nonlocal trigger_game_tune, hit_audio_game_tune_started
-            self._finalize_projectile_hit_presentation(
-                post_ctx=post_ctx,
-                fx_queue=fx_queue,
-            )
-            hit_trigger, keys = plan_hit_sfx(
-                [_hit],
-                game_mode=game_mode,
-                demo_mode_active=self.state.demo_mode_active,
-                game_tune_started=hit_audio_game_tune_started,
-                rng=self.state.rng,
-            )
-            if hit_trigger:
-                trigger_game_tune = True
-                hit_audio_game_tune_started = True
-            if keys:
-                hit_sfx.extend(keys)
-
+        step_runtime = _WorldStepRuntime(
+            world=self,
+            dt=float(dt),
+            world_size=float(world_size),
+            detail_preset=int(detail_preset),
+            violence_disabled=int(violence_disabled),
+            fx_queue=fx_queue,
+            game_mode=game_mode,
+            hit_audio_game_tune_started=bool(game_tune_started),
+            deaths=list(creature_result.deaths),
+            sfx=list(creature_result.sfx),
+        )
         hits = self.state.projectiles.step(
             PrimaryStepCtx(
                 dt=float(dt),
@@ -251,9 +312,13 @@ class WorldState(msgspec.Struct):
                     rng=self.state.rng,
                     runtime_state=self.state,
                     players=self.players,
-                    apply_player_damage=_apply_projectile_damage_to_player,
-                    on_hit=_on_projectile_hit_pre,
-                    on_hit_post=cast("Callable[[ProjectileHit, object], None]", _on_projectile_hit_post),
+                    apply_player_damage=step_runtime.apply_player_projectile_damage,
+                    apply_creature_damage=step_runtime.apply_creature_damage,
+                    on_hit=step_runtime.prepare_projectile_hit_presentation,
+                    on_hit_post=cast(
+                        "Callable[[ProjectileHit, object], None]",
+                        step_runtime.finalize_projectile_hit_presentation,
+                    ),
                 ),
             ),
         )
@@ -264,7 +329,8 @@ class WorldState(msgspec.Struct):
                 runtime_state=self.state,
                 fx_queue=fx_queue,
                 detail_preset=int(detail_preset),
-                on_detonation_kill=_on_secondary_detonation_kill,
+                apply_creature_damage=step_runtime.apply_creature_damage,
+                on_detonation_kill=step_runtime.on_secondary_detonation_kill,
             ),
         )
         self._run_post_damage_player_death_hooks(
@@ -273,34 +339,14 @@ class WorldState(msgspec.Struct):
             world_size=float(world_size),
             detail_preset=int(detail_preset),
             fx_queue=fx_queue,
-            deaths=deaths,
+            deaths=step_runtime.deaths,
         )
-
-        def _kill_creature_no_corpse(creature_index: int, owner: OwnerRef) -> None:
-            idx = int(creature_index)
-            if not (0 <= idx < len(self.creatures.entries)):
-                return
-            creature = self.creatures.entries[idx]
-            if not creature.active:
-                return
-            if float(creature.hp) <= 0.0:
-                return
-            creature.last_hit_owner = owner
-            self._record_creature_death(
-                creature_index=idx,
-                dt=float(dt),
-                detail_preset=int(detail_preset),
-                world_size=float(world_size),
-                fx_queue=fx_queue,
-                deaths=deaths,
-                sfx=sfx,
-                keep_corpse=False,
-            )
 
         self.state.particles.update(
             dt,
             creatures=self.creatures.entries,
-            kill_creature=_kill_creature_no_corpse,
+            apply_creature_damage=step_runtime.apply_creature_damage,
+            kill_creature=step_runtime.kill_creature_no_corpse,
             fx_queue=fx_queue,
             sprite_effects=self.state.sprite_effects,
         )
@@ -321,13 +367,9 @@ class WorldState(msgspec.Struct):
                 players=self.players,
                 creatures=self.creatures.entries,
                 spawn_slots=self.creatures.spawn_slots,
-                on_player_lethal=lambda dead_player, dt_value=float(player_dt): self._run_player_death_hooks(
-                    player=dead_player,
+                on_player_lethal=lambda dead_player, dt_value=float(player_dt): step_runtime.on_player_lethal(
+                    dead_player,
                     dt=float(dt_value),
-                    world_size=float(world_size),
-                    detail_preset=int(detail_preset),
-                    fx_queue=fx_queue,
-                    deaths=deaths,
                 ),
                 reload_active_any=bool(reload_active_any),
             )
@@ -365,6 +407,7 @@ class WorldState(msgspec.Struct):
             detail_preset=int(detail_preset),
             defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
             freeze_corpse_indices=freeze_corpse_indices_at_tick_start,
+            apply_creature_damage=step_runtime.apply_creature_damage,
         )
         if pickups:
             emit_bonus_pickup_effects(
@@ -374,57 +417,12 @@ class WorldState(msgspec.Struct):
             )
         survival_enforce_reward_weapon_guard(self.state, self.players)
         if self.state.sfx_queue:
-            sfx.extend(self.state.sfx_queue)
+            step_runtime.sfx.extend(self.state.sfx_queue)
             self.state.sfx_queue.clear()
         # Player-damage VO RNG work lives inside `player_take_damage` for native
         # ordering parity (VO draw before heading-jitter draw).
         self.state.player_death_hook_skip_indices.clear()
-        self._restore_creature_damage_appliers(prev_creature_damage_appliers)
-        return WorldEvents(
-            hits=hits,
-            deaths=tuple(deaths),
-            pickups=pickups,
-            sfx=sfx,
-            trigger_game_tune=bool(trigger_game_tune),
-            hit_sfx=hit_sfx,
-        )
-
-    def _set_creature_damage_appliers(
-        self,
-        applier: Callable[[int, float, int, Vec2, OwnerRef], None] | None,
-    ) -> tuple[
-        Callable[[int, float, int, Vec2, OwnerRef], None] | None,
-        Callable[[int, float, int, Vec2, OwnerRef], None] | None,
-        Callable[[int, float, int, Vec2, OwnerRef], None] | None,
-        Callable[[int, float, int, Vec2, OwnerRef], None] | None,
-    ]:
-        prev = (
-            self.state.projectiles.creature_damage_applier,
-            self.state.secondary_projectiles.creature_damage_applier,
-            self.state.particles.creature_damage_applier,
-            self.state.bonus_pool.creature_damage_applier,
-        )
-        self.state.projectiles.creature_damage_applier = applier
-        self.state.secondary_projectiles.creature_damage_applier = applier
-        self.state.particles.creature_damage_applier = applier
-        self.state.bonus_pool.creature_damage_applier = applier
-        return prev
-
-    def _restore_creature_damage_appliers(
-        self,
-        previous: tuple[
-            Callable[[int, float, int, Vec2, OwnerRef], None] | None,
-            Callable[[int, float, int, Vec2, OwnerRef], None] | None,
-            Callable[[int, float, int, Vec2, OwnerRef], None] | None,
-            Callable[[int, float, int, Vec2, OwnerRef], None] | None,
-        ],
-    ) -> None:
-        (
-            self.state.projectiles.creature_damage_applier,
-            self.state.secondary_projectiles.creature_damage_applier,
-            self.state.particles.creature_damage_applier,
-            self.state.bonus_pool.creature_damage_applier,
-        ) = previous
+        return step_runtime.build_events(hits=hits, pickups=pickups)
 
     def _run_player_death_hooks(
         self,

--- a/tests/gameplay/test_death_timing.py
+++ b/tests/gameplay/test_death_timing.py
@@ -104,7 +104,8 @@ def test_world_step_trooper_death_sfx_respects_preserve_bugs(
     before_state = rng.state
 
     def _fake_projectile_step(*_args: object, **_kwargs: object) -> list[ProjectileHit]:
-        apply_creature_damage = world.state.projectiles.creature_damage_applier
+        ctx = cast("PrimaryStepCtx", _args[0])
+        apply_creature_damage = ctx.options.apply_creature_damage
         assert apply_creature_damage is not None
         apply_creature_damage(0, 1000.0, CreatureDamageType.BULLET, Vec2(), OwnerRef.from_player(0))
         return []
@@ -249,8 +250,7 @@ def test_projectile_lethal_hit_records_death_before_particles_update(mocker) -> 
 
     def _fake_projectile_step(*_args: object, **_kwargs: object) -> list[ProjectileHit]:
         ctx = cast("PrimaryStepCtx", _args[0])
-        _ = ctx.options
-        apply_creature_damage = world.state.projectiles.creature_damage_applier
+        apply_creature_damage = ctx.options.apply_creature_damage
         assert apply_creature_damage is not None
         apply_creature_damage(0, 1000.0, CreatureDamageType.BULLET, Vec2(), OwnerRef.from_player(0))
         return []
@@ -354,8 +354,7 @@ def test_ranged_shock_lethal_has_no_resolved_death_sfx(mocker) -> None:
     def _fake_projectile_step(*args: object, **kwargs: object) -> list[ProjectileHit]:
         _ = kwargs
         ctx = cast("PrimaryStepCtx", args[0])
-        _ = ctx.options
-        apply_creature_damage = world.state.projectiles.creature_damage_applier
+        apply_creature_damage = ctx.options.apply_creature_damage
         if apply_creature_damage is not None:
             apply_creature_damage(0, 1000.0, CreatureDamageType.BULLET, Vec2(), OwnerRef.from_player(0))
         return []

--- a/tests/support/factories.py
+++ b/tests/support/factories.py
@@ -7,7 +7,7 @@ from crimson.creatures.spawn import CreatureFlags, CreatureTypeId, SpawnEnv
 from crimson.effects import FxQueue, FxQueueRotated
 from crimson.gameplay import GameplayState
 from crimson.projectiles.runtime import ProjectileUpdateOptions
-from crimson.projectiles.types import ProjectileHit
+from crimson.projectiles.types import CreatureDamageApplier, ProjectileHit
 from crimson.sim.state_types import PlayerState
 from grim.geom import Vec2
 from grim.rand import CrandLike
@@ -98,6 +98,7 @@ def make_projectile_update_options(
     runtime_state: GameplayState | None = None,
     players: Sequence[PlayerState] | None = None,
     apply_player_damage: Callable[[int, float], None] | None = None,
+    apply_creature_damage: CreatureDamageApplier | None = None,
     on_hit: Callable[[ProjectileHit], object] | None = None,
     on_hit_post: Callable[[ProjectileHit, object], None] | None = None,
 ) -> ProjectileUpdateOptions:
@@ -112,6 +113,7 @@ def make_projectile_update_options(
         apply_player_damage=(
             _default_apply_player_damage(player_seq) if apply_player_damage is None else apply_player_damage
         ),
+        apply_creature_damage=apply_creature_damage,
         ion_aoe_scale=float(ion_aoe_scale),
         detail_preset=int(detail_preset),
         on_hit=on_hit,


### PR DESCRIPTION
## Summary

- replace world-step temporary creature damage callback installation with an explicit `_WorldStepRuntime`
- thread the current runtime damage operation through projectile, secondary projectile, particle, and bonus apply contexts
- update death timing tests to use the concrete step context instead of reading hidden pool state

## Validation

- `just check`

## Follow-up cleanup candidates

- Rename the primary projectile hit presentation callbacks into explicit native pre/post hit phase names.
- Consider removing pool-level damage applier fallbacks after direct pool tests are adjusted to pass full runtime contexts.
- Convert the LAN batch apply callback cluster into a concrete apply transaction object in the next PR.
