### PR TITLE
refactor: name projectile hit presentation phases

### DIFF
--- a/src/crimson/projectiles/runtime/projectile_pool.py
+++ b/src/crimson/projectiles/runtime/projectile_pool.py
@@ -52,8 +52,8 @@ class ProjectileUpdateOptions(msgspec.Struct, frozen=True):
     apply_creature_damage: CreatureDamageApplier | None = None
     ion_aoe_scale: float = 1.0
     detail_preset: int = 5
-    on_hit: Callable[[ProjectileHit], object] | None = None
-    on_hit_post: Callable[[ProjectileHit, object], None] | None = None
+    begin_hit_presentation: Callable[[ProjectileHit], object] | None = None
+    finish_hit_presentation: Callable[[ProjectileHit, object], None] | None = None
 
 
 class PrimaryStepCtx(msgspec.Struct, frozen=True):
@@ -176,8 +176,8 @@ class ProjectilePool:
             if options.apply_creature_damage is not None
             else self._creature_damage_applier
         )
-        on_hit = options.on_hit
-        on_hit_post = options.on_hit_post
+        begin_hit_presentation = options.begin_hit_presentation
+        finish_hit_presentation = options.finish_hit_presentation
 
         if dt <= 0.0:
             return []
@@ -424,7 +424,7 @@ class ProjectilePool:
                         target=target,
                     )
                     hits.append(hit)
-                    hit_ctx = on_hit(hit) if on_hit is not None else None
+                    hit_presentation = begin_hit_presentation(hit) if begin_hit_presentation is not None else None
 
                     if proj.life_timer != 0.25 and rule.stop_on_hit:
                         proj.life_timer = 0.25
@@ -516,17 +516,17 @@ class ProjectilePool:
                             proj.life_timer = 0.25
 
                     if proj.life_timer == 0.25 and rule.stop_on_hit:
-                        if on_hit_post is not None and hit_ctx is not None:
-                            on_hit_post(hit, hit_ctx)
+                        if finish_hit_presentation is not None and hit_presentation is not None:
+                            finish_hit_presentation(hit, hit_presentation)
                         break
 
                     if proj.damage_pool <= 0.0:
-                        if on_hit_post is not None and hit_ctx is not None:
-                            on_hit_post(hit, hit_ctx)
+                        if finish_hit_presentation is not None and hit_presentation is not None:
+                            finish_hit_presentation(hit, hit_presentation)
                         break
 
-                    if on_hit_post is not None and hit_ctx is not None:
-                        on_hit_post(hit, hit_ctx)
+                    if finish_hit_presentation is not None and hit_presentation is not None:
+                        finish_hit_presentation(hit, hit_presentation)
 
                 step += 3
 

--- a/src/crimson/sim/world_state.py
+++ b/src/crimson/sim/world_state.py
@@ -138,9 +138,10 @@ class _WorldStepRuntime(msgspec.Struct):
             violence_disabled=int(self.violence_disabled),
         )
 
-    def finalize_projectile_hit_presentation(self, hit: ProjectileHit, post_ctx: ProjectileDecalPostCtx) -> None:
+    def finalize_projectile_hit_presentation(self, hit: ProjectileHit, post_ctx: object) -> None:
+        decal_post_ctx = cast("ProjectileDecalPostCtx", post_ctx)
         self.world._finalize_projectile_hit_presentation(
-            post_ctx=post_ctx,
+            post_ctx=decal_post_ctx,
             fx_queue=self.fx_queue,
         )
         hit_trigger, keys = plan_hit_sfx(
@@ -314,11 +315,8 @@ class WorldState(msgspec.Struct):
                     players=self.players,
                     apply_player_damage=step_runtime.apply_player_projectile_damage,
                     apply_creature_damage=step_runtime.apply_creature_damage,
-                    on_hit=step_runtime.prepare_projectile_hit_presentation,
-                    on_hit_post=cast(
-                        "Callable[[ProjectileHit, object], None]",
-                        step_runtime.finalize_projectile_hit_presentation,
-                    ),
+                    begin_hit_presentation=step_runtime.prepare_projectile_hit_presentation,
+                    finish_hit_presentation=step_runtime.finalize_projectile_hit_presentation,
                 ),
             ),
         )

--- a/tests/gameplay/test_death_timing.py
+++ b/tests/gameplay/test_death_timing.py
@@ -474,9 +474,9 @@ def test_freeze_hit_path_triggers_tune_and_skips_hit_sfx(mocker) -> None:
 
     def _fake_projectile_step(*args: object, **_kwargs: object) -> list[ProjectileHit]:
         ctx = cast("PrimaryStepCtx", args[0])
-        on_hit = ctx.options.on_hit
-        on_hit_post = ctx.options.on_hit_post
-        if on_hit is None or on_hit_post is None:
+        begin_hit_presentation = ctx.options.begin_hit_presentation
+        finish_hit_presentation = ctx.options.finish_hit_presentation
+        if begin_hit_presentation is None or finish_hit_presentation is None:
             return []
         hit = ProjectileHit(
             type_id=ProjectileTemplateId.PISTOL,
@@ -484,8 +484,8 @@ def test_freeze_hit_path_triggers_tune_and_skips_hit_sfx(mocker) -> None:
             hit=Vec2(1.0, 1.0),
             target=Vec2(1.0, 1.0),
         )
-        post_ctx = on_hit(hit)
-        on_hit_post(hit, post_ctx)
+        post_ctx = begin_hit_presentation(hit)
+        finish_hit_presentation(hit, post_ctx)
         return [hit]
 
     mocker.patch.object(world.state.projectiles, "step", side_effect=_fake_projectile_step)

--- a/tests/support/factories.py
+++ b/tests/support/factories.py
@@ -99,8 +99,8 @@ def make_projectile_update_options(
     players: Sequence[PlayerState] | None = None,
     apply_player_damage: Callable[[int, float], None] | None = None,
     apply_creature_damage: CreatureDamageApplier | None = None,
-    on_hit: Callable[[ProjectileHit], object] | None = None,
-    on_hit_post: Callable[[ProjectileHit, object], None] | None = None,
+    begin_hit_presentation: Callable[[ProjectileHit], object] | None = None,
+    finish_hit_presentation: Callable[[ProjectileHit, object], None] | None = None,
 ) -> ProjectileUpdateOptions:
     state = GameplayState() if runtime_state is None else runtime_state
     player_seq: Sequence[PlayerState] = () if players is None else players
@@ -116,6 +116,6 @@ def make_projectile_update_options(
         apply_creature_damage=apply_creature_damage,
         ion_aoe_scale=float(ion_aoe_scale),
         detail_preset=int(detail_preset),
-        on_hit=on_hit,
-        on_hit_post=on_hit_post,
+        begin_hit_presentation=begin_hit_presentation,
+        finish_hit_presentation=finish_hit_presentation,
     )


### PR DESCRIPTION
## Summary

- rename projectile hit presentation hooks from generic `on_hit` / `on_hit_post` callbacks to explicit begin/finish phases
- keep the projectile loop as the phase owner while `WorldState` supplies the native-parity presentation work
- update the projectile update test helper and death-timing fake to use the new names

## Notes

- This is a naming and callsite clarity PR only; the hit ordering and RNG-consuming presentation work stay in the same places.
- A later cleanup can tighten the remaining opaque hit presentation token if the projectile runtime gets a concrete phase object that does not make the lower-level projectile package depend on `sim.presentation_step`.

## Validation

- `uv run ruff check src/crimson/projectiles/runtime/projectile_pool.py src/crimson/sim/world_state.py tests/gameplay/test_death_timing.py tests/support/factories.py`
- `uv run python -m py_compile src/crimson/projectiles/runtime/projectile_pool.py src/crimson/sim/world_state.py tests/gameplay/test_death_timing.py tests/support/factories.py`
- `uv run pytest tests/gameplay/test_death_timing.py tests/projectiles/test_projectiles.py tests/projectiles/test_projectile_hit_effects.py`
- `just check`
- after rebasing onto current `origin/master`: `uv run pytest tests/gameplay/test_death_timing.py tests/projectiles/test_projectiles.py tests/projectiles/test_projectile_hit_effects.py tests/net/cli/test_zig_net_cli.py::test_zig_net_smoke_rollback_reports_jitter_burst_recovery`
