### PR TITLE
refactor: remove pool damage applier slots

### DIFF
--- a/src/crimson/bonuses/pool.py
+++ b/src/crimson/bonuses/pool.py
@@ -87,19 +87,10 @@ class BonusPool:
         # Native bonus code uses a writable sentinel entry when allocation/spacing
         # checks fail. Some callers still mutate it, which affects RNG consumption.
         self._sentinel = BonusEntry()
-        self._creature_damage_applier: CreatureDamageApplier | None = None
 
     @property
     def entries(self) -> list[BonusEntry]:
         return self._entries
-
-    @property
-    def creature_damage_applier(self) -> CreatureDamageApplier | None:
-        return self._creature_damage_applier
-
-    @creature_damage_applier.setter
-    def creature_damage_applier(self, value: CreatureDamageApplier | None) -> None:
-        self._creature_damage_applier = value
 
     def reset(self) -> None:
         for entry in self._entries:
@@ -412,11 +403,7 @@ class BonusPool:
                         detail_preset=int(detail_preset),
                         defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
                         freeze_corpse_indices=freeze_corpse_indices,
-                        apply_creature_damage=(
-                            apply_creature_damage
-                            if apply_creature_damage is not None
-                            else self._creature_damage_applier
-                        ),
+                        apply_creature_damage=apply_creature_damage,
                     )
                     entry.picked = True
                     entry.time_left = BONUS_PICKUP_LINGER

--- a/src/crimson/effects.py
+++ b/src/crimson/effects.py
@@ -87,23 +87,13 @@ class ParticlePool:
         *,
         size: int = PARTICLE_POOL_SIZE,
         rng: CrandLike | None = None,
-        creature_damage_applier: CreatureDamageApplier | None = None,
     ) -> None:
         self._entries = [Particle() for _ in range(int(size))]
         self._rng = Crand(0) if rng is None else rng
-        self._creature_damage_applier = creature_damage_applier
 
     @property
     def entries(self) -> list[Particle]:
         return self._entries
-
-    @property
-    def creature_damage_applier(self) -> CreatureDamageApplier | None:
-        return self._creature_damage_applier
-
-    @creature_damage_applier.setter
-    def creature_damage_applier(self, value: CreatureDamageApplier | None) -> None:
-        self._creature_damage_applier = value
 
     def reset(self) -> None:
         for entry in self._entries:
@@ -198,7 +188,7 @@ class ParticlePool:
         if dt <= 0.0:
             return []
         dt = f32(float(dt))
-        damage_applier = apply_creature_damage or self._creature_damage_applier
+        damage_applier = apply_creature_damage
 
         def _creature_find_in_radius(*, pos: Vec2, radius: float) -> int:
             if creatures is None:

--- a/src/crimson/projectiles/runtime/projectile_pool.py
+++ b/src/crimson/projectiles/runtime/projectile_pool.py
@@ -88,19 +88,10 @@ def projectile_collision_profile(type_id: ProjectileTemplateId) -> ProjectileCol
 class ProjectilePool:
     def __init__(self, *, size: int = MAIN_PROJECTILE_POOL_SIZE) -> None:
         self._entries = [Projectile() for _ in range(size)]
-        self._creature_damage_applier: CreatureDamageApplier | None = None
 
     @property
     def entries(self) -> list[Projectile]:
         return self._entries
-
-    @property
-    def creature_damage_applier(self) -> CreatureDamageApplier | None:
-        return self._creature_damage_applier
-
-    @creature_damage_applier.setter
-    def creature_damage_applier(self, value: CreatureDamageApplier | None) -> None:
-        self._creature_damage_applier = value
 
     def reset(self) -> None:
         for entry in self._entries:
@@ -171,11 +162,7 @@ class ProjectilePool:
         runtime_state = options.runtime_state
         players = options.players
         apply_player_damage = options.apply_player_damage
-        apply_creature_damage = (
-            options.apply_creature_damage
-            if options.apply_creature_damage is not None
-            else self._creature_damage_applier
-        )
+        apply_creature_damage = options.apply_creature_damage
         begin_hit_presentation = options.begin_hit_presentation
         finish_hit_presentation = options.finish_hit_presentation
 

--- a/src/crimson/projectiles/runtime/secondary_pool.py
+++ b/src/crimson/projectiles/runtime/secondary_pool.py
@@ -80,19 +80,10 @@ class SecondaryStepCtx(msgspec.Struct, frozen=True):
 class SecondaryProjectilePool:
     def __init__(self, *, size: int = SECONDARY_PROJECTILE_POOL_SIZE) -> None:
         self._entries = [SecondaryProjectile() for _ in range(size)]
-        self._creature_damage_applier: CreatureDamageApplier | None = None
 
     @property
     def entries(self) -> list[SecondaryProjectile]:
         return self._entries
-
-    @property
-    def creature_damage_applier(self) -> CreatureDamageApplier | None:
-        return self._creature_damage_applier
-
-    @creature_damage_applier.setter
-    def creature_damage_applier(self, value: CreatureDamageApplier | None) -> None:
-        self._creature_damage_applier = value
 
     def reset(self) -> None:
         for entry in self._entries:
@@ -169,11 +160,7 @@ class SecondaryProjectilePool:
         runtime_state = ctx.runtime_state
         fx_queue = ctx.fx_queue
         detail_preset = int(ctx.detail_preset)
-        apply_creature_damage = (
-            ctx.apply_creature_damage
-            if ctx.apply_creature_damage is not None
-            else self._creature_damage_applier
-        )
+        apply_creature_damage = ctx.apply_creature_damage
         on_detonation_kill = ctx.on_detonation_kill
 
         if dt <= 0.0:

--- a/tests/gameplay/test_effects.py
+++ b/tests/gameplay/test_effects.py
@@ -285,7 +285,7 @@ def test_particle_pool_tags_style_specific_jitter_callers() -> None:
     ]
 
 
-def test_particle_update_uses_argument_or_pool_damage_applier() -> None:
+def test_particle_update_uses_explicit_damage_applier() -> None:
     def _spawn_hit_particle(pool: ParticlePool) -> None:
         pool.spawn_particle(
             pos=Vec2(),
@@ -303,62 +303,26 @@ def test_particle_update_uses_argument_or_pool_damage_applier() -> None:
         creature.lifecycle_stage = 16.0
         return creature
 
-    # No kwarg: fall back to pool-level damage applier.
     pool = ParticlePool(size=1, rng=ScriptedCrand(0, fallback=ScriptedCrand.Fallback.REPEAT_LAST))
     creature = _new_creature()
-    pool_calls: list[tuple[int, float, int, Vec2, OwnerRef]] = []
+    calls: list[tuple[int, float, int, Vec2, OwnerRef]] = []
 
-    def _pool_applier(
+    def _applier(
         creature_index: int,
         damage: float,
         damage_type: int,
         impulse: Vec2,
         owner: OwnerRef,
     ) -> None:
-        pool_calls.append((creature_index, damage, damage_type, impulse, owner))
+        calls.append((creature_index, damage, damage_type, impulse, owner))
 
-    pool.creature_damage_applier = _pool_applier
     _spawn_hit_particle(pool)
-    pool.update(0.016, creatures=[creature])
-    assert len(pool_calls) == 1
-    assert pool_calls[0][0] == 0
-    assert pool_calls[0][2] == 4
-    assert pool_calls[0][4] == OwnerRef.from_player(0)
+    pool.update(0.016, creatures=[creature], apply_creature_damage=_applier)
+    assert len(calls) == 1
+    assert calls[0][0] == 0
+    assert calls[0][2] == 4
+    assert calls[0][4] == OwnerRef.from_player(0)
     assert_float_close(creature.hp, 100.0)
-
-    # With kwarg: prefer provided applier over pool-level fallback.
-    pool2 = ParticlePool(size=1, rng=ScriptedCrand(0, fallback=ScriptedCrand.Fallback.REPEAT_LAST))
-    creature2 = _new_creature()
-    pool2_calls: list[tuple[int, float, int, Vec2, OwnerRef]] = []
-    arg_calls: list[tuple[int, float, int, Vec2, OwnerRef]] = []
-
-    def _pool2_applier(
-        creature_index: int,
-        damage: float,
-        damage_type: int,
-        impulse: Vec2,
-        owner: OwnerRef,
-    ) -> None:
-        pool2_calls.append((creature_index, damage, damage_type, impulse, owner))
-
-    def _arg_applier(
-        creature_index: int,
-        damage: float,
-        damage_type: int,
-        impulse: Vec2,
-        owner: OwnerRef,
-    ) -> None:
-        arg_calls.append((creature_index, damage, damage_type, impulse, owner))
-
-    pool2.creature_damage_applier = _pool2_applier
-    _spawn_hit_particle(pool2)
-    pool2.update(0.016, creatures=[creature2], apply_creature_damage=_arg_applier)
-    assert len(arg_calls) == 1
-    assert pool2_calls == []
-    assert arg_calls[0][0] == 0
-    assert arg_calls[0][2] == 4
-    assert arg_calls[0][4] == OwnerRef.from_player(0)
-    assert_float_close(creature2.hp, 100.0)
 
 
 def test_effect_pool_blood_splatter_queues_decal_on_expiry() -> None:

--- a/tests/projectiles/test_projectile_spatial_hash.py
+++ b/tests/projectiles/test_projectile_spatial_hash.py
@@ -64,7 +64,6 @@ def test_secondary_projectile_hit_order_matches_linear_index_scan() -> None:
         _ = (damage, damage_type, impulse, owner)
         hit_indices.append(int(idx))
 
-    pool.creature_damage_applier = _apply
-    pool.step(SecondaryStepCtx(dt=0.1, creatures=creatures))
+    pool.step(SecondaryStepCtx(dt=0.1, creatures=creatures, apply_creature_damage=_apply))
 
     assert hit_indices == [0]

--- a/tests/projectiles/test_projectiles.py
+++ b/tests/projectiles/test_projectiles.py
@@ -365,8 +365,7 @@ def test_secondary_projectile_impulse_callbacks_snapshot(snapshot: SnapshotAsser
     creatures: list[CreatureState] = [_creature(pos=Vec2(0.0, -9.0), hp=1000.0)]
 
     apply_damage = mocker.Mock()
-    pool.creature_damage_applier = apply_damage
-    pool.step(SecondaryStepCtx(dt=0.1, creatures=creatures))
+    pool.step(SecondaryStepCtx(dt=0.1, creatures=creatures, apply_creature_damage=apply_damage))
 
     snapshot.assert_match(
         [
@@ -395,12 +394,12 @@ def test_secondary_projectile_kill_followup_snapshot(snapshot: SnapshotAssertion
         creatures[int(idx)].hp -= float(damage)
 
     on_kill = mocker.Mock()
-    pool.creature_damage_applier = _apply
     pool.step(
         SecondaryStepCtx(
             dt=0.1,
             creatures=creatures,
             fx_queue=fx_queue,
+            apply_creature_damage=_apply,
             on_detonation_kill=on_kill,
         ),
     )


### PR DESCRIPTION
## Summary

- remove the mutable `creature_damage_applier` slots from projectile, secondary projectile, particle, and bonus pools
- keep custom damage handling attached to each update/step context instead of storing it on long-lived pools
- update direct pool tests to pass explicit damage appliers at the callsite

## Notes

- This preserves the existing low-level direct-hp fallback when no custom damage applier is supplied.
- The next tightening step can make those update contexts require a concrete damage runtime in tests that care about lethal follow-up behavior.

## Validation

- `uv run ruff check src/crimson/bonuses/pool.py src/crimson/effects.py src/crimson/projectiles/runtime/projectile_pool.py src/crimson/projectiles/runtime/secondary_pool.py tests/gameplay/test_effects.py tests/projectiles/test_projectile_spatial_hash.py tests/projectiles/test_projectiles.py`
- `uv run python -m py_compile src/crimson/bonuses/pool.py src/crimson/effects.py src/crimson/projectiles/runtime/projectile_pool.py src/crimson/projectiles/runtime/secondary_pool.py tests/gameplay/test_effects.py tests/projectiles/test_projectile_spatial_hash.py tests/projectiles/test_projectiles.py`
- `uv run pytest tests/gameplay/test_effects.py tests/projectiles/test_projectiles.py tests/projectiles/test_projectile_spatial_hash.py tests/bonuses/test_nuke_bonus.py tests/perks/test_telekinetic_perk.py`
- `just check`
- after rebasing onto current `origin/master`: `uv run pytest tests/gameplay/test_effects.py tests/projectiles/test_projectiles.py tests/projectiles/test_projectile_spatial_hash.py tests/bonuses/test_nuke_bonus.py tests/perks/test_telekinetic_perk.py`
