### PR TITLE
refactor: replace LAN sync callback bundle

### DIFF
--- a/src/crimson/modes/base_gameplay_mode.py
+++ b/src/crimson/modes/base_gameplay_mode.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import datetime as dt
 import time
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias, cast
 
 import msgspec
 
@@ -64,7 +63,6 @@ from ..sim.clock import FixedStepClock
 from ..sim.frame_pump import advance_tick_runner_frame
 from ..sim.hooks import (
     LanFrameSample,
-    LanSyncCallbacks,
     LanTickSync,
     TickResult,
 )
@@ -105,15 +103,13 @@ if TYPE_CHECKING:
 LanRuntime = LockstepRuntime | RollbackRuntime
 
 
-@dataclass(slots=True)
-class _AppliedBatchTick:
+class _AppliedBatchTick(msgspec.Struct):
     tick: DeterministicSessionTick
     replay_tick_index: int | None
     frame_tick_index: int | None = None
 
 
-@dataclass(frozen=True, slots=True)
-class _BatchApplyOutcome:
+class _BatchApplyOutcome(msgspec.Struct, frozen=True):
     ticks_applied: int = 0
     stopped: bool = False
     stop_after_finalize: bool = False
@@ -121,8 +117,7 @@ class _BatchApplyOutcome:
     post_apply_reactions: tuple[PostApplyReaction, ...] = ()
 
 
-@dataclass(frozen=True, slots=True)
-class _ModeFrameState:
+class _ModeFrameState(msgspec.Struct, frozen=True):
     dt: float
     dt_ui_ms: float
 
@@ -217,6 +212,39 @@ class _LanRuntimeInputProvider:
             return
         if isinstance(runtime, LockstepRuntime):
             runtime.submit_local_command(command)
+
+
+class _LanTickSyncRuntime(msgspec.Struct, frozen=True):
+    role: str
+    provider: _LanRuntimeInputProvider
+    lockstep_runtime: object | None = None
+
+    def prepare_tick_result(self, tick_result: TickResult) -> None:
+        source_tick = tick_result.source_tick
+        sample = self.provider.take_frame_sample(int(source_tick.tick_index))
+        if sample is None:
+            raise RuntimeError("lan tick runner completed without runtime frame metadata")
+        if tuple(source_tick.commands) != tuple(sample.commands):
+            raise RuntimeError("lan tick result commands diverged from canonical frame")
+        tick_result.lan_sync = LanTickSync(
+            frame_tick_index=int(sample.frame_tick_index),
+            frame_inputs=tuple(sample.frame_inputs),
+        )
+
+    def finalize_tick_result(self, tick_result: TickResult) -> None:
+        sync = tick_result.lan_sync
+        if sync is None:
+            raise RuntimeError("lan tick result missing frame metadata")
+        if str(self.role) != "host" or self.lockstep_runtime is None:
+            return
+        runtime = cast(LockstepRuntime, self.lockstep_runtime)
+        runtime.broadcast_tick_frame(
+            TickFrame(
+                tick_index=int(sync.frame_tick_index),
+                frame_inputs=[list(packed) for packed in sync.frame_inputs],
+                commands=list(tick_result.source_tick.commands),
+            ),
+        )
 
 
 # LAN lockstep must keep presentation-step RNG consumption identical across peers.
@@ -1412,30 +1440,17 @@ class BaseGameplayMode:
     def _reset_lan_capture_clock(self) -> None:
         self._network_input_provider.reset_capture_clock()
 
-    def _build_lan_sync_callbacks(
+    def _build_lan_tick_sync_runtime(
         self,
         *,
-        runtime: LanRuntime,
         lockstep_runtime: LockstepRuntime | None,
         role: str,
         provider: _LanRuntimeInputProvider,
-    ) -> LanSyncCallbacks:
-        return LanSyncCallbacks(
+    ) -> _LanTickSyncRuntime:
+        return _LanTickSyncRuntime(
             role=str(role),
-            take_frame_sample=provider.take_frame_sample,
-            broadcast_tick_frame=(
-                (
-                    lambda frame_tick_index, frame_inputs, commands: lockstep_runtime.broadcast_tick_frame(
-                        TickFrame(
-                            tick_index=int(frame_tick_index),
-                            frame_inputs=[list(packed) for packed in frame_inputs],
-                            commands=list(commands),
-                        ),
-                    )
-                )
-                if role == "host" and lockstep_runtime is not None
-                else None
-            ),
+            provider=provider,
+            lockstep_runtime=lockstep_runtime if role == "host" else None,
         )
 
     def _ensure_tick_runner(
@@ -1501,43 +1516,6 @@ class BaseGameplayMode:
             None if bool(is_networked) else FixedStepClock(tick_rate=int(self._gameplay_tick_rate()))
         )
         return (runner, provider)
-
-    @staticmethod
-    def _prepare_lan_tick_sync(
-        *,
-        tick_result: TickResult,
-        callbacks: LanSyncCallbacks,
-    ) -> None:
-        source_tick = tick_result.source_tick
-        sample = callbacks.take_frame_sample(int(source_tick.tick_index))
-        if sample is None:
-            raise RuntimeError("lan tick runner completed without runtime frame metadata")
-        if tuple(source_tick.commands) != tuple(sample.commands):
-            raise RuntimeError("lan tick result commands diverged from canonical frame")
-        tick_result.lan_sync = LanTickSync(
-            frame_tick_index=int(sample.frame_tick_index),
-            frame_inputs=tuple(sample.frame_inputs),
-        )
-
-    @staticmethod
-    def _finalize_lan_tick_sync(
-        *,
-        tick_result: TickResult,
-        callbacks: LanSyncCallbacks,
-    ) -> None:
-        sync = tick_result.lan_sync
-        if sync is None:
-            raise RuntimeError("lan tick result missing frame metadata")
-        frame_tick_index = int(sync.frame_tick_index)
-        role = str(callbacks.role)
-
-        broadcast = callbacks.broadcast_tick_frame
-        if role == "host" and broadcast is not None:
-            broadcast(
-                int(frame_tick_index),
-                tuple(sync.frame_inputs),
-                tuple(tick_result.source_tick.commands),
-            )
 
     def _record_replay_checkpoint_from_tick(
         self,
@@ -1718,8 +1696,7 @@ class BaseGameplayMode:
             if provider.pop_blocked:
                 return False
         else:
-            lan_sync_callbacks = self._build_lan_sync_callbacks(
-                runtime=runtime,
+            lan_tick_sync = self._build_lan_tick_sync_runtime(
                 lockstep_runtime=lockstep_runtime,
                 role=str(role),
                 provider=provider,
@@ -1740,7 +1717,7 @@ class BaseGameplayMode:
                 batch=batch,
                 session=session,
                 recorder=self._replay_recorder,
-                lan_sync_callbacks=lan_sync_callbacks,
+                lan_tick_sync=lan_tick_sync,
                 on_tick_applied=_on_tick_applied,
                 on_checkpoint=lambda replay_tick_index, tick: self._record_replay_checkpoint_from_tick(
                     tick_index=int(replay_tick_index),
@@ -1806,7 +1783,7 @@ class BaseGameplayMode:
         batch: TickBatchResult,
         session: DeterministicSession,
         recorder: ReplayRecorder | None = None,
-        lan_sync_callbacks: LanSyncCallbacks | None = None,
+        lan_tick_sync: _LanTickSyncRuntime | None = None,
         on_tick_applied: Callable[[_AppliedBatchTick], LanStepAction] | None = None,
         on_checkpoint: Callable[[int, DeterministicSessionTick], None] | None = None,
     ) -> _BatchApplyOutcome:
@@ -1830,11 +1807,8 @@ class BaseGameplayMode:
                 tick=tick,
                 replay_tick_index=replay_tick_index,
             )
-            if lan_sync_callbacks is not None:
-                self._prepare_lan_tick_sync(
-                    tick_result=tick_result,
-                    callbacks=lan_sync_callbacks,
-                )
+            if lan_tick_sync is not None:
+                lan_tick_sync.prepare_tick_result(tick_result)
             if tick_result.lan_sync is not None:
                 applied.frame_tick_index = int(tick_result.lan_sync.frame_tick_index)
 
@@ -1868,11 +1842,8 @@ class BaseGameplayMode:
             if replay_tick_index is not None and on_checkpoint is not None:
                 on_checkpoint(int(replay_tick_index), tick)
 
-            if lan_sync_callbacks is not None:
-                self._finalize_lan_tick_sync(
-                    tick_result=tick_result,
-                    callbacks=lan_sync_callbacks,
-                )
+            if lan_tick_sync is not None:
+                lan_tick_sync.finalize_tick_result(tick_result)
 
             if action == "stop_after_finalize":
                 stop_after_finalize = True

--- a/src/crimson/sim/hooks.py
+++ b/src/crimson/sim/hooks.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import msgspec
@@ -20,21 +18,12 @@ class TickResult(msgspec.Struct):
     lan_sync: LanTickSync | None = None
 
 
-@dataclass(frozen=True, slots=True)
-class LanFrameSample:
+class LanFrameSample(msgspec.Struct, frozen=True):
     frame_tick_index: int
     frame_inputs: tuple[list[float], ...]
     commands: tuple[GameCommand, ...] = ()
 
 
-@dataclass(frozen=True, slots=True)
-class LanTickSync:
+class LanTickSync(msgspec.Struct, frozen=True):
     frame_tick_index: int
     frame_inputs: tuple[list[float], ...]
-
-
-@dataclass(slots=True)
-class LanSyncCallbacks:
-    role: str
-    take_frame_sample: Callable[[int], LanFrameSample | None]
-    broadcast_tick_frame: Callable[[int, tuple[list[float], ...], tuple[GameCommand, ...]], None] | None = None

--- a/tests/sim/test_runtime_pump_ownership.py
+++ b/tests/sim/test_runtime_pump_ownership.py
@@ -14,9 +14,11 @@ import crimson.game.loop_view as loop_view_module
 from crimson.game.loop_view import GameLoopView
 from crimson.game.types import LockstepEndpoint, NetworkSessionConfig, PendingNetworkSession
 from crimson.game_modes import GameMode
-from crimson.modes.base_gameplay_mode import _LanRuntimeInputProvider
+from crimson.modes.base_gameplay_mode import _LanRuntimeInputProvider, _LanTickSyncRuntime
 from crimson.modes.survival_mode import SurvivalMode
-from crimson.sim.hooks import LanFrameSample, LanSyncCallbacks, LanTickSync, TickResult
+from crimson.net.lockstep_protocol import TickFrame
+from crimson.net.lockstep_runtime import HostLockstepRuntimeConfig, LockstepRuntime
+from crimson.sim.hooks import LanFrameSample, LanTickSync, TickResult
 from crimson.sim.input_providers import InputStatus, PerkPickCommand, ResolvedTick
 from crimson.sim.tick_runner import TickBatchResult
 from grim.rand import Crand
@@ -43,6 +45,14 @@ class _DummyRuntime:
         return None
 
 
+class _BroadcastTickFrameRuntime:
+    def __init__(self) -> None:
+        self.frames: list[TickFrame] = []
+
+    def broadcast_tick_frame(self, frame: TickFrame) -> None:
+        self.frames.append(frame)
+
+
 def _pending_session() -> PendingNetworkSession:
     return PendingNetworkSession(
         role="host",
@@ -57,6 +67,18 @@ def _pending_session() -> PendingNetworkSession:
 
 def _assets_dir() -> Path:
     return Path(__file__).resolve().parents[1] / "artifacts" / "assets"
+
+
+def _host_lan_runtime() -> LockstepRuntime:
+    return LockstepRuntime(
+        HostLockstepRuntimeConfig(
+            mode_id=GameMode.SURVIVAL,
+            player_count=1,
+            bind_host="127.0.0.1",
+            host_ip="127.0.0.1",
+            port=0,
+        ),
+    )
 
 
 def _mode_rng() -> Crand:
@@ -125,7 +147,7 @@ def test_lan_tick_consumption_drives_runner_until_stall(mocker, make_mode_config
         player_count=1,
         tick_rate=60,
     )
-    mocker.patch.object(mode, "_build_lan_sync_callbacks", return_value=None)
+    mocker.patch.object(mode, "_build_lan_tick_sync_runtime", return_value=None)
     mocker.patch.object(mode, "_lan_on_tick_applied", return_value="continue")
     mocker.patch.object(
         mode,
@@ -134,7 +156,7 @@ def test_lan_tick_consumption_drives_runner_until_stall(mocker, make_mode_config
     )
 
     stop = mode._consume_lan_tick_frames(
-        runtime=object(),  # type: ignore[arg-type]  # _ensure_tick_runner is patched
+        runtime=_host_lan_runtime(),
         lockstep_runtime=None,
         session=make_session()[0],
         role="host",
@@ -161,11 +183,11 @@ def test_lan_tick_consumption_treats_before_pop_block_as_non_stall(mocker, make_
         "_ensure_tick_runner",
         return_value=(runner, provider),
     )
-    mocker.patch.object(mode, "_build_lan_sync_callbacks", return_value=None)
+    mocker.patch.object(mode, "_build_lan_tick_sync_runtime", return_value=None)
 
     before_stall_count = int(mode._input_stall_count)
     stop = mode._consume_lan_tick_frames(
-        runtime=object(),  # type: ignore[arg-type]  # _ensure_tick_runner is patched
+        runtime=_host_lan_runtime(),
         lockstep_runtime=None,
         session=make_session()[0],
         role="host",
@@ -199,16 +221,6 @@ def test_lan_tick_consumption_does_not_emit_sync_for_stop_before_finalize(mocker
             payload=make_tick_payload(elapsed_ms=33.33),
         ),
     ]
-    runner = FakeRunner(results=
-        [
-            TickBatchResult(
-                ticks_completed=2,
-                batch_status=InputStatus.READY,
-                next_tick_index=2,
-                completed_results=ticks,
-            ),
-        ],
-    )
     provider = _LanRuntimeInputProvider(
         player_count=1,
         tick_rate=60,
@@ -225,16 +237,25 @@ def test_lan_tick_consumption_does_not_emit_sync_for_stop_before_finalize(mocker
             commands=(),
         ),
     }
-    broadcast_calls: list[int] = []
-    callbacks = LanSyncCallbacks(
+    runner = FakeRunner(
+        results=[
+            TickBatchResult(
+                ticks_completed=2,
+                batch_status=InputStatus.READY,
+                next_tick_index=2,
+                completed_results=ticks,
+            ),
+        ],
+        on_advance=lambda: provider._samples_by_runner_tick.update(sync_samples),
+    )
+    runtime = _BroadcastTickFrameRuntime()
+    tick_sync = _LanTickSyncRuntime(
         role="host",
-        take_frame_sample=lambda tick: sync_samples.pop(int(tick), None),
-        broadcast_tick_frame=lambda frame_tick_index, _frame_inputs, _commands: broadcast_calls.append(
-            int(frame_tick_index),
-        ),
+        provider=provider,
+        lockstep_runtime=runtime,
     )
 
-    mocker.patch.object(mode, "_build_lan_sync_callbacks", return_value=callbacks)
+    mocker.patch.object(mode, "_build_lan_tick_sync_runtime", return_value=tick_sync)
     mocker.patch.object(mode, "_lan_on_tick_applied", return_value="stop_before_finalize")
     mocker.patch.object(
         mode,
@@ -243,7 +264,7 @@ def test_lan_tick_consumption_does_not_emit_sync_for_stop_before_finalize(mocker
     )
 
     stop = mode._consume_lan_tick_frames(
-        runtime=object(),  # type: ignore[arg-type]  # _ensure_tick_runner is patched
+        runtime=_host_lan_runtime(),
         lockstep_runtime=None,
         session=make_session()[0],
         role="host",
@@ -252,9 +273,9 @@ def test_lan_tick_consumption_does_not_emit_sync_for_stop_before_finalize(mocker
 
     assert stop is False
     assert runner.calls == 1
-    assert broadcast_calls == []
+    assert runtime.frames == []
     # Tick 1 was not finalized and its sample should remain untouched.
-    assert 1 in sync_samples
+    assert 1 in provider._samples_by_runner_tick
 
 
 def test_lan_tick_consumption_broadcasts_tick_frame_commands(mocker, make_mode_config) -> None:
@@ -269,14 +290,6 @@ def test_lan_tick_consumption_broadcasts_tick_frame_commands(mocker, make_mode_c
         ),
         payload=make_tick_payload(elapsed_ms=16.67),
     )
-    runner = FakeRunner(results=[
-        TickBatchResult(
-            ticks_completed=1,
-            batch_status=InputStatus.READY,
-            next_tick_index=1,
-            completed_results=[tick],
-        ),
-    ])
     provider = _LanRuntimeInputProvider(
         player_count=1,
         tick_rate=60,
@@ -288,15 +301,24 @@ def test_lan_tick_consumption_broadcasts_tick_frame_commands(mocker, make_mode_c
             commands=(command,),
         ),
     }
-    broadcast_calls: list[tuple[int, tuple[object, ...]]] = []
-    callbacks = LanSyncCallbacks(
-        role="host",
-        take_frame_sample=lambda tick: sync_samples.pop(int(tick), None),
-        broadcast_tick_frame=lambda frame_tick_index, _frame_inputs, commands: broadcast_calls.append(
-            (int(frame_tick_index), tuple(commands)),
-        ),
+    runner = FakeRunner(
+        results=[
+            TickBatchResult(
+                ticks_completed=1,
+                batch_status=InputStatus.READY,
+                next_tick_index=1,
+                completed_results=[tick],
+            ),
+        ],
+        on_advance=lambda: provider._samples_by_runner_tick.update(sync_samples),
     )
-    mocker.patch.object(mode, "_build_lan_sync_callbacks", return_value=callbacks)
+    runtime = _BroadcastTickFrameRuntime()
+    tick_sync = _LanTickSyncRuntime(
+        role="host",
+        provider=provider,
+        lockstep_runtime=runtime,
+    )
+    mocker.patch.object(mode, "_build_lan_tick_sync_runtime", return_value=tick_sync)
     mocker.patch.object(
         mode,
         "_ensure_tick_runner",
@@ -304,7 +326,7 @@ def test_lan_tick_consumption_broadcasts_tick_frame_commands(mocker, make_mode_c
     )
 
     stop = mode._consume_lan_tick_frames(
-        runtime=object(),  # type: ignore[arg-type]
+        runtime=_host_lan_runtime(),
         lockstep_runtime=None,
         session=make_session()[0],
         role="host",
@@ -312,7 +334,7 @@ def test_lan_tick_consumption_broadcasts_tick_frame_commands(mocker, make_mode_c
     )
 
     assert stop is False
-    assert broadcast_calls == [(10, (command,))]
+    assert [(int(frame.tick_index), tuple(frame.commands)) for frame in runtime.frames] == [(10, (command,))]
 
 
 def test_gameplay_frame_telemetry_is_propagated_to_game_state(make_game_state, mocker) -> None:


### PR DESCRIPTION
## Summary

- replace the `LanSyncCallbacks` callable bundle with a concrete `_LanTickSyncRuntime`
- move LAN frame sample preparation and host tick-frame broadcast finalization into runtime methods
- convert the touched orchestration records from dataclasses to `msgspec.Struct`
- update LAN pump tests to use concrete runtime objects instead of callback bundles

## Notes

- This keeps the mode-specific `on_tick_applied` hook in place. That is the next candidate if we want to reduce the remaining `_process_tick_batch_results` callback surface.
- The Zig UDP test rerun needed socket permissions locally; the first sandboxed rerun failed while binding UDP sockets with errno 1.

## Validation

- `uv run ruff check src/crimson/sim/hooks.py src/crimson/modes/base_gameplay_mode.py tests/sim/test_runtime_pump_ownership.py`
- `uv run python -m py_compile src/crimson/sim/hooks.py src/crimson/modes/base_gameplay_mode.py tests/sim/test_runtime_pump_ownership.py`
- `uv run ty check src/crimson/sim/hooks.py src/crimson/modes/base_gameplay_mode.py tests/sim/test_runtime_pump_ownership.py`
- `uv run pytest tests/sim/test_runtime_pump_ownership.py tests/net/test_lan_runtime.py tests/modes/test_survival_mode_progression.py`
- `just check` reached and passed the full Python suite; the Zig phase failed under sandboxed UDP bind
- with socket permissions: `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast`
- `zig build wasm`
- after rebasing onto current `origin/master`: `uv run pytest tests/sim/test_runtime_pump_ownership.py tests/net/test_lan_runtime.py tests/modes/test_survival_mode_progression.py`
