### PR TITLE
refactor: move session hooks into mode runtimes

### DIFF
--- a/src/crimson/modes/rush_mode.py
+++ b/src/crimson/modes/rush_mode.py
@@ -23,8 +23,8 @@ from ..persistence.save_status import GameStatusData
 from ..replay import Replay, ReplayHeader, ReplayRecorder
 from ..replay.checkpoints import DEFAULT_CHECKPOINT_SAMPLE_RATE
 from ..sim.bootstrap import advance_unlock_terrain
-from ..sim.session_builders import build_rush_session, enforce_rush_loadout
-from ..sim.sessions import DeterministicSession, DeterministicSessionTick, RushSpawnState
+from ..sim.session_builders import build_rush_session
+from ..sim.sessions import DeterministicSession, DeterministicSessionTick, RushSpawnState, enforce_rush_loadout
 from ..ui.cursor import draw_menu_cursor
 from ..ui.hud import HudRenderContext, draw_hud_overlay, hud_flags_for_game_mode
 from .base_gameplay_mode import (

--- a/src/crimson/replay/driver/playback_driver.py
+++ b/src/crimson/replay/driver/playback_driver.py
@@ -29,11 +29,11 @@ from ...sim.session_builders import (
     build_survival_session,
     build_tutorial_session,
     build_typo_session,
-    enforce_rush_loadout,
 )
 from ...sim.sessions import (
     DeterministicSession,
     QuestSpawnState,
+    enforce_rush_loadout,
 )
 from ...sim.world_state import WorldState
 from ...typo.state import typo_shot_counts

--- a/src/crimson/sim/session_builders.py
+++ b/src/crimson/sim/session_builders.py
@@ -5,32 +5,20 @@ from ..quests.level import QuestLevel
 from ..quests.types import SpawnEntry
 from ..sim.world_state import WorldState
 from ..tutorial import reset_tutorial_state
-from ..tutorial.runtime import tutorial_before_step, tutorial_input_transform, tutorial_post_step
-from ..typo.runtime import typo_before_step, typo_input_transform, typo_mid_step, typo_post_step
 from ..typo.state import reset_typo_state
 from ..weapon_runtime import weapon_assign_player
 from ..weapons import WeaponId
 from .sessions import (
     DeterministicSession,
+    QuestSessionRuntime,
     QuestSpawnState,
+    RushSessionRuntime,
     RushSpawnState,
+    SurvivalSessionRuntime,
     SurvivalSpawnState,
-    quest_post_step,
-    rush_input_transform,
-    rush_mid_step,
-    survival_mid_step,
+    TutorialSessionRuntime,
+    TypoSessionRuntime,
 )
-
-RUSH_WEAPON_ID = WeaponId.ASSAULT_RIFLE
-RUSH_FORCED_AMMO = 30.0
-
-
-def enforce_rush_loadout(world: WorldState) -> None:
-    for player in world.players:
-        if player.weapon.weapon_id != RUSH_WEAPON_ID:
-            weapon_assign_player(player, RUSH_WEAPON_ID, state=world.state)
-        # Native `rush_mode_update` forces assault rifle + 30 ammo every frame.
-        player.weapon.ammo = float(RUSH_FORCED_AMMO)
 
 
 def build_survival_session(
@@ -44,7 +32,7 @@ def build_survival_session(
     finalize_post_render_lifecycle: bool,
     apply_world_dt_steps: bool = False,
 ) -> tuple[DeterministicSession, SurvivalSpawnState]:
-    spawn_state = SurvivalSpawnState()
+    mode_runtime = SurvivalSessionRuntime()
     session = DeterministicSession(
         world=world,
         world_size=world_size,
@@ -56,9 +44,9 @@ def build_survival_session(
         game_tune_started=game_tune_started,
         apply_world_dt_steps=apply_world_dt_steps,
         finalize_post_render_lifecycle=finalize_post_render_lifecycle,
-        mid_step_hook=lambda ctx: survival_mid_step(ctx, spawn_state),
+        mode_runtime=mode_runtime,
     )
-    return session, spawn_state
+    return session, mode_runtime.spawn
 
 
 def build_rush_session(
@@ -71,7 +59,7 @@ def build_rush_session(
     game_tune_started: bool,
     finalize_post_render_lifecycle: bool,
 ) -> tuple[DeterministicSession, RushSpawnState]:
-    spawn_state = RushSpawnState()
+    mode_runtime = RushSessionRuntime(world=world)
     session = DeterministicSession(
         world=world,
         world_size=world_size,
@@ -83,11 +71,9 @@ def build_rush_session(
         game_tune_started=game_tune_started,
         finalize_post_render_lifecycle=finalize_post_render_lifecycle,
         elapsed_uses_raw_dt=True,
-        mid_step_hook=lambda ctx: rush_mid_step(ctx, spawn_state),
-        before_step_hook=lambda: enforce_rush_loadout(world),
-        input_transform=rush_input_transform,
+        mode_runtime=mode_runtime,
     )
-    return session, spawn_state
+    return session, mode_runtime.spawn
 
 
 def build_quest_session(
@@ -113,6 +99,7 @@ def build_quest_session(
 
     world.creatures.capture_spawn_events_authoritative = False
     quest_state = QuestSpawnState(spawn_entries=tuple(spawn_entries))
+    mode_runtime = QuestSessionRuntime(spawn=quest_state)
     session = DeterministicSession(
         world=world,
         world_size=world_size,
@@ -125,7 +112,7 @@ def build_quest_session(
         demo_mode_active=demo_mode_active,
         apply_world_dt_steps=apply_world_dt_steps,
         finalize_post_render_lifecycle=finalize_post_render_lifecycle,
-        post_step_hook=lambda ctx: quest_post_step(ctx, quest_state),
+        mode_runtime=mode_runtime,
     )
     return session, quest_state
 
@@ -156,10 +143,7 @@ def build_typo_session(
         detail_preset=detail_preset,
         violence_disabled=violence_disabled,
         game_tune_started=game_tune_started,
-        before_step_hook=lambda: typo_before_step(world),
-        mid_step_hook=typo_mid_step,
-        post_step_hook=typo_post_step,
-        input_transform=lambda inputs: typo_input_transform(world, inputs),
+        mode_runtime=TypoSessionRuntime(world=world),
     )
     return session
 
@@ -189,8 +173,6 @@ def build_tutorial_session(
         violence_disabled=violence_disabled,
         game_tune_started=game_tune_started,
         demo_mode_active=demo_mode_active,
-        before_step_hook=lambda: tutorial_before_step(world),
-        post_step_hook=tutorial_post_step,
-        input_transform=lambda inputs: tutorial_input_transform(world, inputs),
+        mode_runtime=TutorialSessionRuntime(world=world),
     )
     return session

--- a/src/crimson/sim/sessions.py
+++ b/src/crimson/sim/sessions.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
-from dataclasses import dataclass
-from typing import TypeAlias
 
 import msgspec
 
@@ -21,8 +18,11 @@ from ..perks.selection import (
 from ..quests.runtime import tick_quest_completion_transition
 from ..quests.timeline import quest_spawn_table_empty, tick_quest_mode_spawns
 from ..quests.types import SpawnEntry
-from ..typo.runtime import apply_typo_command
+from ..tutorial.runtime import tutorial_before_step, tutorial_input_transform, tutorial_post_step
+from ..typo.runtime import apply_typo_command, typo_before_step, typo_input_transform, typo_mid_step, typo_post_step
+from ..weapon_runtime import weapon_assign_player
 from ..weapon_runtime.availability import prepare_weapon_availability
+from ..weapons import WeaponId
 from .input import PlayerInput
 from .input_frame import normalize_input_frame
 from .input_providers import (
@@ -43,6 +43,9 @@ from .terrain_fx import TerrainFxScratch
 from .timing import FrameTiming
 from .world_state import WorldState
 
+RUSH_WEAPON_ID = WeaponId.ASSAULT_RIFLE
+RUSH_FORCED_AMMO = 30.0
+
 # ---------------------------------------------------------------------------
 # Tick result types
 # ---------------------------------------------------------------------------
@@ -54,9 +57,8 @@ class DeterministicSessionTick(msgspec.Struct):
     presentation_plan_ms: float = 0.0
 
 
-
 # ---------------------------------------------------------------------------
-# Mid-/post-step hook system (spawn strategies)
+# Mode runtime system
 # ---------------------------------------------------------------------------
 
 class MidStepContext(msgspec.Struct, frozen=True):
@@ -68,7 +70,6 @@ class MidStepContext(msgspec.Struct, frozen=True):
     dt_raw_ms: float
     world_size: float
 
-MidStepHook: TypeAlias = Callable[[MidStepContext], None]
 
 class PostStepContext(msgspec.Struct, frozen=True):
     """Context passed to post-step hooks during deterministic stepping."""
@@ -79,19 +80,17 @@ class PostStepContext(msgspec.Struct, frozen=True):
     world_size: float
     detail_preset: int
 
-PostStepHook: TypeAlias = Callable[[PostStepContext], None]
 
-@dataclass
-class SurvivalSpawnState:
+class SurvivalSpawnState(msgspec.Struct):
     stage: int = 0
     spawn_cooldown_ms: float = 0.0
 
-@dataclass
-class RushSpawnState:
+
+class RushSpawnState(msgspec.Struct):
     spawn_cooldown_ms: float = 0.0
 
-@dataclass
-class QuestSpawnState:
+
+class QuestSpawnState(msgspec.Struct):
     spawn_entries: tuple[SpawnEntry, ...] = ()
     spawn_timeline_ms: float = 0.0
     no_creatures_timer_ms: float = 0.0
@@ -99,6 +98,15 @@ class QuestSpawnState:
     completed: bool = False
     play_hit_sfx: bool = False
     play_completion_music: bool = False
+
+
+def enforce_rush_loadout(world: WorldState) -> None:
+    for player in world.players:
+        if player.weapon.weapon_id != RUSH_WEAPON_ID:
+            weapon_assign_player(player, RUSH_WEAPON_ID, state=world.state)
+        # Native `rush_mode_update` forces assault rifle + 30 ammo every frame.
+        player.weapon.ammo = float(RUSH_FORCED_AMMO)
+
 
 def survival_mid_step(ctx: MidStepContext, spawn: SurvivalSpawnState) -> None:
     state = ctx.world.state
@@ -133,6 +141,7 @@ def survival_mid_step(ctx: MidStepContext, spawn: SurvivalSpawnState) -> None:
     spawn.spawn_cooldown_ms = cooldown
     ctx.world.creatures.spawn_inits(wave_spawns)
 
+
 def rush_mid_step(ctx: MidStepContext, spawn: RushSpawnState) -> None:
     state = ctx.world.state
     cooldown, spawns = tick_rush_mode_spawns(
@@ -146,6 +155,7 @@ def rush_mid_step(ctx: MidStepContext, spawn: RushSpawnState) -> None:
     )
     spawn.spawn_cooldown_ms = cooldown
     ctx.world.creatures.spawn_inits(spawns)
+
 
 def quest_post_step(ctx: PostStepContext, spawn: QuestSpawnState) -> None:
     state = ctx.world.state
@@ -195,11 +205,98 @@ def quest_post_step(ctx: PostStepContext, spawn: QuestSpawnState) -> None:
         spawn.play_hit_sfx = False
         spawn.play_completion_music = False
 
+
 def rush_input_transform(inputs: list[PlayerInput]) -> list[PlayerInput]:
     return [
         msgspec.structs.replace(inp, reload_pressed=False) if inp.reload_pressed else inp
         for inp in inputs
     ]
+
+
+class SessionModeRuntime(msgspec.Struct):
+    def before_step(self) -> None:
+        return None
+
+    def needs_mid_step(self) -> bool:
+        return False
+
+    def transform_inputs(self, inputs: list[PlayerInput]) -> list[PlayerInput]:
+        return inputs
+
+    def mid_step(self, ctx: MidStepContext) -> None:
+        _ = ctx
+        return None
+
+    def post_step(self, ctx: PostStepContext) -> None:
+        _ = ctx
+        return None
+
+
+class SurvivalSessionRuntime(SessionModeRuntime):
+    spawn: SurvivalSpawnState = msgspec.field(default_factory=SurvivalSpawnState)
+
+    def needs_mid_step(self) -> bool:
+        return True
+
+    def mid_step(self, ctx: MidStepContext) -> None:
+        survival_mid_step(ctx, self.spawn)
+
+
+class RushSessionRuntime(SessionModeRuntime):
+    world: WorldState
+    spawn: RushSpawnState = msgspec.field(default_factory=RushSpawnState)
+
+    def before_step(self) -> None:
+        enforce_rush_loadout(self.world)
+
+    def needs_mid_step(self) -> bool:
+        return True
+
+    def transform_inputs(self, inputs: list[PlayerInput]) -> list[PlayerInput]:
+        return rush_input_transform(inputs)
+
+    def mid_step(self, ctx: MidStepContext) -> None:
+        rush_mid_step(ctx, self.spawn)
+
+
+class QuestSessionRuntime(SessionModeRuntime):
+    spawn: QuestSpawnState
+
+    def post_step(self, ctx: PostStepContext) -> None:
+        quest_post_step(ctx, self.spawn)
+
+
+class TypoSessionRuntime(SessionModeRuntime):
+    world: WorldState
+
+    def before_step(self) -> None:
+        typo_before_step(self.world)
+
+    def needs_mid_step(self) -> bool:
+        return True
+
+    def transform_inputs(self, inputs: list[PlayerInput]) -> list[PlayerInput]:
+        return typo_input_transform(self.world, inputs)
+
+    def mid_step(self, ctx: MidStepContext) -> None:
+        typo_mid_step(ctx)
+
+    def post_step(self, ctx: PostStepContext) -> None:
+        typo_post_step(ctx)
+
+
+class TutorialSessionRuntime(SessionModeRuntime):
+    world: WorldState
+
+    def before_step(self) -> None:
+        tutorial_before_step(self.world)
+
+    def transform_inputs(self, inputs: list[PlayerInput]) -> list[PlayerInput]:
+        return tutorial_input_transform(self.world, inputs)
+
+    def post_step(self, ctx: PostStepContext) -> None:
+        tutorial_post_step(ctx)
+
 
 # ---------------------------------------------------------------------------
 # Shared timing helper
@@ -245,11 +342,7 @@ class DeterministicSession(msgspec.Struct):
     elapsed_ms: float = 0.0
     terrain_fx: TerrainFxScratch = msgspec.field(default_factory=TerrainFxScratch)
 
-    # Optional hooks (provided by modes / callers)
-    mid_step_hook: MidStepHook | None = None
-    post_step_hook: PostStepHook | None = None
-    before_step_hook: Callable[[], None] | None = None
-    input_transform: Callable[[list[PlayerInput]], list[PlayerInput]] | None = None
+    mode_runtime: SessionModeRuntime = msgspec.field(default_factory=SessionModeRuntime)
 
     def __post_init__(self) -> None:
         state = self.world.state
@@ -270,8 +363,8 @@ class DeterministicSession(msgspec.Struct):
         commands: list[GameCommand] | None = None,
     ) -> DeterministicSessionTick:
         timing = self.timing_for_dt(dt)
-        if self.before_step_hook is not None:
-            self.before_step_hook()
+        mode_runtime = self.mode_runtime
+        mode_runtime.before_step()
 
         post_apply_sfx: list[SfxId] = []
         for cmd in (commands or ()):
@@ -306,16 +399,16 @@ class DeterministicSession(msgspec.Struct):
                     raise RuntimeError(f"unhandled command type: {type(cmd).__name__}")
 
         tick_inputs = inputs
-        if tick_inputs is not None and self.input_transform is not None:
-            tick_inputs = self.input_transform(tick_inputs)
+        if tick_inputs is not None:
+            tick_inputs = mode_runtime.transform_inputs(tick_inputs)
 
         state = self.world.state
         dt_sim_ms = float(timing.dt_sim_ms_i32)
         dt_raw_ms = float(timing.dt_ms_i32)
         elapsed_before_ms = self.elapsed_ms
 
-        hook: Callable[[], None] | None = None
-        if self.mid_step_hook is not None:
+        hook = None
+        if mode_runtime.needs_mid_step():
             ctx = MidStepContext(
                 world=self.world,
                 elapsed_before_ms=elapsed_before_ms,
@@ -323,8 +416,7 @@ class DeterministicSession(msgspec.Struct):
                 dt_raw_ms=dt_raw_ms,
                 world_size=self.world_size,
             )
-            _mid = self.mid_step_hook
-            hook = lambda: _mid(ctx)  # noqa: E731
+            hook = lambda: mode_runtime.mid_step(ctx)  # noqa: E731
 
         fx_queue = self.terrain_fx.decals
         fx_queue_rotated = self.terrain_fx.corpses
@@ -404,16 +496,15 @@ class DeterministicSession(msgspec.Struct):
         if step.presentation.trigger_game_tune:
             self.game_tune_started = True
 
-        if self.post_step_hook is not None:
-            self.post_step_hook(
-                PostStepContext(
-                    world=self.world,
-                    step_result=step,
-                    dt_sim_ms=dt_sim_ms,
-                    world_size=self.world_size,
-                    detail_preset=self.detail_preset,
-                ),
-            )
+        mode_runtime.post_step(
+            PostStepContext(
+                world=self.world,
+                step_result=step,
+                dt_sim_ms=dt_sim_ms,
+                world_size=self.world_size,
+                detail_preset=self.detail_preset,
+            ),
+        )
 
         creature_count_world_step = sum(1 for c in self.world.creatures.entries if c.active)
 

--- a/tests/modes/test_typo_typing.py
+++ b/tests/modes/test_typo_typing.py
@@ -6,8 +6,9 @@ from crimson.game_modes import GameMode
 from crimson.rng_caller_static import RngCallerStatic
 from crimson.sim.input import PlayerInput
 from crimson.sim.input_providers import TypoBackspaceCommand, TypoCharCommand, TypoSubmitCommand
-from crimson.sim.sessions import DeterministicSession, MidStepContext
+from crimson.sim.sessions import DeterministicSession, MidStepContext, SessionModeRuntime
 from crimson.sim.state_types import PlayerState
+from crimson.sim.world_state import WorldState
 from crimson.typo.runtime import apply_typo_command, typo_input_transform, typo_mid_step
 from crimson.typo.state import reset_typo_state
 from crimson.typo.typing import TYPING_MAX_CHARS, TypingBuffer
@@ -66,9 +67,14 @@ def test_typo_commands_apply_before_input_transform(make_world_state) -> None:
     class _StopAfterTransform(RuntimeError):
         pass
 
-    def _transform(inputs: list[PlayerInput]) -> list[PlayerInput]:
-        seen_typing_text.append(str(world.state.typo.typing.text))
-        raise _StopAfterTransform
+    class _TransformObserver(SessionModeRuntime):
+        world: WorldState
+        seen_typing_text: list[str]
+
+        def transform_inputs(self, inputs: list[PlayerInput]) -> list[PlayerInput]:
+            _ = inputs
+            self.seen_typing_text.append(str(self.world.state.typo.typing.text))
+            raise _StopAfterTransform
 
     session = DeterministicSession(
         world=world,
@@ -76,7 +82,7 @@ def test_typo_commands_apply_before_input_transform(make_world_state) -> None:
         damage_scale_by_type={},
         game_mode=GameMode.TYPO,
         perk_progression_enabled=False,
-        input_transform=_transform,
+        mode_runtime=_TransformObserver(world=world, seen_typing_text=seen_typing_text),
     )
 
     with pytest.raises(_StopAfterTransform):

--- a/tests/render/test_camera_shake.py
+++ b/tests/render/test_camera_shake.py
@@ -12,11 +12,8 @@ from crimson.rng_caller_static import RngCallerStatic
 from crimson.sim.input import PlayerInput
 from crimson.sim.sessions import (
     DeterministicSession,
-    RushSpawnState,
-    SurvivalSpawnState,
-    rush_input_transform,
-    rush_mid_step,
-    survival_mid_step,
+    RushSessionRuntime,
+    SurvivalSessionRuntime,
 )
 from crimson.sim.state_types import PlayerState
 from crimson.sim.world_state import WorldState
@@ -168,14 +165,13 @@ def test_survival_session_nuke_pickup_skips_deferred_camera_decay() -> None:
     world = _build_session_world(seed=0x1234)
     entry = _spawn_nuke_pickup_on_player(world)
     player = world.players[0]
-    spawn = SurvivalSpawnState()
     session = DeterministicSession(
         world=world,
         world_size=1024.0,
         damage_scale_by_type=build_damage_scale_by_type(),
         game_mode=GameMode.SURVIVAL,
         perk_progression_enabled=True,
-        mid_step_hook=lambda ctx: survival_mid_step(ctx, spawn),
+        mode_runtime=SurvivalSessionRuntime(),
         finalize_post_render_lifecycle=True,
     )
 
@@ -193,15 +189,13 @@ def test_rush_session_nuke_pickup_skips_deferred_camera_decay() -> None:
     world = _build_session_world(seed=0x5678)
     entry = _spawn_nuke_pickup_on_player(world)
     player = world.players[0]
-    spawn = RushSpawnState()
     session = DeterministicSession(
         world=world,
         world_size=1024.0,
         damage_scale_by_type=build_damage_scale_by_type(),
         game_mode=GameMode.RUSH,
         perk_progression_enabled=False,
-        mid_step_hook=lambda ctx: rush_mid_step(ctx, spawn),
-        input_transform=rush_input_transform,
+        mode_runtime=RushSessionRuntime(world=world),
         elapsed_uses_raw_dt=True,
         finalize_post_render_lifecycle=True,
     )

--- a/tests/sim/test_quest_deterministic_session.py
+++ b/tests/sim/test_quest_deterministic_session.py
@@ -8,7 +8,7 @@ from crimson.quests.level import QuestLevel
 from crimson.quests.runtime import build_quest_spawn_table
 from crimson.quests.types import QuestContext
 from crimson.sim.input import PlayerInput
-from crimson.sim.sessions import DeterministicSession, QuestSpawnState, quest_post_step
+from crimson.sim.sessions import DeterministicSession, QuestSessionRuntime, QuestSpawnState
 from grim.geom import Vec2
 from grim.rand import Crand
 from tests.support.world_runtime import WorldRuntimeHost
@@ -36,7 +36,7 @@ def _build_session(*, seed: int = 101, level: str = "1.1") -> tuple[Deterministi
         damage_scale_by_type=world.sim_world.damage_scale_by_type,
         game_mode=GameMode.QUESTS,
         perk_progression_enabled=True,
-        post_step_hook=lambda ctx: quest_post_step(ctx, spawn_state),
+        mode_runtime=QuestSessionRuntime(spawn=spawn_state),
     )
     return session, spawn_state
 

--- a/tests/support/world_runtime.py
+++ b/tests/support/world_runtime.py
@@ -9,7 +9,12 @@ from crimson.sim.hooks import TickResult
 from crimson.sim.input import PlayerInput
 from crimson.sim.input_providers import ResolvedTick
 from crimson.sim.presentation_reactions import apply_post_apply_reaction, build_post_apply_reaction
-from crimson.sim.sessions import DeterministicSession, DeterministicSessionTick, SurvivalSpawnState, survival_mid_step
+from crimson.sim.sessions import (
+    DeterministicSession,
+    DeterministicSessionTick,
+    SurvivalSessionRuntime,
+    SurvivalSpawnState,
+)
 from crimson.sim.world_state import WorldState
 from crimson.terrain_slots import TerrainSlotTriplet
 from crimson.world import WorldRuntime
@@ -281,7 +286,7 @@ class WorldRuntimeHost:
             game_tune_started=self.sim_world.game_tune_started,
             demo_mode_active=self.demo_mode_active,
             defer_camera_shake_update=defer_camera_shake_update,
-            mid_step_hook=lambda ctx: survival_mid_step(ctx, self._survival_test_spawn_state),
+            mode_runtime=SurvivalSessionRuntime(spawn=self._survival_test_spawn_state),
         )
         session.elapsed_ms = float(self._survival_test_elapsed_ms)
 


### PR DESCRIPTION
## Summary

- replace `DeterministicSession` hook slots with concrete `SessionModeRuntime` objects for survival, rush, quest, typo, and tutorial
- move survival/rush/quest spawn state records from `dataclass` to mutable `msgspec.Struct`
- update session builders and focused tests to construct mode runtime objects directly instead of passing lambdas

## Validation

- `just check`
- post-rebase focused `uv run ruff check ...`
- post-rebase focused `uv run ty check ...`
- post-rebase focused `uv run pytest tests/render/test_camera_shake.py tests/sim/test_quest_deterministic_session.py tests/modes/test_typo_typing.py tests/sim/test_step_pipeline_parity.py tests/replay/test_replay_runners_survival.py tests/replay/test_replay_runners_rush.py tests/replay/test_replay_runners_quest.py tests/replay/test_replay_runners_tutorial.py tests/replay/test_replay_runners_typo.py tests/replay/test_playback_driver_walk.py`
