### PR TITLE
refactor: replace world mid-step callback

### DIFF
--- a/src/crimson/sim/sessions.py
+++ b/src/crimson/sim/sessions.py
@@ -41,7 +41,7 @@ from .step_pipeline import (
 )
 from .terrain_fx import TerrainFxScratch
 from .timing import FrameTiming
-from .world_state import WorldState
+from .world_state import WorldMidStepRuntime, WorldState
 
 RUSH_WEAPON_ID = WeaponId.ASSAULT_RIFLE
 RUSH_FORCED_AMMO = 30.0
@@ -298,6 +298,14 @@ class TutorialSessionRuntime(SessionModeRuntime):
         tutorial_post_step(ctx)
 
 
+class _SessionWorldMidStepRuntime(WorldMidStepRuntime):
+    mode_runtime: SessionModeRuntime
+    ctx: MidStepContext
+
+    def run_mid_step(self) -> None:
+        self.mode_runtime.mid_step(self.ctx)
+
+
 # ---------------------------------------------------------------------------
 # Shared timing helper
 # ---------------------------------------------------------------------------
@@ -407,7 +415,7 @@ class DeterministicSession(msgspec.Struct):
         dt_raw_ms = float(timing.dt_ms_i32)
         elapsed_before_ms = self.elapsed_ms
 
-        hook = None
+        mid_step_runtime = None
         if mode_runtime.needs_mid_step():
             ctx = MidStepContext(
                 world=self.world,
@@ -416,7 +424,10 @@ class DeterministicSession(msgspec.Struct):
                 dt_raw_ms=dt_raw_ms,
                 world_size=self.world_size,
             )
-            hook = lambda: mode_runtime.mid_step(ctx)  # noqa: E731
+            mid_step_runtime = _SessionWorldMidStepRuntime(
+                mode_runtime=mode_runtime,
+                ctx=ctx,
+            )
 
         fx_queue = self.terrain_fx.decals
         fx_queue_rotated = self.terrain_fx.corpses
@@ -443,7 +454,7 @@ class DeterministicSession(msgspec.Struct):
             dt_player_local=timing.dt_player_local,
             defer_camera_shake_update=self.defer_camera_shake_update,
             defer_freeze_corpse_fx=False,
-            mid_step_hook=hook,
+            mid_step_runtime=mid_step_runtime,
             inputs=normalized_inputs,
             world_size=self.world_size,
             damage_scale_by_type=self.damage_scale_by_type,

--- a/src/crimson/sim/world_state.py
+++ b/src/crimson/sim/world_state.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import cast
 
 import msgspec
@@ -49,6 +48,11 @@ class WorldEvents(msgspec.Struct):
     sfx: list[SfxId]
     trigger_game_tune: bool = False
     hit_sfx: list[SfxId] = msgspec.field(default_factory=list)
+
+
+class WorldMidStepRuntime(msgspec.Struct):
+    def run_mid_step(self) -> None:
+        return None
 
 
 _WORLD_DT_STEPS = WORLD_DT_STEPS
@@ -243,7 +247,7 @@ class WorldState(msgspec.Struct):
         dt_player_local: float | None = None,
         defer_camera_shake_update: bool = False,
         defer_freeze_corpse_fx: bool = False,
-        mid_step_hook: Callable[[], None] | None = None,
+        mid_step_runtime: WorldMidStepRuntime | None = None,
         inputs: list[PlayerInput] | None,
         world_size: float,
         damage_scale_by_type: dict[int, float],
@@ -381,8 +385,8 @@ class WorldState(msgspec.Struct):
         if dt > 0.0:
             self._advance_creature_anim(dt)
             self._advance_player_anim(dt, prev_positions)
-        if mid_step_hook is not None:
-            mid_step_hook()
+        if mid_step_runtime is not None:
+            mid_step_runtime.run_mid_step()
         if not bool(defer_camera_shake_update):
             camera_shake_update(self.state, dt)
         # Native level-up/perk-pending check runs before `bonus_update` in


### PR DESCRIPTION
## Summary

- replace `WorldState.step(mid_step_hook=...)` with a concrete `WorldMidStepRuntime`
- have deterministic sessions pass a bound mid-step runtime object instead of synthesizing a lambda
- remove the last `mid_step_hook` naming from the Python simulation path

## Validation

- `just check`
- post-rebase focused `uv run ruff check src/crimson/sim/world_state.py src/crimson/sim/sessions.py`
- post-rebase focused `uv run ty check src/crimson/sim/world_state.py src/crimson/sim/sessions.py`
- post-rebase focused `uv run pytest tests/sim/test_step_pipeline_parity.py tests/sim/test_runtime_pump_ownership.py tests/render/test_camera_shake.py tests/sim/test_quest_deterministic_session.py tests/replay/test_replay_runners_survival.py tests/replay/test_replay_runners_rush.py tests/replay/test_replay_runners_quest.py tests/replay/test_replay_runners_tutorial.py tests/replay/test_replay_runners_typo.py`
