### PR TITLE
refactor: replace presentation apply callback

### DIFF
--- a/src/crimson/modes/base_gameplay_mode.py
+++ b/src/crimson/modes/base_gameplay_mode.py
@@ -55,6 +55,7 @@ from ..replay.checkpoints import (
 from ..replay.input_codec import pack_player_input, unpack_player_input
 from ..screens.results.game_over import GameOverUi
 from ..sim.batch_apply import (
+    PresentationApplyRuntime,
     PresentationTickOutput,
     apply_presentation_outputs,
     apply_sim_metadata_tick_result,
@@ -115,6 +116,17 @@ class _BatchApplyOutcome(msgspec.Struct, frozen=True):
     stop_after_finalize: bool = False
     presentation_outputs: tuple[PresentationTickOutput, ...] = ()
     post_apply_reactions: tuple[PostApplyReaction, ...] = ()
+
+
+class _ModePresentationApplyRuntime(PresentationApplyRuntime):
+    mode: BaseGameplayMode
+    reactions_by_tick: dict[int, PostApplyReaction]
+
+    def output_applied(self, output: PresentationTickOutput) -> None:
+        self.mode._apply_tick_post_apply_reaction(
+            self.reactions_by_tick.get(int(output.tick_index), PostApplyReaction()),
+            dt_seconds=float(output.dt_sim),
+        )
 
 
 class _ModeFrameState(msgspec.Struct, frozen=True):
@@ -1800,9 +1812,9 @@ class BaseGameplayMode:
         apply_presentation_outputs(
             outputs=outputs,
             runtime=self._world_runtime,
-            on_output_applied=lambda output: self._apply_tick_post_apply_reaction(
-                reaction_by_tick.get(int(output.tick_index), PostApplyReaction()),
-                dt_seconds=float(output.dt_sim),
+            apply_runtime=_ModePresentationApplyRuntime(
+                mode=self,
+                reactions_by_tick=reaction_by_tick,
             ),
             apply_audio=bool(apply_audio),
             update_camera=bool(update_camera),

--- a/src/crimson/modes/replay_playback_mode.py
+++ b/src/crimson/modes/replay_playback_mode.py
@@ -31,6 +31,7 @@ from ..replay.driver.playback_driver import (
 from ..replay.driver.playback_pump import advance_playback_frame
 from ..replay.driver.setup import ReplayRunnerError
 from ..sim.batch_apply import (
+    PresentationApplyRuntime,
     PresentationTickOutput,
     apply_presentation_outputs,
 )
@@ -76,6 +77,14 @@ _REPLAY_WIDGET_TEXT_OFFSET_X = 0.0
 _REPLAY_WIDGET_TEXT_OFFSET_Y = 0.0
 _REPLAY_WIDGET_BAR_OFFSET_X = 0.0
 _REPLAY_WIDGET_BAR_OFFSET_Y = 0.0
+
+
+class _ReplayPresentationApplyRuntime(PresentationApplyRuntime):
+    mode: ReplayPlaybackMode
+    reactions_by_tick: dict[int, PostApplyReaction]
+
+    def output_applied(self, output: PresentationTickOutput) -> None:
+        self.mode._apply_post_apply_reaction(self.reactions_by_tick[int(output.tick_index)])
 
 
 class ReplayPlaybackMode:
@@ -490,9 +499,6 @@ class ReplayPlaybackMode:
         self._frame_index = int(advance.frame_index)
         self._tick_index = int(advance.next_tick_index)
 
-        def _on_output_applied(output: PresentationTickOutput) -> None:
-            self._apply_post_apply_reaction(reaction_by_tick[int(output.tick_index)])
-
         reaction_by_tick = {
             int(tick_result.source_tick.tick_index): self._build_post_apply_reaction(tick_result=tick_result)
             for tick_result in advance.tick_results
@@ -501,12 +507,15 @@ class ReplayPlaybackMode:
             apply_presentation_outputs(
                 outputs=advance.outputs,
                 runtime=runtime,
-                on_output_applied=_on_output_applied,
+                apply_runtime=_ReplayPresentationApplyRuntime(
+                    mode=self,
+                    reactions_by_tick=reaction_by_tick,
+                ),
                 apply_audio=True,
             )
         else:
             for output in advance.outputs:
-                _on_output_applied(output)
+                self._apply_post_apply_reaction(reaction_by_tick[int(output.tick_index)])
 
         self._mark_finished_if_complete()
         self._dt_accum = float(self._clock.accum)

--- a/src/crimson/sim/batch_apply.py
+++ b/src/crimson/sim/batch_apply.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from collections.abc import Sequence
 from typing import Any, Protocol
+
+import msgspec
 
 from .hooks import TickResult
 from .presentation_step import DeterministicPresentationPlan
@@ -21,11 +22,16 @@ class SimMetadataSink(Protocol):
     ) -> None: ...
 
 
-@dataclass(frozen=True, slots=True)
-class PresentationTickOutput:
+class PresentationTickOutput(msgspec.Struct, frozen=True):
     tick_index: int
     dt_sim: float
     presentation: DeterministicPresentationPlan | None
+
+
+class PresentationApplyRuntime(msgspec.Struct):
+    def output_applied(self, output: PresentationTickOutput) -> None:
+        _ = output
+        return None
 
 
 def apply_sim_metadata_tick_result(
@@ -82,7 +88,7 @@ def apply_presentation_outputs(
     *,
     outputs: Sequence[PresentationTickOutput],
     runtime: Any,
-    on_output_applied: Callable[[PresentationTickOutput], None] | None = None,
+    apply_runtime: PresentationApplyRuntime | None = None,
     apply_audio: bool,
     update_camera: bool = True,
 ) -> None:
@@ -98,5 +104,5 @@ def apply_presentation_outputs(
             terrain_fx = output.presentation.terrain_fx
             if not terrain_fx.is_empty():
                 runtime.render_resources.consume_terrain_fx_batch(terrain_fx)
-        if on_output_applied is not None:
-            on_output_applied(output)
+        if apply_runtime is not None:
+            apply_runtime.output_applied(output)

--- a/src/crimson/world/standalone_tick_harness.py
+++ b/src/crimson/world/standalone_tick_harness.py
@@ -5,7 +5,12 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ..game_modes import GameMode
-from ..sim.batch_apply import apply_presentation_outputs, apply_sim_metadata_batch
+from ..sim.batch_apply import (
+    PresentationApplyRuntime,
+    PresentationTickOutput,
+    apply_presentation_outputs,
+    apply_sim_metadata_batch,
+)
 from ..sim.clock import FixedStepClock
 from ..sim.frame_pump import advance_tick_runner_frame
 from ..sim.input import PlayerInput
@@ -23,6 +28,17 @@ if TYPE_CHECKING:
 
 
 WorldTickInputBuilder = Callable[[FrameContext], Sequence[PlayerInput]]
+
+
+class _StandalonePresentationApplyRuntime(PresentationApplyRuntime):
+    runtime: WorldRuntime
+    reactions_by_tick: dict[int, PostApplyReaction]
+
+    def output_applied(self, output: PresentationTickOutput) -> None:
+        apply_post_apply_reaction(
+            reaction=self.reactions_by_tick.get(int(output.tick_index), PostApplyReaction()),
+            play_sfx=self.runtime.audio_bridge.router.play_sfx,
+        )
 
 
 @dataclass(slots=True)
@@ -122,9 +138,9 @@ class StandaloneTickHarness:
         apply_presentation_outputs(
             outputs=outputs,
             runtime=runtime,
-            on_output_applied=lambda output: apply_post_apply_reaction(
-                reaction=reactions.get(int(output.tick_index), PostApplyReaction()),
-                play_sfx=runtime.audio_bridge.router.play_sfx,
+            apply_runtime=_StandalonePresentationApplyRuntime(
+                runtime=runtime,
+                reactions_by_tick=reactions,
             ),
             apply_audio=True,
         )

--- a/tests/contracts/test_architecture_contracts.py
+++ b/tests/contracts/test_architecture_contracts.py
@@ -320,10 +320,10 @@ def test_contract_4_live_to_replay_uses_survival_session_and_matches_ticks(
 
     replay_tick_indices: list[int] = []
 
-    def _apply_presentation_outputs(*, outputs, on_output_applied, **_kwargs) -> None:
+    def _apply_presentation_outputs(*, outputs, apply_runtime, **_kwargs) -> None:
         for output in outputs:
             replay_tick_indices.append(int(output.tick_index))
-            on_output_applied(output)
+            apply_runtime.output_applied(output)
 
     mocker.patch.object(
         replay_playback_mode,
@@ -444,7 +444,7 @@ def test_contract_9_post_apply_reactions_are_shared() -> None:
     helper_source = inspect.getsource(presentation_reactions_module.apply_post_apply_reaction)
     gameplay_source = inspect.getsource(base_gameplay_mode_module.BaseGameplayMode._process_tick_batch_results)
     replay_source = inspect.getsource(replay_playback_mode.ReplayPlaybackMode._apply_post_apply_reaction)
-    world_source = inspect.getsource(standalone_tick_harness_module.StandaloneTickHarness._apply_tick_batch)
+    world_source = inspect.getsource(standalone_tick_harness_module._StandalonePresentationApplyRuntime.output_applied)
 
     assert 'play_sfx(SfxId.QUESTHIT)' in helper_source
     assert "PerkPickCommand" not in gameplay_source

--- a/tests/replay/test_replay_playback_mode_timing.py
+++ b/tests/replay/test_replay_playback_mode_timing.py
@@ -46,10 +46,10 @@ def _replay_with_ticks(tick_count: int) -> Replay:
 
 
 def _capture_output_ticks(mocker, captured_ticks: list[int]) -> None:
-    def _apply_presentation_outputs(*, outputs, on_output_applied, **_kwargs) -> None:
+    def _apply_presentation_outputs(*, outputs, apply_runtime, **_kwargs) -> None:
         for output in outputs:
             captured_ticks.append(int(output.tick_index))
-            on_output_applied(output)
+            apply_runtime.output_applied(output)
 
     mocker.patch.object(
         replay_playback_mode,

--- a/tests/sim/test_terrain_fx_batch.py
+++ b/tests/sim/test_terrain_fx_batch.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from crimson.sim.batch_apply import PresentationTickOutput, apply_presentation_outputs
+from crimson.sim.batch_apply import PresentationApplyRuntime, PresentationTickOutput, apply_presentation_outputs
 from crimson.sim.presentation_step import DeterministicPresentationPlan
 from crimson.sim.terrain_fx import TerrainCorpseFx, TerrainDecalFx, TerrainFxBatch, TerrainFxScratch
 from grim.color import RGBA
@@ -63,6 +63,13 @@ class _PresentationRuntime:
         self._calls.append(("camera", 1))
 
 
+class _PresentationApplyRuntime(PresentationApplyRuntime):
+    calls: list[tuple[str, int | None]]
+
+    def output_applied(self, output: PresentationTickOutput) -> None:
+        self.calls.append(("done", int(output.tick_index)))
+
+
 def test_terrain_fx_scratch_take_batch_copies_active_entries_and_clears() -> None:
     scratch = TerrainFxScratch()
     scratch.decals.add(
@@ -106,7 +113,7 @@ def test_apply_presentation_outputs_applies_terrain_fx_in_output_order() -> None
     apply_presentation_outputs(
         outputs=outputs,
         runtime=_PresentationRuntime(calls),
-        on_output_applied=lambda output: calls.append(("done", int(output.tick_index))),
+        apply_runtime=_PresentationApplyRuntime(calls=calls),
         apply_audio=True,
     )
 


### PR DESCRIPTION
## Summary

- add `PresentationApplyRuntime` and pass presentation post-apply work through runtime objects instead of output-applied callbacks
- convert `PresentationTickOutput` to `msgspec.Struct`
- update gameplay, replay playback, standalone tick harness, and tests to use presentation apply runtime objects

## Validation

- `just check`
- `uv run pytest tests/net/cli/test_zig_net_cli.py::test_zig_net_smoke_rollback_reports_jitter_burst_recovery` (rerun after one transient failure in the first full run)
- `uv run ruff check src/crimson/sim/batch_apply.py src/crimson/modes/base_gameplay_mode.py src/crimson/modes/replay_playback_mode.py src/crimson/world/standalone_tick_harness.py tests/sim/test_terrain_fx_batch.py tests/contracts/test_architecture_contracts.py tests/replay/test_replay_playback_mode_timing.py`
- `uv run ty check src/crimson/sim/batch_apply.py src/crimson/modes/base_gameplay_mode.py src/crimson/modes/replay_playback_mode.py src/crimson/world/standalone_tick_harness.py tests/sim/test_terrain_fx_batch.py tests/contracts/test_architecture_contracts.py tests/replay/test_replay_playback_mode_timing.py`
- `uv run pytest tests/sim/test_terrain_fx_batch.py tests/contracts/test_architecture_contracts.py tests/replay/test_replay_playback_mode_timing.py tests/replay/test_replay_playback_mode_audio.py tests/replay/test_replay_runners_survival.py tests/replay/test_replay_runners_quest.py tests/sim/test_step_pipeline_parity.py`
