### PR TITLE
refactor: replace local input builder callback

### DIFF
--- a/src/crimson/debug_views/arsenal_debug.py
+++ b/src/crimson/debug_views/arsenal_debug.py
@@ -16,7 +16,7 @@ from ..creatures.spawn import SpawnId
 from ..game_modes import GameMode
 from ..projectiles.types import ProjectileTemplateId
 from ..sim.input import PlayerInput
-from ..sim.input_providers import FrameContext
+from ..sim.input_providers import FrameContext, LocalInputRuntime
 from ..tooling.audio_bootstrap import init_view_audio
 from ..ui.cursor import draw_aim_cursor
 from ..weapon_runtime import weapon_assign_player
@@ -91,6 +91,13 @@ def _projectile_type_label(type_id: int) -> str:
     return f"{name} (id {type_id})"
 
 
+class _ArsenalLocalInputRuntime(LocalInputRuntime):
+    view: ArsenalDebugView
+
+    def capture_frame_inputs(self, frame_ctx: FrameContext) -> list[PlayerInput]:
+        return self.view._build_runner_inputs(frame_ctx)
+
+
 class ArsenalDebugView:
     def __init__(self, ctx: ViewContext) -> None:
         self._assets_root = ctx.assets_dir
@@ -121,7 +128,7 @@ class ArsenalDebugView:
         self._screenshot_requested = False
         self._tick_harness = StandaloneTickHarness(
             game_mode=GameMode.SURVIVAL,
-            build_inputs=self._build_runner_inputs,
+            input_runtime=_ArsenalLocalInputRuntime(view=self),
         )
 
     def _load_texture(self, texture_id: TextureId) -> rl.Texture:

--- a/src/crimson/debug_views/lighting_debug.py
+++ b/src/crimson/debug_views/lighting_debug.py
@@ -22,7 +22,7 @@ from ..owner_ref import OwnerRef
 from ..projectiles.runtime import SecondarySpawnSpec
 from ..projectiles.types import ProjectileTemplateId, SecondaryProjectileTypeId
 from ..sim.input import PlayerInput
-from ..sim.input_providers import FrameContext
+from ..sim.input_providers import FrameContext, LocalInputRuntime
 from ..tooling.audio_bootstrap import init_view_audio
 from ..ui.cursor import draw_aim_cursor
 from ..weapons import WEAPON_BY_ID, WeaponId
@@ -1191,6 +1191,13 @@ def _shadow_debug_mode_name(mode: int) -> str:
     return f"mode{index}"
 
 
+class _LightingLocalInputRuntime(LocalInputRuntime):
+    view: LightingDebugView
+
+    def capture_frame_inputs(self, frame_ctx: FrameContext) -> list[PlayerInput]:
+        return self.view._build_runner_inputs(frame_ctx)
+
+
 class LightingDebugView:
     def __init__(self, ctx: ViewContext) -> None:
         self._assets_root = ctx.assets_dir
@@ -1289,7 +1296,7 @@ class LightingDebugView:
         self._screenshot_requested = False
         self._tick_harness = StandaloneTickHarness(
             game_mode=GameMode.SURVIVAL,
-            build_inputs=self._build_runner_inputs,
+            input_runtime=_LightingLocalInputRuntime(view=self),
         )
 
     def _load_texture(self, texture_id: TextureId) -> rl.Texture:

--- a/src/crimson/demo.py
+++ b/src/crimson/demo.py
@@ -20,7 +20,7 @@ from .rng_caller_static import RngCallerStatic
 from .screens.assets import require_runtime_resources
 from .sim.bootstrap import advance_explicit_terrain
 from .sim.input import PlayerInput
-from .sim.input_providers import FrameContext
+from .sim.input_providers import FrameContext, LocalInputRuntime
 from .sim.state_types import PlayerState
 from .terrain_slots import Q2_TERRAIN_SLOTS, TerrainSlotTriplet
 from .ui.cursor import draw_menu_cursor
@@ -58,6 +58,13 @@ _DEMO_PURCHASE_FEATURE_LINES: tuple[tuple[str, float], ...] = (
     ("-The ability to post your high scores online!", 44.0),
 )
 _DEMO_PURCHASE_FOOTER = "Purchasing the game is very easy and secure."
+
+
+class _DemoLocalInputRuntime(LocalInputRuntime):
+    view: DemoView
+
+    def capture_frame_inputs(self, frame_ctx: FrameContext) -> list[PlayerInput]:
+        return self.view._build_runner_inputs(frame_ctx)
 
 
 def _weapon_name(weapon_id: WeaponId, *, preserve_bugs: bool = False) -> str:
@@ -103,7 +110,7 @@ class DemoView:
         self._maybe_later_button = UiButtonState("Maybe later", force_wide=True)
         self._tick_harness = StandaloneTickHarness(
             game_mode=GameMode.DEMO,
-            build_inputs=self._build_runner_inputs,
+            input_runtime=_DemoLocalInputRuntime(view=self),
         )
         self._seed_from_app_state = True
 

--- a/src/crimson/modes/base_gameplay_mode.py
+++ b/src/crimson/modes/base_gameplay_mode.py
@@ -73,6 +73,7 @@ from ..sim.input_providers import (
     GameCommand,
     InputStatus,
     LocalInputProvider,
+    LocalInputRuntime,
     PerkMenuOpenCommand,
     PerkPickCommand,
     ResolvedTick,
@@ -127,6 +128,13 @@ class _ModePresentationApplyRuntime(PresentationApplyRuntime):
             self.reactions_by_tick.get(int(output.tick_index), PostApplyReaction()),
             dt_seconds=float(output.dt_sim),
         )
+
+
+class _ModeLocalInputRuntime(LocalInputRuntime):
+    mode: BaseGameplayMode
+
+    def capture_frame_inputs(self, frame_ctx: FrameContext) -> list[PlayerInput]:
+        return self.mode._build_local_inputs(dt=float(frame_ctx.dt_seconds))
 
 
 class _ModeFrameState(msgspec.Struct, frozen=True):
@@ -1560,7 +1568,7 @@ class BaseGameplayMode:
         else:
             provider = LocalInputProvider(
                 player_count=max(0, len(self.sim_world.players)),
-                build_inputs=lambda frame_ctx: self._build_local_inputs(dt=float(frame_ctx.dt_seconds)),
+                runtime=_ModeLocalInputRuntime(mode=self),
             )
         self._flush_queued_input_commands(provider=provider)
 

--- a/src/crimson/sim/input_providers.py
+++ b/src/crimson/sim/input_providers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from enum import Enum
 from typing import Annotated, Protocol, TypeAlias
 
@@ -80,7 +80,10 @@ class InputProvider(Protocol):
     def submit_command(self, command: GameCommand) -> None: ...
 
 
-LocalInputBuilder: TypeAlias = Callable[[FrameContext], Sequence[PlayerInput]]
+class LocalInputRuntime(msgspec.Struct):
+    def capture_frame_inputs(self, frame_ctx: FrameContext) -> Sequence[PlayerInput]:
+        _ = frame_ctx
+        raise NotImplementedError
 
 
 class LocalInputProvider:
@@ -90,10 +93,10 @@ class LocalInputProvider:
         self,
         *,
         player_count: int,
-        build_inputs: LocalInputBuilder,
+        runtime: LocalInputRuntime,
     ) -> None:
         self._player_count = max(0, player_count)
-        self._build_inputs = build_inputs
+        self._runtime = runtime
         self._pending_commands: list[GameCommand] = []
         self._commands_for_next_tick: list[GameCommand] = []
         self._frame_inputs: list[PlayerInput] = []
@@ -101,7 +104,7 @@ class LocalInputProvider:
         self._first_tick_pending = False
 
     def begin_frame(self, frame_ctx: FrameContext) -> None:
-        frame_inputs = list(self._build_inputs(frame_ctx))
+        frame_inputs = list(self._runtime.capture_frame_inputs(frame_ctx))
         self._frame_inputs = list(frame_inputs)
         self._edge_inputs = clear_input_edges(self._frame_inputs)
         self._first_tick_pending = True

--- a/src/crimson/world/standalone_tick_harness.py
+++ b/src/crimson/world/standalone_tick_harness.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -13,8 +12,7 @@ from ..sim.batch_apply import (
 )
 from ..sim.clock import FixedStepClock
 from ..sim.frame_pump import advance_tick_runner_frame
-from ..sim.input import PlayerInput
-from ..sim.input_providers import FrameContext, LocalInputProvider
+from ..sim.input_providers import LocalInputProvider, LocalInputRuntime
 from ..sim.presentation_reactions import (
     PostApplyReaction,
     apply_post_apply_reaction,
@@ -25,9 +23,6 @@ from ..sim.tick_runner import TickBatchResult, TickRunner, TickRunnerConfig
 
 if TYPE_CHECKING:
     from .runtime import WorldRuntime
-
-
-WorldTickInputBuilder = Callable[[FrameContext], Sequence[PlayerInput]]
 
 
 class _StandalonePresentationApplyRuntime(PresentationApplyRuntime):
@@ -46,7 +41,7 @@ class StandaloneTickHarness:
     """Standalone local runner for demo/debug screens outside BaseGameplayMode."""
 
     game_mode: GameMode
-    build_inputs: WorldTickInputBuilder
+    input_runtime: LocalInputRuntime
     tick_rate: int = 60
     session: DeterministicSession | None = None
     runner: TickRunner | None = None
@@ -103,7 +98,7 @@ class StandaloneTickHarness:
         )
         provider = LocalInputProvider(
             player_count=int(player_count),
-            build_inputs=self.build_inputs,
+            runtime=self.input_runtime,
         )
         runner = TickRunner(
             session=session,

--- a/tests/contracts/test_architecture_contracts.py
+++ b/tests/contracts/test_architecture_contracts.py
@@ -41,7 +41,7 @@ from grim.geom import Vec2
 from grim.rand import Crand
 from grim.raylib_api import rl
 from grim.view import ViewContext
-from tests.support.builders.input_providers import CallbackInputProvider
+from tests.support.builders.input_providers import CallbackInputProvider, StaticLocalInputRuntime
 from tests.support.builders.session import make_session
 
 
@@ -102,7 +102,7 @@ def test_contract_1_pure_headless_execution_no_render_or_audio_dependencies(mock
     session, sim_world = make_session()
     provider = LocalInputProvider(
         player_count=len(sim_world.players),
-        build_inputs=lambda _frame_ctx: [PlayerInput(aim=Vec2(512.0, 512.0))],
+        runtime=StaticLocalInputRuntime(inputs=(PlayerInput(aim=Vec2(512.0, 512.0)),)),
     )
     runner = TickRunner(
         session=session,
@@ -231,7 +231,7 @@ def test_contract_4_live_to_replay_uses_survival_session_and_matches_ticks(
     live_session, sim_world = make_session(seed=int(header.seed))
     live_provider = LocalInputProvider(
         player_count=1,
-        build_inputs=lambda _frame_ctx: list(input_row),
+        runtime=StaticLocalInputRuntime(inputs=tuple(input_row)),
     )
     live_runner = TickRunner(
         session=live_session,
@@ -345,7 +345,7 @@ def test_contract_5_plan_vs_apply_isolation_for_audio_and_render_side_effects(mo
 
     provider = LocalInputProvider(
         player_count=1,
-        build_inputs=lambda _frame_ctx: [PlayerInput()],
+        runtime=StaticLocalInputRuntime(inputs=(PlayerInput(),)),
     )
     runner = TickRunner(
         session=session,

--- a/tests/gameplay/test_game_world_audio.py
+++ b/tests/gameplay/test_game_world_audio.py
@@ -19,6 +19,7 @@ from grim.music import init_music_state
 from grim.rand import Crand
 from grim.sfx import init_sfx_state
 from grim.sfx_map import SfxId
+from tests.support.builders.input_providers import StaticLocalInputRuntime
 from tests.support.builders.session import make_session
 from tests.support.builders.tick_payload import make_tick_payload
 from tests.support.helpers import assert_float_close
@@ -203,7 +204,7 @@ def test_world_runtime_apply_tick_batch_applies_post_apply_bonus_sfx(mocker) -> 
 
     StandaloneTickHarness(
         game_mode=GameMode.SURVIVAL,
-        build_inputs=lambda _ctx: [],
+        input_runtime=StaticLocalInputRuntime(),
     )._apply_tick_batch(
         world._runtime,
         batch=batch,

--- a/tests/net/test_resync_snapshot_apply.py
+++ b/tests/net/test_resync_snapshot_apply.py
@@ -26,6 +26,7 @@ from crimson.sim.tick_runner import TickRunner, TickRunnerConfig
 from grim.geom import Vec2
 from grim.rand import Crand
 from grim.view import ViewContext
+from tests.support.builders.input_providers import StaticLocalInputRuntime
 
 if TYPE_CHECKING:
     from crimson.net.rollback_runtime import RollbackRuntime
@@ -171,7 +172,7 @@ def test_consume_net_runtime_recovery_applies_snapshot_and_resets_runner(make_mo
     session = mode._sim_session
     assert isinstance(session, DeterministicSession)
     session.elapsed_ms = 0.0
-    input_provider = LocalInputProvider(player_count=1, build_inputs=lambda _frame_ctx: [])
+    input_provider = LocalInputProvider(player_count=1, runtime=StaticLocalInputRuntime())
     mode._tick_input_provider = input_provider
     mode._tick_runner = TickRunner(
         session=session,
@@ -235,7 +236,7 @@ def test_quest_consume_net_runtime_recovery_restores_authoritative_runtime(make_
     mode._rollback_runtime = cast("RollbackRuntime", _RollbackRuntimeStub(tick_index=9, payload=payload))
     session = mode._sim_session
     assert isinstance(session, DeterministicSession)
-    input_provider = LocalInputProvider(player_count=1, build_inputs=lambda _frame_ctx: [])
+    input_provider = LocalInputProvider(player_count=1, runtime=StaticLocalInputRuntime())
     mode._tick_input_provider = input_provider
     mode._tick_runner = TickRunner(
         session=session,

--- a/tests/regressions/test_runner_presentation_regressions.py
+++ b/tests/regressions/test_runner_presentation_regressions.py
@@ -6,9 +6,10 @@ from crimson.creatures.spawn import SpawnId
 from crimson.game_modes import GameMode
 from crimson.sim.clock import FixedStepClock
 from crimson.sim.input import PlayerInput
-from crimson.sim.input_providers import FrameContext, InputStatus, LocalInputProvider
+from crimson.sim.input_providers import FrameContext, InputStatus, LocalInputProvider, LocalInputRuntime
 from crimson.sim.sessions import DeterministicSession
 from crimson.sim.tick_runner import TickBatchResult, TickRunner, TickRunnerConfig
+from tests.support.builders.input_providers import StaticLocalInputRuntime
 from tests.support.world_runtime import WorldRuntimeHost
 
 
@@ -19,7 +20,7 @@ def _assets_dir() -> Path:
 def _build_runner(
     world: WorldRuntimeHost,
     *,
-    build_inputs,
+    input_runtime: LocalInputRuntime,
 ) -> tuple[DeterministicSession, TickRunner]:
     session = DeterministicSession(
         world=world.sim_world.world_state,
@@ -35,7 +36,7 @@ def _build_runner(
     )
     provider = LocalInputProvider(
         player_count=len(world.sim_world.players),
-        build_inputs=build_inputs,
+        runtime=input_runtime,
     )
     runner = TickRunner(
         session=session,
@@ -116,13 +117,9 @@ def test_runner_path_projectile_hits_enqueue_decals() -> None:
 
     session, runner = _build_runner(
         world,
-        build_inputs=lambda frame_ctx: [
-            PlayerInput(
-                aim=target,
-                fire_down=True,
-                fire_pressed=True,
-            ),
-        ],
+        input_runtime=StaticLocalInputRuntime(
+            inputs=(PlayerInput(aim=target, fire_down=True, fire_pressed=True),),
+        ),
     )
     clock = FixedStepClock(tick_rate=60)
     frame_index = 0
@@ -148,7 +145,7 @@ def test_runner_multi_tick_batch_apply_order_is_deterministic() -> None:
         world = WorldRuntimeHost(assets_dir=_assets_dir())
         session, runner = _build_runner(
             world,
-            build_inputs=lambda frame_ctx: [PlayerInput()],
+            input_runtime=StaticLocalInputRuntime(inputs=(PlayerInput(),)),
         )
         clock = FixedStepClock(tick_rate=60)
         frame_index = 0

--- a/tests/sim/test_input_provider_semantics.py
+++ b/tests/sim/test_input_provider_semantics.py
@@ -14,7 +14,7 @@ from crimson.sim.input_providers import (
     TickSupply,
 )
 from crimson.sim.tick_runner import TickRunner, TickRunnerConfig
-from tests.support.builders.input_providers import CallbackInputProvider
+from tests.support.builders.input_providers import CallbackInputProvider, StaticLocalInputRuntime
 from tests.support.builders.session import make_session
 
 _FRAME_CTX = FrameContext(
@@ -28,7 +28,7 @@ _FRAME_CTX = FrameContext(
 def test_local_provider_never_stalls_and_clears_edges() -> None:
     provider = LocalInputProvider(
         player_count=1,
-        build_inputs=lambda _frame_ctx: [PlayerInput(fire_down=True, fire_pressed=True)],
+        runtime=StaticLocalInputRuntime(inputs=(PlayerInput(fire_down=True, fire_pressed=True),)),
     )
     provider.begin_frame(_FRAME_CTX)
 
@@ -44,7 +44,7 @@ def test_local_provider_never_stalls_and_clears_edges() -> None:
 
 
 def test_local_provider_allows_empty_inputs_for_zero_players() -> None:
-    provider = LocalInputProvider(player_count=0, build_inputs=lambda _frame_ctx: [])
+    provider = LocalInputProvider(player_count=0, runtime=StaticLocalInputRuntime())
     provider.begin_frame(_FRAME_CTX)
 
     tick0 = provider.pull_tick(0, _FRAME_CTX.tick_dt_seconds)

--- a/tests/support/builders/input_providers.py
+++ b/tests/support/builders/input_providers.py
@@ -8,9 +8,18 @@ from crimson.sim.input_providers import (
     GameCommand,
     InputProvider,
     InputStatus,
+    LocalInputRuntime,
     ResolvedTick,
     TickSupply,
 )
+
+
+class StaticLocalInputRuntime(LocalInputRuntime):
+    inputs: tuple[PlayerInput, ...] = ()
+
+    def capture_frame_inputs(self, frame_ctx: FrameContext) -> tuple[PlayerInput, ...]:
+        _ = frame_ctx
+        return tuple(self.inputs)
 
 
 class CallbackInputProvider(InputProvider):


### PR DESCRIPTION
## Summary

- add `LocalInputRuntime` so local frame capture is a runtime object instead of a generic `build_inputs` callback
- update gameplay, demo/debug standalone harnesses, and tests to pass concrete local input runtime objects
- keep `LocalInputProvider` focused on deterministic tick supply semantics: first tick gets frame inputs and commands, later ticks get edge-cleared inputs

## Grounding

- The rewrite pipeline treats `ResolvedTick` as the canonical deterministic boundary for live, LAN, replay, and harness flows.
- This keeps the original-style live input quirks outside the deterministic tick contract while preserving frame-latched edge behavior from local input polling.
- Replay and LAN providers remain separate sources; this PR only cleans the local player input adapter.

## Other cleanup candidates

- `_LanRuntimeInputProvider.set_before_pop(...)` is still a callback-shaped gate around LAN pop ownership.
- `PerkMenuController(on_close=...)` and the mode perk-menu SFX supplier still have UI callback wiring that could become a small mode-owned runtime object.
- `CallbackInputProvider` remains a test-only callback helper for stalled/network-like providers; it is outside the local-input runtime path but still worth replacing when those tests are touched.

## Validation

- `just check`
- `uv run ruff check src/crimson/sim/input_providers.py src/crimson/modes/base_gameplay_mode.py src/crimson/world/standalone_tick_harness.py src/crimson/demo.py src/crimson/debug_views/arsenal_debug.py src/crimson/debug_views/lighting_debug.py tests/support/builders/input_providers.py tests/sim/test_input_provider_semantics.py tests/contracts/test_architecture_contracts.py tests/net/test_resync_snapshot_apply.py tests/gameplay/test_game_world_audio.py tests/regressions/test_runner_presentation_regressions.py`
- `uv run ty check src/crimson/sim/input_providers.py src/crimson/modes/base_gameplay_mode.py src/crimson/world/standalone_tick_harness.py src/crimson/demo.py src/crimson/debug_views/arsenal_debug.py src/crimson/debug_views/lighting_debug.py tests/support/builders/input_providers.py tests/sim/test_input_provider_semantics.py tests/contracts/test_architecture_contracts.py tests/net/test_resync_snapshot_apply.py tests/gameplay/test_game_world_audio.py tests/regressions/test_runner_presentation_regressions.py`
- `uv run pytest tests/sim/test_input_provider_semantics.py tests/contracts/test_architecture_contracts.py tests/net/test_resync_snapshot_apply.py tests/gameplay/test_game_world_audio.py tests/regressions/test_runner_presentation_regressions.py tests/modes/test_demo_runtime.py tests/input/test_local_input.py`
