### PR TITLE
refactor: move perk menu callbacks into runtime

### DIFF
--- a/src/crimson/modes/base_gameplay_mode.py
+++ b/src/crimson/modes/base_gameplay_mode.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal, TypeAlias, cast
 
 import msgspec
@@ -91,7 +91,7 @@ from ..ui.hud import HudState, draw_target_health_bar
 from ..weapon_runtime import most_used_weapon_id_for_player
 from ..world.runtime import WorldRuntime
 from .components.highscore_record_builder import shots_from_state
-from .components.perk_menu_controller import PerkMenuController, PerkMenuUiContext
+from .components.perk_menu_controller import PerkMenuController, PerkMenuRuntime, PerkMenuUiContext
 
 if TYPE_CHECKING:
     from ..creatures.runtime import CreatureDeath, CreaturePool
@@ -135,6 +135,16 @@ class _ModeLocalInputRuntime(LocalInputRuntime):
 
     def capture_frame_inputs(self, frame_ctx: FrameContext) -> list[PlayerInput]:
         return self.mode._build_local_inputs(dt=float(frame_ctx.dt_seconds))
+
+
+class _ModePerkMenuRuntime(PerkMenuRuntime):
+    mode: BaseGameplayMode
+
+    def on_close(self) -> None:
+        self.mode._perk_menu_closed()
+
+    def play_sfx(self, sfx_id: SfxId) -> None:
+        self.mode.audio_bridge.router.play_sfx(sfx_id)
 
 
 class _ModeFrameState(msgspec.Struct, frozen=True):
@@ -707,8 +717,11 @@ class BaseGameplayMode:
         assert font is not None, "small font must be loaded before ui text draw"
         draw_small_text(font, text, pos, color)
 
-    def _perk_menu_play_sfx(self) -> Callable[[SfxId], None] | None:
-        return self.audio_bridge.router.play_sfx
+    def _perk_menu_runtime(self) -> PerkMenuRuntime:
+        return _ModePerkMenuRuntime(mode=self)
+
+    def _perk_menu_closed(self) -> None:
+        return None
 
     def _perk_menu_ui_context(self) -> PerkMenuUiContext:
         return PerkMenuUiContext(
@@ -718,7 +731,6 @@ class BaseGameplayMode:
             fx_detail=self.config.display.fx_detail_enabled(level=0, default=False),
             resources=self.render_resources.resources,
             mouse=self._ui_mouse_pos(),
-            play_sfx=self._perk_menu_play_sfx(),
         )
 
     def _open_perk_menu_ui(
@@ -731,7 +743,6 @@ class BaseGameplayMode:
     ) -> None:
         if menu.active:
             return
-        perk_ctx = self._perk_menu_ui_context()
         recorder = getattr(self, "_replay_recorder", None)
         if recorder is not None:
             self._record_replay_checkpoint(max(0, int(recorder.tick_index) - 1), force=True)
@@ -743,7 +754,7 @@ class BaseGameplayMode:
             player_count=int(player_count),
         )
         assert choices, "perk menu open requires prepared perk choices"
-        menu.open_menu(play_sfx=perk_ctx.play_sfx)
+        menu.open_menu()
         self.enqueue_input_command(PerkMenuOpenCommand(player_index=0))
 
     def _ui_mouse_pos(self) -> rl.Vector2:

--- a/src/crimson/modes/components/perk_menu_controller.py
+++ b/src/crimson/modes/components/perk_menu_controller.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 
 import msgspec
 
@@ -28,11 +28,17 @@ from ...ui.perk_menu import (
     perk_menu_panel_slide_x,
 )
 
-PlaySfxFn = Callable[[SfxId], None]
-OnCloseFn = Callable[[], None]
-
 UI_TEXT_COLOR = rl.Color(220, 220, 220, 255)
 UI_SPONSOR_COLOR = rl.Color(255, 255, 255, int(255 * 0.5))
+
+
+class PerkMenuRuntime(msgspec.Struct):
+    def on_close(self) -> None:
+        return None
+
+    def play_sfx(self, sfx_id: SfxId) -> None:
+        _ = sfx_id
+        return None
 
 
 class PerkMenuUiContext(msgspec.Struct, frozen=True):
@@ -42,7 +48,6 @@ class PerkMenuUiContext(msgspec.Struct, frozen=True):
     resources: RuntimeResources
     mouse: rl.Vector2
     fx_detail: bool = False
-    play_sfx: PlaySfxFn | None = None
 
 
 class PerkMenuController:
@@ -52,10 +57,10 @@ class PerkMenuController:
         self,
         *,
         cancel_label: str = "Cancel",
-        on_close: OnCloseFn | None = None,
+        runtime: PerkMenuRuntime | None = None,
     ) -> None:
         self._cancel_label = cancel_label
-        self._on_close = on_close
+        self._runtime = runtime if runtime is not None else PerkMenuRuntime()
         self.reset()
 
     @property
@@ -159,14 +164,12 @@ class PerkMenuController:
         if not self._open:
             return
         self._open = False
-        if self._on_close is not None:
-            self._on_close()
+        self._runtime.on_close()
 
-    def open_menu(self, *, play_sfx: PlaySfxFn | None = None) -> None:
+    def open_menu(self) -> None:
         if self._open:
             return
-        if play_sfx is not None:
-            play_sfx(SfxId.UI_PANELCLICK)
+        self._runtime.play_sfx(SfxId.UI_PANELCLICK)
         self._open = True
         self._selected_index = 0
 
@@ -228,8 +231,7 @@ class PerkMenuController:
             if rect.contains(ctx.mouse):
                 self._selected_index = idx
                 if click:
-                    if ctx.play_sfx is not None:
-                        ctx.play_sfx(SfxId.UI_BUTTONCLICK)
+                    self._runtime.play_sfx(SfxId.UI_BUTTONCLICK)
                     self.close()
                     return int(idx)
                 break
@@ -248,14 +250,12 @@ class PerkMenuController:
             mouse=ctx.mouse,
             click=click,
         ):
-            if ctx.play_sfx is not None:
-                ctx.play_sfx(SfxId.UI_BUTTONCLICK)
+            self._runtime.play_sfx(SfxId.UI_BUTTONCLICK)
             self.close()
             return None
 
         if rl.is_key_pressed(rl.KeyboardKey.KEY_ENTER) or rl.is_key_pressed(rl.KeyboardKey.KEY_SPACE):
-            if ctx.play_sfx is not None:
-                ctx.play_sfx(SfxId.UI_BUTTONCLICK)
+            self._runtime.play_sfx(SfxId.UI_BUTTONCLICK)
             self.close()
             return int(self._selected_index)
         return None

--- a/src/crimson/modes/quest_mode.py
+++ b/src/crimson/modes/quest_mode.py
@@ -115,7 +115,7 @@ class QuestMode(BaseGameplayMode):
         self._outcome: QuestRunOutcome | None = None
         self._grim_mono: GrimMonoFont | None = None
         self._perk_prompt = PerkPromptState()
-        self._perk_menu = PerkMenuController(on_close=self._reset_perk_prompt)
+        self._perk_menu = PerkMenuController(runtime=self._perk_menu_runtime())
         self._quest_spawn_state = QuestSpawnState()
         self._sim_session: DeterministicSession | None = None
         self._replay_recorder: ReplayRecorder | None = None
@@ -169,7 +169,7 @@ class QuestMode(BaseGameplayMode):
             player_count=max(1, len(self.sim_world.players)),
         )
 
-    def _reset_perk_prompt(self) -> None:
+    def _perk_menu_closed(self) -> None:
         self._perk_prompt.reset_if_pending(pending_count=int(self.state.perk_selection.pending_count))
 
     def _update_perk_ui(self, *, dt_ui_ms: float) -> None:

--- a/src/crimson/modes/survival_mode.py
+++ b/src/crimson/modes/survival_mode.py
@@ -79,7 +79,7 @@ class SurvivalMode(BaseGameplayMode):
             audio_rng=audio_rng,
         )
         self._perk_prompt = PerkPromptState()
-        self._perk_menu = PerkMenuController(on_close=self._reset_perk_prompt)
+        self._perk_menu = PerkMenuController(runtime=self._perk_menu_runtime())
         self._hud_fade_ms = PERK_MENU_TRANSITION_MS
         self._cursor_time = 0.0
         self._replay_recorder: ReplayRecorder | None = None
@@ -122,7 +122,7 @@ class SurvivalMode(BaseGameplayMode):
             player_count=max(1, len(self.sim_world.players)),
         )
 
-    def _reset_perk_prompt(self) -> None:
+    def _perk_menu_closed(self) -> None:
         self._perk_prompt.reset_if_pending(pending_count=int(self.state.perk_selection.pending_count))
 
     def _update_perk_ui(

--- a/src/crimson/modes/tutorial_mode.py
+++ b/src/crimson/modes/tutorial_mode.py
@@ -64,7 +64,7 @@ class TutorialMode(BaseGameplayMode):
             audio=audio,
             audio_rng=audio_rng,
         )
-        self._perk_menu = PerkMenuController()
+        self._perk_menu = PerkMenuController(runtime=self._perk_menu_runtime())
 
         self._skip_button = UiButtonState("Skip tutorial", force_wide=True)
         self._play_button = UiButtonState("Play a game", force_wide=True)

--- a/tests/perks/test_perk_menu_controller_sfx.py
+++ b/tests/perks/test_perk_menu_controller_sfx.py
@@ -4,8 +4,10 @@ from collections.abc import Callable
 from types import SimpleNamespace
 from typing import cast
 
+import msgspec
+
 import crimson.modes.components.perk_menu_controller as perk_menu_controller_module
-from crimson.modes.components.perk_menu_controller import PerkMenuController, PerkMenuUiContext
+from crimson.modes.components.perk_menu_controller import PerkMenuController, PerkMenuRuntime, PerkMenuUiContext
 from crimson.perks import PerkId
 from crimson.sim.state_types import PlayerState
 from grim.assets import RuntimeResources
@@ -40,6 +42,17 @@ def _dummy_player() -> PlayerState:
     return player
 
 
+class _RecordingPerkMenuRuntime(PerkMenuRuntime):
+    played: list[SfxId] = msgspec.field(default_factory=list)
+    closed_count: int = 0
+
+    def on_close(self) -> None:
+        self.closed_count += 1
+
+    def play_sfx(self, sfx_id: SfxId) -> None:
+        self.played.append(sfx_id)
+
+
 def _patch_perk_menu_raylib(
     mocker,
     *,
@@ -65,32 +78,31 @@ def _patch_perk_menu_raylib(
     return stub
 
 
-def _ctx(*, play_sfx=None) -> PerkMenuUiContext:
+def _ctx() -> PerkMenuUiContext:
     return PerkMenuUiContext(
         player=_dummy_player(),
         violence_disabled=0,
         preserve_bugs=False,
         resources=_dummy_resources(),
         mouse=rl.Vector2(0.0, 0.0),
-        play_sfx=play_sfx,
     )
 
 
-def test_open_perk_menu_plays_panel_click(mocker) -> None:
-    menu = PerkMenuController()
-    play_sfx = mocker.Mock()
+def test_open_perk_menu_plays_panel_click() -> None:
+    runtime = _RecordingPerkMenuRuntime()
+    menu = PerkMenuController(runtime=runtime)
 
     assert menu.open is False
-    menu.open_menu(play_sfx=play_sfx)
+    menu.open_menu()
     assert menu.open is True
-    play_sfx.assert_called_once_with(SfxId.UI_PANELCLICK)
+    assert runtime.played == [SfxId.UI_PANELCLICK]
 
 
 def test_perk_menu_pick_returns_selected_index_and_plays_button_click(mocker) -> None:
-    menu = PerkMenuController()
+    runtime = _RecordingPerkMenuRuntime()
+    menu = PerkMenuController(runtime=runtime)
     menu.open = True
 
-    play_sfx = mocker.Mock()
     mocker.patch.object(perk_menu_controller_module, "button_update", side_effect=lambda *args, **kwargs: False)
     _patch_perk_menu_raylib(
         mocker,
@@ -98,32 +110,34 @@ def test_perk_menu_pick_returns_selected_index_and_plays_button_click(mocker) ->
     )
 
     choice_index = menu.handle_input(
-        _ctx(play_sfx=play_sfx),
+        _ctx(),
         [PerkId.SHARPSHOOTER],
         dt_ui_ms=0.0,
     )
 
     assert choice_index == 0
-    assert [call.args[0] for call in play_sfx.call_args_list] == [SfxId.UI_BUTTONCLICK]
+    assert runtime.played == [SfxId.UI_BUTTONCLICK]
+    assert runtime.closed_count == 1
     assert menu.open is False
 
 
 def test_perk_menu_cancel_plays_button_click_and_returns_none(mocker) -> None:
-    menu = PerkMenuController()
+    runtime = _RecordingPerkMenuRuntime()
+    menu = PerkMenuController(runtime=runtime)
     menu.open = True
 
-    play_sfx = mocker.Mock()
     mocker.patch.object(perk_menu_controller_module, "button_update", side_effect=lambda *args, **kwargs: True)
     _patch_perk_menu_raylib(mocker)
 
     choice_index = menu.handle_input(
-        _ctx(play_sfx=play_sfx),
+        _ctx(),
         [PerkId.SHARPSHOOTER],
         dt_ui_ms=0.0,
     )
 
     assert choice_index is None
-    play_sfx.assert_called_once_with(SfxId.UI_BUTTONCLICK)
+    assert runtime.played == [SfxId.UI_BUTTONCLICK]
+    assert runtime.closed_count == 1
     assert menu.open is False
 
 


### PR DESCRIPTION
## Summary

- add `PerkMenuRuntime` for controller-owned UI side effects
- move perk menu close handling and button/panel SFX out of constructor/per-call callbacks
- update survival, quest, tutorial, and controller tests to use concrete runtime objects

## Grounding

- This is a presentation/UI cleanup, not a deterministic tick-path change.
- Survival and quest still reset their perk prompt when the menu closes; that policy now lives behind the mode runtime instead of a raw `on_close` callback.
- Panel/button SFX still route through the mode audio bridge, but the controller now calls a named runtime object instead of receiving ad hoc `play_sfx` functions.

## Other cleanup candidates

- `CallbackInputProvider` remains the biggest callback-shaped test helper; replacing it with scenario-specific providers would be the next cleanup if we want to keep going.
- Broader rendering callbacks in `grim.render_pipeline`/render sinks are infrastructure rather than gameplay flow, so I would leave them until there is a renderer-specific reason.

## Validation

- `just check`
- `uv run pytest tests/net/cli/test_zig_net_cli.py::test_zig_net_smoke_rollback_reports_jitter_burst_recovery` (rerun after one transient pre-push failure: `RollbackJitterGuestInputMismatch`)
- `uv run ruff check src/crimson/modes/components/perk_menu_controller.py src/crimson/modes/base_gameplay_mode.py src/crimson/modes/survival_mode.py src/crimson/modes/quest_mode.py src/crimson/modes/tutorial_mode.py tests/perks/test_perk_menu_controller_sfx.py tests/modes/test_perk_prompt_controller.py tests/modes/test_tutorial_mode_replay.py`
- `uv run ty check src/crimson/modes/components/perk_menu_controller.py src/crimson/modes/base_gameplay_mode.py src/crimson/modes/survival_mode.py src/crimson/modes/quest_mode.py src/crimson/modes/tutorial_mode.py tests/perks/test_perk_menu_controller_sfx.py tests/modes/test_perk_prompt_controller.py tests/modes/test_tutorial_mode_replay.py`
- `uv run pytest tests/perks/test_perk_menu_controller_sfx.py tests/modes/test_perk_prompt_controller.py tests/modes/test_tutorial_mode_replay.py tests/modes/test_survival_mode_progression.py tests/modes/test_quest_completion_transition.py tests/replay/test_replay_runners_survival.py tests/replay/test_replay_runners_quest.py`
