### PR TITLE
test: name input provider scenarios

### DIFF
--- a/tests/contracts/test_architecture_contracts.py
+++ b/tests/contracts/test_architecture_contracts.py
@@ -24,10 +24,14 @@ from crimson.sim.frame_pump import advance_tick_runner_frame
 from crimson.sim.hooks import TickResult
 from crimson.sim.input import PlayerInput
 from crimson.sim.input_providers import (
+    FrameContext,
     GameCommand,
+    InputProvider,
+    InputStatus,
     LocalInputProvider,
     PerkPickCommand,
     ResolvedTick,
+    TickSupply,
 )
 from crimson.sim.presentation_step import DeterministicPresentationPlan
 from crimson.sim.sessions import DeterministicSession, DeterministicSessionTick
@@ -41,7 +45,7 @@ from grim.geom import Vec2
 from grim.rand import Crand
 from grim.raylib_api import rl
 from grim.view import ViewContext
-from tests.support.builders.input_providers import CallbackInputProvider, StaticLocalInputRuntime
+from tests.support.builders.input_providers import StaticLocalInputRuntime
 from tests.support.builders.session import make_session
 
 
@@ -68,6 +72,43 @@ class _MockLockstepRuntime:
             for target in self._commands_by_peer_and_tick:
                 self._commands_by_peer_and_tick[target][tick] = list(commands)
         return list(self._commands_by_peer_and_tick[str(peer)].pop(int(tick_index), []))
+
+
+class _LockstepInputProvider(InputProvider):
+    def __init__(
+        self,
+        *,
+        runtime: _MockLockstepRuntime,
+        peer: str,
+        inputs: tuple[PlayerInput, ...],
+        accepts_local_commands: bool = False,
+    ) -> None:
+        self._runtime = runtime
+        self._peer = peer
+        self._inputs = inputs
+        self._accepts_local_commands = accepts_local_commands
+
+    def begin_frame(self, frame_ctx: FrameContext) -> None:
+        _ = frame_ctx
+
+    def pull_tick(self, tick_index: int, default_dt_seconds: float) -> TickSupply:
+        tick = int(tick_index)
+        return TickSupply(
+            status=InputStatus.READY,
+            tick=ResolvedTick(
+                tick_index=tick,
+                dt_seconds=float(default_dt_seconds),
+                inputs=tuple(self._inputs),
+                commands=tuple(self._runtime.pull_commands(peer=self._peer, tick_index=tick)),
+            ),
+        )
+
+    def supports_command_submission(self) -> bool:
+        return bool(self._accepts_local_commands)
+
+    def submit_command(self, command: GameCommand) -> None:
+        if self._accepts_local_commands:
+            self._runtime.submit_local_command(command)
 
 
 def _advance_with_clock(
@@ -145,23 +186,17 @@ def test_contract_1_pure_headless_execution_no_render_or_audio_dependencies(mock
 
 def test_contract_3_lockstep_command_propagation_over_network_provider() -> None:
     runtime = _MockLockstepRuntime()
-    tick_input = [PlayerInput()]
-    host_provider = CallbackInputProvider(
-        resolve_tick=lambda tick, dt: ResolvedTick(
-            tick_index=int(tick),
-            dt_seconds=float(dt),
-            inputs=tuple(tick_input),
-            commands=tuple(runtime.pull_commands(peer="host", tick_index=int(tick))),
-        ),
-        submit_command=runtime.submit_local_command,
+    tick_input = (PlayerInput(),)
+    host_provider = _LockstepInputProvider(
+        runtime=runtime,
+        peer="host",
+        inputs=tick_input,
+        accepts_local_commands=True,
     )
-    client_provider = CallbackInputProvider(
-        resolve_tick=lambda tick, dt: ResolvedTick(
-            tick_index=int(tick),
-            dt_seconds=float(dt),
-            inputs=tuple(tick_input),
-            commands=tuple(runtime.pull_commands(peer="client", tick_index=int(tick))),
-        ),
+    client_provider = _LockstepInputProvider(
+        runtime=runtime,
+        peer="client",
+        inputs=tick_input,
     )
     host_session, _ = make_session(seed=42)
     client_session, _ = make_session(seed=42)

--- a/tests/sim/test_input_normalization_contract.py
+++ b/tests/sim/test_input_normalization_contract.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import pytest
 
 from crimson.sim.input import PlayerInput
-from crimson.sim.input_providers import InputStatus, ResolvedTick
+from crimson.sim.input_providers import InputStatus
 from grim.geom import Vec2
-from tests.support.builders.input_providers import CallbackInputProvider
+from tests.support.builders.input_providers import ReadyTickInputProvider, StalledInputProvider
 
 
 def test_network_provider_stalls_when_runtime_frame_missing() -> None:
-    provider = CallbackInputProvider(resolve_tick=lambda _tick, _dt: None)
+    provider = StalledInputProvider()
 
     tick_input = provider.pull_tick(10, 1.0 / 60.0)
     assert tick_input.status is InputStatus.STALLED
@@ -17,15 +17,11 @@ def test_network_provider_stalls_when_runtime_frame_missing() -> None:
 
 
 def test_network_provider_uses_runtime_resolved_order_without_remerge() -> None:
-    runtime_resolved = [PlayerInput(move=Vec2(3.0, 0.0)), PlayerInput(move=Vec2(4.0, 0.0))]
-    provider = CallbackInputProvider(
-        resolve_tick=lambda tick, dt: ResolvedTick(
-            tick_index=int(tick),
-            dt_seconds=float(dt),
-            inputs=tuple(runtime_resolved),
-            commands=(),
-        ),
+    runtime_resolved = (
+        PlayerInput(move=Vec2(3.0, 0.0)),
+        PlayerInput(move=Vec2(4.0, 0.0)),
     )
+    provider = ReadyTickInputProvider(inputs=runtime_resolved)
 
     tick_input = provider.pull_tick(5, 1.0 / 60.0)
 

--- a/tests/sim/test_input_provider_semantics.py
+++ b/tests/sim/test_input_provider_semantics.py
@@ -14,7 +14,11 @@ from crimson.sim.input_providers import (
     TickSupply,
 )
 from crimson.sim.tick_runner import TickRunner, TickRunnerConfig
-from tests.support.builders.input_providers import CallbackInputProvider, StaticLocalInputRuntime
+from tests.support.builders.input_providers import (
+    ReadyTickInputProvider,
+    StalledInputProvider,
+    StaticLocalInputRuntime,
+)
 from tests.support.builders.session import make_session
 
 _FRAME_CTX = FrameContext(
@@ -54,7 +58,7 @@ def test_local_provider_allows_empty_inputs_for_zero_players() -> None:
 
 
 def test_network_provider_returns_stalled_when_no_inputs() -> None:
-    provider = CallbackInputProvider(resolve_tick=lambda tick, _dt: None)
+    provider = StalledInputProvider()
     provider.begin_frame(_FRAME_CTX)
 
     tick0 = provider.pull_tick(0, _FRAME_CTX.tick_dt_seconds)
@@ -63,14 +67,7 @@ def test_network_provider_returns_stalled_when_no_inputs() -> None:
 
 
 def test_network_provider_returns_resolved_tick_inline() -> None:
-    provider = CallbackInputProvider(
-        resolve_tick=lambda tick, dt: ResolvedTick(
-            tick_index=int(tick),
-            dt_seconds=float(dt),
-            inputs=(PlayerInput(),),
-            commands=(),
-        ),
-    )
+    provider = ReadyTickInputProvider(inputs=(PlayerInput(),))
     provider.begin_frame(_FRAME_CTX)
 
     tick0 = provider.pull_tick(0, _FRAME_CTX.tick_dt_seconds)

--- a/tests/support/builders/input_providers.py
+++ b/tests/support/builders/input_providers.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-
 from crimson.sim.input import PlayerInput
 from crimson.sim.input_providers import (
     FrameContext,
@@ -22,34 +20,53 @@ class StaticLocalInputRuntime(LocalInputRuntime):
         return tuple(self.inputs)
 
 
-class CallbackInputProvider(InputProvider):
+class StalledInputProvider(InputProvider):
+    def begin_frame(self, frame_ctx: FrameContext) -> None:
+        _ = frame_ctx
+
+    def pull_tick(self, tick_index: int, default_dt_seconds: float) -> TickSupply:
+        _ = tick_index, default_dt_seconds
+        return TickSupply(status=InputStatus.STALLED, tick=None)
+
+    def supports_command_submission(self) -> bool:
+        return False
+
+    def submit_command(self, command: GameCommand) -> None:
+        _ = command
+
+
+class ReadyTickInputProvider(InputProvider):
     def __init__(
         self,
         *,
-        resolve_tick: Callable[[int, float], ResolvedTick | None] | None = None,
-        submit_command: Callable[[GameCommand], None] | None = None,
+        inputs: tuple[PlayerInput, ...] = (),
+        commands: tuple[GameCommand, ...] = (),
+        dt_seconds: float | None = None,
     ) -> None:
-        self._resolve_tick = resolve_tick
-        self._submit_command = submit_command
+        self._inputs = inputs
+        self._commands = commands
+        self._dt_seconds = dt_seconds
 
     def begin_frame(self, frame_ctx: FrameContext) -> None:
         _ = frame_ctx
 
     def pull_tick(self, tick_index: int, default_dt_seconds: float) -> TickSupply:
-        if self._resolve_tick is None:
-            return TickSupply(status=InputStatus.STALLED, tick=None)
-        resolved_tick = self._resolve_tick(int(tick_index), float(default_dt_seconds))
-        if resolved_tick is None:
-            return TickSupply(status=InputStatus.STALLED, tick=None)
-        return TickSupply(status=InputStatus.READY, tick=resolved_tick)
+        dt_seconds = float(default_dt_seconds) if self._dt_seconds is None else float(self._dt_seconds)
+        return TickSupply(
+            status=InputStatus.READY,
+            tick=ResolvedTick(
+                tick_index=int(tick_index),
+                dt_seconds=dt_seconds,
+                inputs=tuple(self._inputs),
+                commands=tuple(self._commands),
+            ),
+        )
 
     def supports_command_submission(self) -> bool:
-        return self._submit_command is not None
+        return False
 
     def submit_command(self, command: GameCommand) -> None:
-        submit_command = self._submit_command
-        if submit_command is not None:
-            submit_command(command)
+        _ = command
 
 
 class StallableInputProvider(InputProvider):


### PR DESCRIPTION
## Summary

- replace the generic callback-backed input provider test helper with named stalled and ready-tick scenarios
- move the lockstep command propagation contract onto a concrete test provider that owns peer/runtime behavior directly
- update input provider tests to describe their runtime scenario without lambda callbacks

## Verification

- `uv run ruff check tests/support/builders/input_providers.py tests/sim/test_input_normalization_contract.py tests/sim/test_input_provider_semantics.py tests/contracts/test_architecture_contracts.py`
- `uv run ty check tests/support/builders/input_providers.py tests/sim/test_input_normalization_contract.py tests/sim/test_input_provider_semantics.py tests/contracts/test_architecture_contracts.py`
- `uv run pytest tests/sim/test_input_normalization_contract.py tests/sim/test_input_provider_semantics.py tests/contracts/test_architecture_contracts.py`
- `just check`

## Follow-ups

- `tests/support/builders/runners.py` still has a callback-backed fake runner that can become named runner scenario objects.
- `tests/support/replay_runner_helpers.py` still exposes replay progress/observer callbacks; that likely wants a small observer runtime object.
- `tests/support/factories.py` still has projectile presentation callbacks; that should be cleaned up carefully around the original-parity hit presentation phases.
