### PR TITLE
refactor: replace replay walk callbacks

### DIFF
--- a/src/crimson/cli/replay.py
+++ b/src/crimson/cli/replay.py
@@ -1604,12 +1604,15 @@ def cmd_replay_verify_checkpoints(
     from ..dbg.checkpoint_diff import compare_checkpoints
     from ..replay import ReplayCodecError, ReplayGameVersionError, load_replay
     from ..replay.checkpoints import (
+        ReplayCheckpoint,
         ReplayCheckpointsError,
         default_checkpoints_path,
         load_checkpoints_file,
     )
-    from ..replay.driver.playback_driver import PlaybackWalkHooks, build_verify_playback_driver
+    from ..replay.driver.playback_driver import PlaybackDriver, PlaybackWalkObserver, build_verify_playback_driver
     from ..replay.driver.setup import ReplayRunnerError
+    from ..sim.hooks import TickResult
+    from ..sim.world_state import WorldState
 
     replay_path, tried = _resolve_replay_path(replay_file, base_dir=base_dir)
     if not replay_path.is_file():
@@ -1641,7 +1644,18 @@ def cmd_replay_verify_checkpoints(
         raise typer.Exit(code=1) from exc
 
     checkpoint_ticks = {int(ckpt.tick_index) for ckpt in expected.checkpoints}
-    actual = []
+    actual: list[ReplayCheckpoint] = []
+
+    class _CheckpointVerifyObserver(PlaybackWalkObserver):
+        driver: PlaybackDriver
+        checkpoint_ticks: set[int]
+        actual: list[ReplayCheckpoint]
+
+        def after_tick(self, tick_result: TickResult, world: WorldState) -> None:
+            _ = world
+            tick_index = int(tick_result.source_tick.tick_index)
+            if tick_index in self.checkpoint_ticks:
+                self.actual.append(self.driver.build_checkpoint(tick_result=tick_result))
 
     try:
         driver = build_verify_playback_driver(
@@ -1650,13 +1664,12 @@ def cmd_replay_verify_checkpoints(
             trace_rng=bool(trace_rng),
         )
 
-        def _after_tick(tick_result, _world) -> None:
-            tick_index = int(tick_result.source_tick.tick_index)
-            if tick_index in checkpoint_ticks:
-                actual.append(driver.build_checkpoint(tick_result=tick_result))
-
         result = driver.run(
-            hooks=PlaybackWalkHooks(after_tick=_after_tick),
+            observer=_CheckpointVerifyObserver(
+                driver=driver,
+                checkpoint_ticks=checkpoint_ticks,
+                actual=actual,
+            ),
         )
     except (ReplayGameVersionError, ReplayRunnerError) as exc:
         typer.echo(f"replay verification failed: {exc}", err=True)

--- a/src/crimson/dbg/record.py
+++ b/src/crimson/dbg/record.py
@@ -14,8 +14,9 @@ from grim.rand import RecordedCallerStatic
 from ..math_parity import f32
 from ..replay import load_replay_file
 from ..replay.checkpoints import ReplayCheckpoint
-from ..replay.driver.playback_driver import PlaybackWalkHooks, build_verify_playback_driver
+from ..replay.driver.playback_driver import PlaybackWalkObserver, RngTraceDraw, build_verify_playback_driver
 from ..replay.types import Replay
+from ..sim.hooks import TickResult
 from ..sim.step_pipeline import time_scale_reflex_boost_factor
 from ..sim.timing import ftol_ms_i32
 from ..sim.world_state import WorldState
@@ -390,30 +391,6 @@ def _record_replay_to_trace_python(
     secondary_state = _EntityGenerationState()
     bonus_state = _EntityGenerationState()
 
-    def _tick_observer(tick_index: int, world: WorldState) -> None:
-        entity_samples_by_tick[tick_index] = _entity_samples_for_world(
-            world,
-            creature_state=creature_state,
-            projectile_state=projectile_state,
-            secondary_state=secondary_state,
-            bonus_state=bonus_state,
-        )
-        sim_state_by_tick[tick_index] = _sim_state_from_world(world, replay=replay)
-
-    def _tick_rng_trace_observer(tick_index: int, draws: list[tuple[int, int, int, RecordedCallerStatic]]) -> None:
-        rng_stream_by_tick[int(tick_index)] = _rng_stream_from_draws(draws)
-
-    def _before_tick(tick_index: int, world: WorldState, dt: float) -> None:
-        dt_ms_i32 = int(ftol_ms_i32(dt))
-        if dt_ms_i32 < 0:
-            raise ValueError(f"invalid replay dt_ms_i32 at tick {tick_index}: {dt_ms_i32}")
-        timing_samples_by_tick[int(tick_index)] = _timing_samples_for_tick(
-            tick_index=int(tick_index),
-            dt=float(dt),
-            dt_ms_i32=dt_ms_i32,
-            world=world,
-        )
-
     driver = build_verify_playback_driver(
         replay,
         max_ticks=None,
@@ -421,24 +398,36 @@ def _record_replay_to_trace_python(
         strict_rng_trace=True,
     )
 
-    def _after_tick(tick_result, world: WorldState) -> None:
-        tick_index = int(tick_result.source_tick.tick_index)
-        if tick_index in checkpoint_ticks:
-            checkpoints.append(driver.build_checkpoint(tick_result=tick_result))
-        _tick_observer(tick_index, world)
+    class _ReplayRecordObserver(PlaybackWalkObserver):
+        def before_tick(self, tick_index: int, world: WorldState, dt_tick: float) -> None:
+            dt_ms_i32 = int(ftol_ms_i32(dt_tick))
+            if dt_ms_i32 < 0:
+                raise ValueError(f"invalid replay dt_ms_i32 at tick {tick_index}: {dt_ms_i32}")
+            timing_samples_by_tick[int(tick_index)] = _timing_samples_for_tick(
+                tick_index=int(tick_index),
+                dt=float(dt_tick),
+                dt_ms_i32=dt_ms_i32,
+                world=world,
+            )
 
-    def _on_rng_trace(tick_result, draws: tuple[tuple[int, int, int, RecordedCallerStatic], ...]) -> None:
-        _tick_rng_trace_observer(
-            int(tick_result.source_tick.tick_index),
-            list(draws),
-        )
+        def after_tick(self, tick_result: TickResult, world: WorldState) -> None:
+            tick_index = int(tick_result.source_tick.tick_index)
+            if tick_index in checkpoint_ticks:
+                checkpoints.append(driver.build_checkpoint(tick_result=tick_result))
+            entity_samples_by_tick[tick_index] = _entity_samples_for_world(
+                world,
+                creature_state=creature_state,
+                projectile_state=projectile_state,
+                secondary_state=secondary_state,
+                bonus_state=bonus_state,
+            )
+            sim_state_by_tick[tick_index] = _sim_state_from_world(world, replay=replay)
+
+        def rng_trace(self, tick_result: TickResult, draws: tuple[RngTraceDraw, ...]) -> None:
+            rng_stream_by_tick[int(tick_result.source_tick.tick_index)] = _rng_stream_from_draws(list(draws))
 
     driver.run(
-        hooks=PlaybackWalkHooks(
-            before_tick=_before_tick,
-            after_tick=_after_tick,
-            on_rng_trace=_on_rng_trace,
-        ),
+        observer=_ReplayRecordObserver(),
     )
 
     tick_rows: list[TickRecord] = []

--- a/src/crimson/replay/driver/playback_driver.py
+++ b/src/crimson/replay/driver/playback_driver.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeAlias
+
+import msgspec
 
 from crimson.quests.level import QuestLevel
 from grim.rand import CallerStatic, CrtRand, RecordedCallerStatic, RngTraceSink
@@ -49,13 +50,6 @@ from .setup import (
 )
 
 RngTraceDraw: TypeAlias = tuple[int, int, int, RecordedCallerStatic]
-TickRngTraceObserver: TypeAlias = Callable[[TickResult, tuple[RngTraceDraw, ...]], None]
-TickProgressCallback: TypeAlias = Callable[[int], None]
-TickBeginObserver: TypeAlias = Callable[
-    [int, WorldState, float],
-    None,
-]
-TickEndObserver: TypeAlias = Callable[[TickResult, WorldState], None]
 
 
 def require_quest_level_from_replay(replay: Replay) -> QuestLevel:
@@ -108,16 +102,21 @@ def _tick_rng_trace(rng: object, *, enabled: bool, strict: bool = False) -> Iter
         rng.set_trace_sink(previous_sink, require_caller=bool(previous_require_caller))
 
 
-@dataclass(slots=True, frozen=True)
-class PlaybackWalkHooks:
-    before_tick: TickBeginObserver | None = None
-    after_tick: TickEndObserver | None = None
-    on_progress: TickProgressCallback | None = None
-    on_rng_trace: TickRngTraceObserver | None = None
+class PlaybackWalkObserver(msgspec.Struct):
+    def before_tick(self, tick_index: int, world: WorldState, dt_tick: float) -> None:
+        _ = tick_index, world, dt_tick
+
+    def after_tick(self, tick_result: TickResult, world: WorldState) -> None:
+        _ = tick_result, world
+
+    def rng_trace(self, tick_result: TickResult, draws: tuple[RngTraceDraw, ...]) -> None:
+        _ = tick_result, draws
+
+    def progress(self, next_tick_index: int) -> None:
+        _ = next_tick_index
 
 
-@dataclass(slots=True, frozen=True)
-class PlaybackWalkResult:
+class PlaybackWalkResult(msgspec.Struct, frozen=True):
     start_tick: int
     next_tick_index: int
     ticks_completed: int
@@ -453,7 +452,7 @@ class PlaybackDriver:
         *,
         start_tick: int = 0,
         stop_tick: int | None = None,
-        hooks: PlaybackWalkHooks | None = None,
+        observer: PlaybackWalkObserver | None = None,
     ) -> PlaybackWalkResult:
         requested_start_tick = int(start_tick)
         if requested_start_tick < 0:
@@ -467,24 +466,20 @@ class PlaybackDriver:
         tick_limit = int(self.tick_limit)
         next_tick_index = min(requested_start_tick, tick_limit)
         stop_tick_index = min(requested_stop_tick, tick_limit)
-        active_hooks = hooks if hooks is not None else PlaybackWalkHooks()
+        active_observer = observer if observer is not None else PlaybackWalkObserver()
 
         while next_tick_index < stop_tick_index:
-            if active_hooks.before_tick is not None:
-                active_hooks.before_tick(
-                    int(next_tick_index),
-                    self.world,
-                    float(self.replay.ticks[next_tick_index].dt),
-                )
+            active_observer.before_tick(
+                int(next_tick_index),
+                self.world,
+                float(self.replay.ticks[next_tick_index].dt),
+            )
             tick_result = self.step_tick(next_tick_index)
             next_tick_index = int(tick_result.source_tick.tick_index) + 1
 
-            if active_hooks.after_tick is not None:
-                active_hooks.after_tick(tick_result, self.world)
-            if active_hooks.on_rng_trace is not None:
-                active_hooks.on_rng_trace(tick_result, self._last_tick_rng_rows)
-            if active_hooks.on_progress is not None:
-                active_hooks.on_progress(int(next_tick_index))
+            active_observer.after_tick(tick_result, self.world)
+            active_observer.rng_trace(tick_result, self._last_tick_rng_rows)
+            active_observer.progress(int(next_tick_index))
 
         return PlaybackWalkResult(
             start_tick=min(requested_start_tick, tick_limit),
@@ -495,12 +490,12 @@ class PlaybackDriver:
     def run(
         self,
         *,
-        hooks: PlaybackWalkHooks | None = None,
+        observer: PlaybackWalkObserver | None = None,
     ) -> RunResult:
         self.walk_ticks(
             start_tick=0,
             stop_tick=int(self.tick_limit),
-            hooks=hooks,
+            observer=observer,
         )
         return self.build_run_result(ticks=int(self.tick_limit))
 

--- a/src/crimson/replay/driver/replay_benchmark.py
+++ b/src/crimson/replay/driver/replay_benchmark.py
@@ -20,7 +20,7 @@ from grim.view import ViewContext
 
 from ...modes.replay_playback_mode import ReplayPlaybackMode
 from ...replay import Replay
-from .playback_driver import PlaybackWalkHooks, build_verify_playback_driver
+from .playback_driver import PlaybackWalkObserver, build_verify_playback_driver
 from .render_telemetry import RenderTelemetryFrameSnapshot, RenderTelemetrySession
 from .render_telemetry_charts import write_render_telemetry_charts
 from .setup import RunResult
@@ -35,6 +35,19 @@ class _ProgressBarLike(Protocol):
     def set_postfix_str(self, s: str, refresh: bool = True) -> None: ...
 
     def close(self) -> None: ...
+
+
+class _TickProgressObserver(PlaybackWalkObserver):
+    tick_progress_bar: _ProgressBarLike
+    tick_total: int
+    completed_ticks: int = 0
+
+    def progress(self, next_tick_index: int) -> None:
+        target_tick = max(0, min(int(self.tick_total), int(next_tick_index)))
+        if target_tick <= int(self.completed_ticks):
+            return
+        self.tick_progress_bar.update(target_tick - int(self.completed_ticks))
+        self.completed_ticks = target_tick
 
 
 class _ProfileStatsLike(Protocol):
@@ -462,8 +475,7 @@ def run_replay_benchmark(
 
         def _run_once_with_tick_progress(*, tick_desc: str) -> RunResult:
             tick_progress: _ProgressBarLike | None = None
-            completed_ticks = 0
-            tick_callback: Callable[[int], None] | None = None
+            tick_observer: _TickProgressObserver | None = None
             completed_run = False
             if bool(show_progress) and tick_total > 0:
                 tick_progress_bar = cast(
@@ -476,16 +488,10 @@ def run_replay_benchmark(
                     ),
                 )
                 tick_progress = tick_progress_bar
-
-                def _on_tick(tick_index: int) -> None:
-                    nonlocal completed_ticks
-                    target_tick = max(0, min(tick_total, int(tick_index)))
-                    if target_tick <= completed_ticks:
-                        return
-                    tick_progress_bar.update(target_tick - completed_ticks)
-                    completed_ticks = target_tick
-
-                tick_callback = _on_tick
+                tick_observer = _TickProgressObserver(
+                    tick_progress_bar=tick_progress_bar,
+                    tick_total=tick_total,
+                )
 
             try:
                 driver = build_verify_playback_driver(
@@ -494,12 +500,13 @@ def run_replay_benchmark(
                     trace_rng=bool(trace_rng),
                 )
                 result = driver.run(
-                    hooks=PlaybackWalkHooks(on_progress=tick_callback),
+                    observer=tick_observer,
                 )
                 completed_run = True
                 return result
             finally:
                 if tick_progress is not None:
+                    completed_ticks = 0 if tick_observer is None else int(tick_observer.completed_ticks)
                     if completed_run and completed_ticks < tick_total:
                         tick_progress.update(tick_total - completed_ticks)
                     tick_progress.close()

--- a/src/crimson/replay/driver/replay_info.py
+++ b/src/crimson/replay/driver/replay_info.py
@@ -20,7 +20,7 @@ from ...sim.input_providers import (
 )
 from ...sim.state_types import BonusPickupEvent, PlayerState
 from ...weapons import WeaponId, weapon_display_name
-from .playback_driver import PlaybackDriver, PlaybackWalkHooks
+from .playback_driver import PlaybackDriver, PlaybackWalkObserver
 from .setup import ReplayRunnerError
 
 _EPSILON = 1e-6
@@ -382,7 +382,6 @@ def collect_replay_info(
     mode = driver.mode_id
     player_filter = _validate_player_filter(replay=replay, player_index=player_index)
     timeline: list[ReplayInfoTimelineEvent] = []
-    before: list[_PlayerSnapshot] | None = None
 
     def _append_tick(tick_result: TickResult, *, after_players: list[PlayerState], before: list[_PlayerSnapshot]) -> None:
         source_tick = tick_result.source_tick
@@ -435,19 +434,20 @@ def collect_replay_info(
             include_extra_events=include_extra_events,
         )
 
-    def _before_tick(_tick_index: int, world, _dt_tick: float) -> None:
-        nonlocal before
-        before = _capture_snapshots(world.players)
+    class _ReplayInfoWalkObserver(PlaybackWalkObserver):
+        before: list[_PlayerSnapshot] | None = None
 
-    def _after_tick(tick_result: TickResult, world) -> None:
-        assert before is not None, "missing pre-step replay snapshot"
-        _append_tick(tick_result, after_players=world.players, before=before)
+        def before_tick(self, tick_index: int, world, dt_tick: float) -> None:
+            _ = tick_index, dt_tick
+            self.before = _capture_snapshots(world.players)
+
+        def after_tick(self, tick_result: TickResult, world) -> None:
+            before_snapshot = self.before
+            assert before_snapshot is not None, "missing pre-step replay snapshot"
+            _append_tick(tick_result, after_players=world.players, before=before_snapshot)
 
     walk_result = driver.walk_ticks(
-        hooks=PlaybackWalkHooks(
-            before_tick=_before_tick,
-            after_tick=_after_tick,
-        ),
+        observer=_ReplayInfoWalkObserver(),
     )
     run_result = driver.build_run_result(ticks=int(walk_result.ticks_completed))
 

--- a/tests/debug/test_dbg_record.py
+++ b/tests/debug/test_dbg_record.py
@@ -124,7 +124,7 @@ def test_record_replay_to_trace_python_writes_unattributed_rows(
                 deaths=[],
             )
 
-        def run(self, *, hooks):
+        def run(self, *, observer):
             tick_result = SimpleNamespace(source_tick=SimpleNamespace(tick_index=0))
             world = SimpleNamespace(
                 state=SimpleNamespace(
@@ -132,15 +132,12 @@ def test_record_replay_to_trace_python_writes_unattributed_rows(
                     bonuses=SimpleNamespace(reflex_boost=0.0),
                 ),
             )
-            if hooks.before_tick is not None:
-                hooks.before_tick(0, world, 0.016)
-            if hooks.after_tick is not None:
-                hooks.after_tick(tick_result, world)
-                if hooks.on_rng_trace is not None:
-                    hooks.on_rng_trace(
-                        tick_result,
-                        ((0x90ABCDEF, 28052, 0xED9D2340, None),),
-                    )
+            observer.before_tick(0, world, 0.016)
+            observer.after_tick(tick_result, world)
+            observer.rng_trace(
+                tick_result,
+                ((0x90ABCDEF, 28052, 0xED9D2340, None),),
+            )
             return SimpleNamespace()
 
     monkeypatch.setattr(dbg_record, "load_replay_file", lambda _path: replay)

--- a/tests/replay/test_playback_driver_walk.py
+++ b/tests/replay/test_playback_driver_walk.py
@@ -3,15 +3,45 @@ from __future__ import annotations
 import pytest
 
 from crimson.replay.driver.playback_driver import (
-    PlaybackWalkHooks,
+    PlaybackWalkObserver,
     PlaybackWalkResult,
     build_verify_playback_driver,
 )
 from crimson.replay.driver.setup import ReplayRunnerError
+from crimson.sim.hooks import TickResult
+from crimson.sim.world_state import WorldState
 from tests.support.replay_runner_helpers import _blank_survival_replay
 
 
-def test_playback_driver_walk_before_and_after_hooks_see_pre_and_post_step_world(mocker) -> None:
+class _ExperienceWalkObserver(PlaybackWalkObserver):
+    observed_before: list[int]
+    observed_after: list[int]
+
+    def before_tick(self, tick_index: int, world: WorldState, dt_tick: float) -> None:
+        _ = tick_index, dt_tick
+        self.observed_before.append(int(world.players[0].experience))
+
+    def after_tick(self, tick_result: TickResult, world: WorldState) -> None:
+        _ = tick_result
+        self.observed_after.append(int(world.players[0].experience))
+
+
+class _ProgressObserver(PlaybackWalkObserver):
+    progress_ticks: list[int]
+
+    def progress(self, next_tick_index: int) -> None:
+        self.progress_ticks.append(int(next_tick_index))
+
+
+class _WalkedTickObserver(PlaybackWalkObserver):
+    walked_ticks: list[int]
+
+    def after_tick(self, tick_result: TickResult, world: WorldState) -> None:
+        _ = world
+        self.walked_ticks.append(int(tick_result.source_tick.tick_index))
+
+
+def test_playback_driver_walk_observer_sees_pre_and_post_step_world(mocker) -> None:
     _header, rec = _blank_survival_replay(ticks=1, seed=0x1234)
     replay = rec.finish()
     driver = build_verify_playback_driver(replay)
@@ -27,9 +57,9 @@ def test_playback_driver_walk_before_and_after_hooks_see_pre_and_post_step_world
     mocker.patch.object(driver, "step_tick", side_effect=_step_tick_with_mutation)
 
     walk_result = driver.walk_ticks(
-        hooks=PlaybackWalkHooks(
-            before_tick=lambda _tick_index, world, _dt_tick: observed_before.append(int(world.players[0].experience)),
-            after_tick=lambda _tick_result, world: observed_after.append(int(world.players[0].experience)),
+        observer=_ExperienceWalkObserver(
+            observed_before=observed_before,
+            observed_after=observed_after,
         ),
     )
 
@@ -47,7 +77,7 @@ def test_playback_driver_walk_progress_uses_absolute_completed_tick_indexes() ->
     walk_result = driver.walk_ticks(
         start_tick=1,
         stop_tick=3,
-        hooks=PlaybackWalkHooks(on_progress=progress_ticks.append),
+        observer=_ProgressObserver(progress_ticks=progress_ticks),
     )
 
     assert walk_result == PlaybackWalkResult(start_tick=1, next_tick_index=3, ticks_completed=2)
@@ -63,9 +93,7 @@ def test_playback_driver_walk_clamps_ranges_to_tick_limit() -> None:
     walk_result = driver.walk_ticks(
         start_tick=2,
         stop_tick=10,
-        hooks=PlaybackWalkHooks(
-            after_tick=lambda tick_result, _world: walked_ticks.append(int(tick_result.source_tick.tick_index)),
-        ),
+        observer=_WalkedTickObserver(walked_ticks=walked_ticks),
     )
 
     assert walk_result == PlaybackWalkResult(start_tick=2, next_tick_index=3, ticks_completed=1)

--- a/tests/replay/test_replay_fixture_integrations.py
+++ b/tests/replay/test_replay_fixture_integrations.py
@@ -6,11 +6,14 @@ import pytest
 
 from crimson.dbg.checkpoint_diff import compare_checkpoints
 from crimson.replay import load_replay_file
-from crimson.replay.checkpoints import load_checkpoints_file
+from crimson.replay.checkpoints import ReplayCheckpoint, load_checkpoints_file
 from crimson.replay.driver.playback_driver import (
-    PlaybackWalkHooks,
+    PlaybackDriver,
+    PlaybackWalkObserver,
     build_verify_playback_driver,
 )
+from crimson.sim.hooks import TickResult
+from crimson.sim.world_state import WorldState
 from tests.support.replay_runner_helpers import _run_verify_playback
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "replays"
@@ -46,6 +49,17 @@ def _build_verify_driver(*, replay):
     )
 
 
+class _CheckpointObserver(PlaybackWalkObserver):
+    driver: PlaybackDriver
+    checkpoint_ticks: set[int]
+    checkpoints: list[ReplayCheckpoint]
+
+    def after_tick(self, tick_result: TickResult, world: WorldState) -> None:
+        _ = world
+        if int(tick_result.source_tick.tick_index) in self.checkpoint_ticks:
+            self.checkpoints.append(self.driver.build_checkpoint(tick_result=tick_result))
+
+
 def _run_walk_playback(
     *,
     replay,
@@ -61,14 +75,14 @@ def _run_walk_playback(
         chunk_size = int(_PLAYBACK_CHUNK_PATTERN[chunk_index % len(_PLAYBACK_CHUNK_PATTERN)])
         chunk_end = min(tick_limit, tick_index + chunk_size)
 
-        def _after_tick(tick_result, _world) -> None:
-            if int(tick_result.source_tick.tick_index) in checkpoint_ticks:
-                playback_checkpoints.append(driver.build_checkpoint(tick_result=tick_result))
-
         walk_result = driver.walk_ticks(
             start_tick=tick_index,
             stop_tick=chunk_end,
-            hooks=PlaybackWalkHooks(after_tick=_after_tick),
+            observer=_CheckpointObserver(
+                driver=driver,
+                checkpoint_ticks=checkpoint_ticks,
+                checkpoints=playback_checkpoints,
+            ),
         )
         tick_index = int(walk_result.next_tick_index)
         chunk_index += 1

--- a/tests/replay/test_replay_runners_quest.py
+++ b/tests/replay/test_replay_runners_quest.py
@@ -7,10 +7,12 @@ from crimson.quests import quest_by_level
 from crimson.quests.level import QuestLevel
 from crimson.quests.runtime import build_quest_spawn_table
 from crimson.quests.types import QuestContext
-from crimson.replay.driver.playback_driver import PlaybackWalkHooks, build_verify_playback_driver
+from crimson.replay.driver.playback_driver import PlaybackWalkObserver, build_verify_playback_driver
 from crimson.rng_caller_static import RngCallerStatic
 from crimson.sim.bootstrap import advance_explicit_terrain, advance_unlock_terrain
+from crimson.sim.hooks import TickResult
 from crimson.sim.input_providers import PerkPickCommand
+from crimson.sim.world_state import WorldState
 from crimson.weapons import WEAPON_BY_ID
 from grim.rand import Crand
 from tests.support.replay_runner_helpers import (
@@ -19,6 +21,19 @@ from tests.support.replay_runner_helpers import (
     _quest_spawn_entries,
     _run_verify_playback,
 )
+
+
+class _ExperienceWalkObserver(PlaybackWalkObserver):
+    observed_before: list[int]
+    observed_after: list[int]
+
+    def before_tick(self, tick_index: int, world: WorldState, dt_tick: float) -> None:
+        _ = tick_index, dt_tick
+        self.observed_before.append(int(world.players[0].experience))
+
+    def after_tick(self, tick_result: TickResult, world: WorldState) -> None:
+        _ = tick_result
+        self.observed_after.append(int(world.players[0].experience))
 
 
 def test_quest_runner_is_deterministic() -> None:
@@ -178,9 +193,9 @@ def test_playback_driver_tick_begin_observer_runs_before_step(mocker) -> None:
     mocker.patch.object(driver, "step_tick", side_effect=_step_tick_with_mutation)
 
     driver.run(
-        hooks=PlaybackWalkHooks(
-            before_tick=lambda _tick_index, world, _dt_tick: observed_before.append(int(world.players[0].experience)),
-            after_tick=lambda _tick_result, world: observed_after.append(int(world.players[0].experience)),
+        observer=_ExperienceWalkObserver(
+            observed_before=observed_before,
+            observed_after=observed_after,
         ),
     )
 

--- a/tests/replay/test_replay_runners_rush.py
+++ b/tests/replay/test_replay_runners_rush.py
@@ -4,8 +4,7 @@ import msgspec
 
 from crimson.game_modes import GameMode
 from crimson.sim.input_providers import PerkPickCommand
-from grim.rand import CallerStatic
-from tests.support.replay_runner_helpers import _blank_rush_replay, _run_verify_playback
+from tests.support.replay_runner_helpers import ReplayRngTraceRecorder, _blank_rush_replay, _run_verify_playback
 
 
 def test_rush_runner_is_deterministic() -> None:
@@ -83,16 +82,13 @@ def test_rush_runner_checkpoints_capture_debug_fields() -> None:
 def test_rush_runner_tick_rng_trace_observer_emits_rows_for_first_tick() -> None:
     _header, rec = _blank_rush_replay(ticks=1, seed=0x1234)
     replay = rec.finish()
-    rows_by_tick: dict[int, list[tuple[int, int, int, CallerStatic]]] = {}
-
-    def _observer(tick_index: int, draws: list[tuple[int, int, int, CallerStatic]]) -> None:
-        rows_by_tick[int(tick_index)] = list(draws)
+    observer = ReplayRngTraceRecorder(rows_by_tick={})
 
     _run_verify_playback(
         replay,
         trace_rng=True,
-        tick_rng_trace_observer=_observer,
+        observer=observer,
     )
 
-    assert sorted(rows_by_tick.keys()) == [0]
-    assert rows_by_tick[0]
+    assert sorted(observer.rows_by_tick.keys()) == [0]
+    assert observer.rows_by_tick[0]

--- a/tests/replay/test_replay_runners_survival.py
+++ b/tests/replay/test_replay_runners_survival.py
@@ -8,7 +8,11 @@ from crimson.rng_caller_static import RngCallerStatic
 from crimson.sim.bootstrap import advance_unlock_terrain
 from crimson.sim.input_providers import PerkMenuOpenCommand, PerkPickCommand
 from grim.rand import CallerStatic, Crand
-from tests.support.replay_runner_helpers import _blank_survival_replay, _run_verify_playback
+from tests.support.replay_runner_helpers import (
+    ReplayRngTraceRecorder,
+    _blank_survival_replay,
+    _run_verify_playback,
+)
 
 
 def test_survival_runner_is_deterministic() -> None:
@@ -120,38 +124,32 @@ def test_survival_runner_checkpoints_capture_debug_fields() -> None:
 def test_survival_runner_tick_rng_trace_observer_emits_rows_for_first_tick() -> None:
     _header, rec = _blank_survival_replay(ticks=1, seed=0x1234)
     replay = rec.finish()
-    rows_by_tick: dict[int, list[tuple[int, int, int, CallerStatic]]] = {}
-
-    def _observer(tick_index: int, draws: list[tuple[int, int, int, CallerStatic]]) -> None:
-        rows_by_tick[int(tick_index)] = list(draws)
+    observer = ReplayRngTraceRecorder(rows_by_tick={})
 
     _run_verify_playback(
         replay,
         trace_rng=True,
-        tick_rng_trace_observer=_observer,
+        observer=observer,
     )
 
-    assert sorted(rows_by_tick.keys()) == [0]
-    assert rows_by_tick[0]
+    assert sorted(observer.rows_by_tick.keys()) == [0]
+    assert observer.rows_by_tick[0]
 
 
 def test_survival_runner_tick_rng_trace_observer_emits_draw_rows() -> None:
     _header, rec = _blank_survival_replay(ticks=3, seed=0x1234)
     replay = rec.finish()
-    rows_by_tick: dict[int, list[tuple[int, int, int, CallerStatic]]] = {}
-
-    def _observer(tick_index: int, draws: list[tuple[int, int, int, CallerStatic]]) -> None:
-        rows_by_tick[int(tick_index)] = list(draws)
+    observer = ReplayRngTraceRecorder(rows_by_tick={})
 
     _run_verify_playback(
         replay,
         trace_rng=True,
-        tick_rng_trace_observer=_observer,
+        observer=observer,
     )
 
-    assert sorted(rows_by_tick.keys()) == [0, 1, 2]
+    assert sorted(observer.rows_by_tick.keys()) == [0, 1, 2]
     tagged_by_tick: dict[int, list[CallerStatic]] = {}
-    for tick_index, draws in sorted(rows_by_tick.items()):
+    for tick_index, draws in sorted(observer.rows_by_tick.items()):
         tagged_callers: list[CallerStatic] = []
         for state_before_u32, value_15, state_after_u32, caller in draws:
             expected_after = (int(state_before_u32) * 214013 + 2531011) & 0xFFFFFFFF

--- a/tests/support/replay_runner_helpers.py
+++ b/tests/support/replay_runner_helpers.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-
 from crimson.game_modes import GameMode
 from crimson.quests import quest_by_level
 from crimson.quests.level import QuestLevel
@@ -9,14 +7,20 @@ from crimson.quests.runtime import build_quest_spawn_table
 from crimson.quests.types import QuestContext
 from crimson.replay import ReplayHeader, ReplayRecorder
 from crimson.replay.checkpoints import ReplayCheckpoint
-from crimson.replay.driver.playback_driver import PlaybackWalkHooks, build_verify_playback_driver
+from crimson.replay.driver.playback_driver import (
+    PlaybackDriver,
+    PlaybackWalkObserver,
+    RngTraceDraw,
+    build_verify_playback_driver,
+)
 from crimson.replay.driver.replay_info import ReplayInfoResult, collect_replay_info
 from crimson.replay.driver.setup import RunResult
 from crimson.replay.types import current_replay_game_version
+from crimson.sim.hooks import TickResult
 from crimson.sim.input import PlayerInput
 from crimson.sim.world_state import WorldState
 from grim.geom import Vec2
-from grim.rand import CallerStatic, Crand
+from grim.rand import Crand
 
 
 def _blank_survival_replay(
@@ -120,6 +124,47 @@ def _quest_spawn_entries(level: str = "1.1", *, player_count: int = 1, seed: int
     )
 
 
+class ReplayRngTraceRecorder(PlaybackWalkObserver):
+    rows_by_tick: dict[int, list[RngTraceDraw]]
+
+    def rng_trace(self, tick_result: TickResult, draws: tuple[RngTraceDraw, ...]) -> None:
+        self.rows_by_tick[int(tick_result.source_tick.tick_index)] = list(draws)
+
+
+class _VerifyPlaybackObserver(PlaybackWalkObserver):
+    driver: PlaybackDriver
+    checkpoints_out: list[ReplayCheckpoint] | None = None
+    checkpoint_ticks: set[int] | None = None
+    checkpoint_use_world_step_creature_count: bool = False
+    observer: PlaybackWalkObserver | None = None
+
+    def before_tick(self, tick_index: int, world: WorldState, dt_tick: float) -> None:
+        if self.observer is not None:
+            self.observer.before_tick(int(tick_index), world, float(dt_tick))
+
+    def after_tick(self, tick_result: TickResult, world: WorldState) -> None:
+        checkpoints_out = self.checkpoints_out
+        checkpoint_ticks = self.checkpoint_ticks
+        tick_index = int(tick_result.source_tick.tick_index)
+        if checkpoints_out is not None and checkpoint_ticks is not None and tick_index in checkpoint_ticks:
+            checkpoints_out.append(
+                self.driver.build_checkpoint(
+                    tick_result=tick_result,
+                    use_world_step_creature_count=bool(self.checkpoint_use_world_step_creature_count),
+                ),
+            )
+        if self.observer is not None:
+            self.observer.after_tick(tick_result, world)
+
+    def rng_trace(self, tick_result: TickResult, draws: tuple[RngTraceDraw, ...]) -> None:
+        if self.observer is not None:
+            self.observer.rng_trace(tick_result, draws)
+
+    def progress(self, next_tick_index: int) -> None:
+        if self.observer is not None:
+            self.observer.progress(int(next_tick_index))
+
+
 def _run_verify_playback(
     replay,
     *,
@@ -133,9 +178,7 @@ def _run_verify_playback(
     inter_tick_rand_draws_by_tick: dict[int, int] | None = None,
     spawn_entries=None,
     start_weapon_id=None,
-    tick_progress_callback: Callable[[int], None] | None = None,
-    tick_observer: Callable[[int, WorldState], None] | None = None,
-    tick_rng_trace_observer: Callable[[int, list[tuple[int, int, int, CallerStatic]]], None] | None = None,
+    observer: PlaybackWalkObserver | None = None,
 ) -> RunResult:
     driver = build_verify_playback_driver(
         replay,
@@ -148,36 +191,13 @@ def _run_verify_playback(
         start_weapon_id=start_weapon_id,
     )
 
-    after_tick = None
-    if checkpoints_out is not None or tick_observer is not None:
-        def _after_tick(tick_result, world) -> None:
-            if checkpoints_out is not None and checkpoint_ticks is not None and int(tick_result.source_tick.tick_index) in checkpoint_ticks:
-                checkpoints_out.append(
-                    driver.build_checkpoint(
-                        tick_result=tick_result,
-                        use_world_step_creature_count=bool(checkpoint_use_world_step_creature_count),
-                    ),
-                )
-            if tick_observer is not None:
-                tick_observer(int(tick_result.source_tick.tick_index), world)
-
-        after_tick = _after_tick
-
-    on_rng_trace = None
-    if tick_rng_trace_observer is not None:
-        def _on_rng_trace(tick_result, draws) -> None:
-            tick_rng_trace_observer(
-                int(tick_result.source_tick.tick_index),
-                list(draws),
-            )
-
-        on_rng_trace = _on_rng_trace
-
     return driver.run(
-        hooks=PlaybackWalkHooks(
-            after_tick=after_tick,
-            on_progress=tick_progress_callback,
-            on_rng_trace=on_rng_trace,
+        observer=_VerifyPlaybackObserver(
+            driver=driver,
+            checkpoints_out=checkpoints_out,
+            checkpoint_ticks=checkpoint_ticks,
+            checkpoint_use_world_step_creature_count=bool(checkpoint_use_world_step_creature_count),
+            observer=observer,
         ),
     )
 


### PR DESCRIPTION
## Summary

- replace `PlaybackWalkHooks` with a concrete `PlaybackWalkObserver` msgspec runtime object
- convert replay info, checkpoint verification, debug recording, and benchmark progress from closure callbacks to named observer objects
- update replay test helpers to use recorder/observer objects instead of callback parameters

## Verification

- `just check`
- `uv run ruff check src/crimson/replay/driver/playback_driver.py src/crimson/replay/driver/replay_info.py src/crimson/replay/driver/replay_benchmark.py src/crimson/cli/replay.py src/crimson/dbg/record.py tests/support/replay_runner_helpers.py tests/replay/test_playback_driver_walk.py tests/replay/test_replay_runners_quest.py tests/replay/test_replay_fixture_integrations.py tests/replay/test_replay_runners_rush.py tests/replay/test_replay_runners_survival.py tests/debug/test_dbg_record.py`
- `uv run ty check src/crimson/replay/driver/playback_driver.py src/crimson/replay/driver/replay_info.py src/crimson/replay/driver/replay_benchmark.py src/crimson/cli/replay.py src/crimson/dbg/record.py tests/support/replay_runner_helpers.py tests/replay/test_playback_driver_walk.py tests/replay/test_replay_runners_quest.py tests/replay/test_replay_fixture_integrations.py tests/replay/test_replay_runners_rush.py tests/replay/test_replay_runners_survival.py tests/debug/test_dbg_record.py`
- `uv run pytest tests/replay/test_replay_fixture_integrations.py tests/replay/test_playback_driver_walk.py tests/replay/test_replay_runners_quest.py tests/replay/test_replay_runners_rush.py tests/replay/test_replay_runners_survival.py tests/debug/test_dbg_record.py tests/replay/cli/test_benchmark.py tests/replay/cli/test_info.py tests/replay/cli/test_verify.py tests/debug/test_dbg_cli.py tests/net/cli/test_zig_net_cli.py::test_zig_net_smoke_rollback_reports_bidirectional_jitter_recovery`

## Notes

- The first commit attempt hit the known transient Zig rollback smoke failure (`RollbackJitterCorrectionMissing`); rerunning that exact test passed, and the retrying commit hook passed.

## Follow-ups

- `tests/support/builders/runners.py` still has a callback-backed fake runner.
- `tests/support/factories.py` still has projectile presentation callbacks that should become explicit projectile/presentation runtime objects.
