### PR TITLE
refactor: move projectile hit callbacks into runtime

### DIFF
--- a/src/crimson/projectiles/runtime/__init__.py
+++ b/src/crimson/projectiles/runtime/__init__.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from .collision import _within_native_find_radius
 from .primary_rules import PRIMARY_PROJECTILE_RULE_BY_TYPE_ID, PrimaryProjectileRule, primary_rule_for_type_id
-from .projectile_pool import PrimaryStepCtx, ProjectilePool, ProjectileUpdateOptions, projectile_collision_profile
+from .projectile_pool import (
+    PrimaryStepCtx,
+    ProjectileHitRuntime,
+    ProjectilePool,
+    ProjectileUpdateOptions,
+    projectile_collision_profile,
+)
 from .secondary_pool import SecondaryProjectilePool, SecondarySpawnSpec, SecondaryStepCtx
 from .secondary_rules import SECONDARY_RULE_BY_TYPE_ID, secondary_rule_for_type_id
 
@@ -10,6 +16,7 @@ __all__ = [
     "PRIMARY_PROJECTILE_RULE_BY_TYPE_ID",
     "PrimaryProjectileRule",
     "PrimaryStepCtx",
+    "ProjectileHitRuntime",
     "ProjectilePool",
     "ProjectileUpdateOptions",
     "SECONDARY_RULE_BY_TYPE_ID",

--- a/src/crimson/projectiles/runtime/projectile_pool.py
+++ b/src/crimson/projectiles/runtime/projectile_pool.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable, MutableSequence, Sequence
-from typing import TYPE_CHECKING
+from collections.abc import MutableSequence, Sequence
+from typing import TYPE_CHECKING, TypeAlias
 
 import msgspec
 
@@ -41,6 +41,20 @@ if TYPE_CHECKING:
     from ...gameplay import GameplayState
     from ...sim.state_types import PlayerState
 
+ProjectileHitPresentation: TypeAlias = object
+
+
+class ProjectileHitRuntime(msgspec.Struct):
+    def apply_player_damage(self, player_index: int, damage: float) -> None:
+        _ = player_index, damage
+
+    def begin_hit_presentation(self, hit: ProjectileHit) -> ProjectileHitPresentation | None:
+        _ = hit
+        return None
+
+    def finish_hit_presentation(self, hit: ProjectileHit, presentation: ProjectileHitPresentation) -> None:
+        _ = hit, presentation
+
 
 class ProjectileUpdateOptions(msgspec.Struct, frozen=True):
     world_size: float
@@ -48,12 +62,10 @@ class ProjectileUpdateOptions(msgspec.Struct, frozen=True):
     rng: CrandLike
     runtime_state: GameplayState
     players: Sequence[PlayerState]
-    apply_player_damage: Callable[[int, float], None]
+    hit_runtime: ProjectileHitRuntime
     apply_creature_damage: CreatureDamageApplier | None = None
     ion_aoe_scale: float = 1.0
     detail_preset: int = 5
-    begin_hit_presentation: Callable[[ProjectileHit], object] | None = None
-    finish_hit_presentation: Callable[[ProjectileHit, object], None] | None = None
 
 
 class PrimaryStepCtx(msgspec.Struct, frozen=True):
@@ -161,10 +173,8 @@ class ProjectilePool:
         rng = options.rng
         runtime_state = options.runtime_state
         players = options.players
-        apply_player_damage = options.apply_player_damage
+        hit_runtime = options.hit_runtime
         apply_creature_damage = options.apply_creature_damage
-        begin_hit_presentation = options.begin_hit_presentation
-        finish_hit_presentation = options.finish_hit_presentation
 
         if dt <= 0.0:
             return []
@@ -375,7 +385,7 @@ class ProjectilePool:
                                 continue
 
                             proj.life_timer = 0.25
-                            apply_player_damage(int(hit_player_idx), 10.0)
+                            hit_runtime.apply_player_damage(int(hit_player_idx), 10.0)
 
                             step += 3
                             continue
@@ -411,7 +421,7 @@ class ProjectilePool:
                         target=target,
                     )
                     hits.append(hit)
-                    hit_presentation = begin_hit_presentation(hit) if begin_hit_presentation is not None else None
+                    hit_presentation = hit_runtime.begin_hit_presentation(hit)
 
                     if proj.life_timer != 0.25 and rule.stop_on_hit:
                         proj.life_timer = 0.25
@@ -503,17 +513,17 @@ class ProjectilePool:
                             proj.life_timer = 0.25
 
                     if proj.life_timer == 0.25 and rule.stop_on_hit:
-                        if finish_hit_presentation is not None and hit_presentation is not None:
-                            finish_hit_presentation(hit, hit_presentation)
+                        if hit_presentation is not None:
+                            hit_runtime.finish_hit_presentation(hit, hit_presentation)
                         break
 
                     if proj.damage_pool <= 0.0:
-                        if finish_hit_presentation is not None and hit_presentation is not None:
-                            finish_hit_presentation(hit, hit_presentation)
+                        if hit_presentation is not None:
+                            hit_runtime.finish_hit_presentation(hit, hit_presentation)
                         break
 
-                    if finish_hit_presentation is not None and hit_presentation is not None:
-                        finish_hit_presentation(hit, hit_presentation)
+                    if hit_presentation is not None:
+                        hit_runtime.finish_hit_presentation(hit, hit_presentation)
 
                 step += 3
 

--- a/src/crimson/sim/world_state.py
+++ b/src/crimson/sim/world_state.py
@@ -27,7 +27,7 @@ from ..owner_ref import OwnerRef
 from ..perks.runtime.effects import perks_update_effects
 from ..perks.runtime.manifest import PLAYER_DEATH_HOOKS, WORLD_DT_STEPS
 from ..player_damage import player_take_projectile_damage
-from ..projectiles.runtime import PrimaryStepCtx, ProjectileUpdateOptions, SecondaryStepCtx
+from ..projectiles.runtime import PrimaryStepCtx, ProjectileHitRuntime, ProjectileUpdateOptions, SecondaryStepCtx
 from ..projectiles.types import ProjectileHit
 from .input import PlayerInput
 from .input_frame import normalize_input_frame
@@ -59,7 +59,7 @@ _WORLD_DT_STEPS = WORLD_DT_STEPS
 _PLAYER_DEATH_HOOKS = PLAYER_DEATH_HOOKS
 
 
-class _WorldStepRuntime(msgspec.Struct):
+class _WorldStepRuntime(ProjectileHitRuntime):
     world: WorldState
     dt: float
     world_size: float
@@ -78,6 +78,9 @@ class _WorldStepRuntime(msgspec.Struct):
         if not (0 <= idx < len(self.world.players)):
             return
         player_take_projectile_damage(self.world.state, self.world.players[idx], float(damage))
+
+    def apply_player_damage(self, player_index: int, damage: float) -> None:
+        self.apply_player_projectile_damage(player_index, damage)
 
     def apply_creature_damage(
         self,
@@ -160,6 +163,12 @@ class _WorldStepRuntime(msgspec.Struct):
             self.hit_audio_game_tune_started = True
         if keys:
             self.hit_sfx.extend(keys)
+
+    def begin_hit_presentation(self, hit: ProjectileHit) -> ProjectileDecalPostCtx:
+        return self.prepare_projectile_hit_presentation(hit)
+
+    def finish_hit_presentation(self, hit: ProjectileHit, presentation: object) -> None:
+        self.finalize_projectile_hit_presentation(hit, presentation)
 
     def kill_creature_no_corpse(self, creature_index: int, owner: OwnerRef) -> None:
         idx = int(creature_index)
@@ -317,10 +326,8 @@ class WorldState(msgspec.Struct):
                     rng=self.state.rng,
                     runtime_state=self.state,
                     players=self.players,
-                    apply_player_damage=step_runtime.apply_player_projectile_damage,
+                    hit_runtime=step_runtime,
                     apply_creature_damage=step_runtime.apply_creature_damage,
-                    begin_hit_presentation=step_runtime.prepare_projectile_hit_presentation,
-                    finish_hit_presentation=step_runtime.finalize_projectile_hit_presentation,
                 ),
             ),
         )

--- a/tests/creatures/test_ranged_attacks.py
+++ b/tests/creatures/test_ranged_attacks.py
@@ -12,7 +12,11 @@ from crimson.rng_caller_static import RngCallerStatic
 from crimson.sim.state_types import PlayerState
 from grim.geom import Vec2
 from grim.sfx_map import SfxId
-from tests.support.factories import make_creature_update_options, make_projectile_update_options
+from tests.support.factories import (
+    RecordingProjectileHitRuntime,
+    make_creature_update_options,
+    make_projectile_update_options,
+)
 from tests.support.helpers import ScriptedCrand, assert_float_close
 
 
@@ -136,9 +140,7 @@ def test_ranged_projectile_can_damage_player() -> None:
         hits_players=True,
     )
 
-    def _apply_player_damage(player_index: int, damage: float) -> None:
-        assert player_index == 0
-        player.health -= float(damage)
+    hit_runtime = RecordingProjectileHitRuntime(players=[player])
 
     state.projectiles.step(
         PrimaryStepCtx(
@@ -149,11 +151,12 @@ def test_ranged_projectile_can_damage_player() -> None:
                 rng=state.rng,
                 runtime_state=state,
                 players=[player],
-                apply_player_damage=_apply_player_damage,
+                hit_runtime=hit_runtime,
             ),
         ),
     )
 
+    assert hit_runtime.player_damage_calls == [(0, 10.0)]
     assert player.health < 100.0
 
 
@@ -181,13 +184,7 @@ def test_ranged_projectile_can_damage_creature_before_player() -> None:
         hits_players=True,
     )
 
-    player_damage_called = False
-
-    def _apply_player_damage(player_index: int, damage: float) -> None:
-        nonlocal player_damage_called
-
-        player_damage_called = True
-        player.health -= float(damage)
+    hit_runtime = RecordingProjectileHitRuntime(players=[player])
 
     state.projectiles.step(
         PrimaryStepCtx(
@@ -198,11 +195,11 @@ def test_ranged_projectile_can_damage_creature_before_player() -> None:
                 rng=state.rng,
                 runtime_state=state,
                 players=[player],
-                apply_player_damage=_apply_player_damage,
+                hit_runtime=hit_runtime,
             ),
         ),
     )
 
     assert target.hp < 100.0
-    assert player_damage_called is False
+    assert hit_runtime.player_damage_calls == []
     assert player.health == 100.0

--- a/tests/gameplay/test_death_timing.py
+++ b/tests/gameplay/test_death_timing.py
@@ -474,18 +474,16 @@ def test_freeze_hit_path_triggers_tune_and_skips_hit_sfx(mocker) -> None:
 
     def _fake_projectile_step(*args: object, **_kwargs: object) -> list[ProjectileHit]:
         ctx = cast("PrimaryStepCtx", args[0])
-        begin_hit_presentation = ctx.options.begin_hit_presentation
-        finish_hit_presentation = ctx.options.finish_hit_presentation
-        if begin_hit_presentation is None or finish_hit_presentation is None:
-            return []
+        hit_runtime = ctx.options.hit_runtime
         hit = ProjectileHit(
             type_id=ProjectileTemplateId.PISTOL,
             origin=Vec2(0.0, 0.0),
             hit=Vec2(1.0, 1.0),
             target=Vec2(1.0, 1.0),
         )
-        post_ctx = begin_hit_presentation(hit)
-        finish_hit_presentation(hit, post_ctx)
+        post_ctx = hit_runtime.begin_hit_presentation(hit)
+        assert post_ctx is not None
+        hit_runtime.finish_hit_presentation(hit, post_ctx)
         return [hit]
 
     mocker.patch.object(world.state.projectiles, "step", side_effect=_fake_projectile_step)

--- a/tests/support/factories.py
+++ b/tests/support/factories.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
+
+import msgspec
 
 from crimson.creatures.runtime import CreatureState, CreatureUpdateOptions
 from crimson.creatures.spawn import CreatureFlags, CreatureTypeId, SpawnEnv
 from crimson.effects import FxQueue, FxQueueRotated
 from crimson.gameplay import GameplayState
-from crimson.projectiles.runtime import ProjectileUpdateOptions
-from crimson.projectiles.types import CreatureDamageApplier, ProjectileHit
+from crimson.projectiles.runtime import ProjectileHitRuntime, ProjectileUpdateOptions
+from crimson.projectiles.types import CreatureDamageApplier
 from crimson.sim.state_types import PlayerState
 from grim.geom import Vec2
 from grim.rand import CrandLike
@@ -76,16 +78,19 @@ def make_creature_update_options(
     )
 
 
-def _default_apply_player_damage(players: Sequence[PlayerState]) -> Callable[[int, float], None]:
-    def _apply_player_damage(player_index: int, damage: float) -> None:
-        idx = int(player_index)
-        if not (0 <= idx < len(players)):
-            return
-        player = players[idx]
-        if float(player.shield_timer) <= 0.0:
-            player.health -= float(damage)
+class RecordingProjectileHitRuntime(ProjectileHitRuntime):
+    players: Sequence[PlayerState] = ()
+    player_damage_calls: list[tuple[int, float]] = msgspec.field(default_factory=list)
 
-    return _apply_player_damage
+    def apply_player_damage(self, player_index: int, damage: float) -> None:
+        idx = int(player_index)
+        damage_value = float(damage)
+        self.player_damage_calls.append((idx, damage_value))
+        if not (0 <= idx < len(self.players)):
+            return
+        player = self.players[idx]
+        if float(player.shield_timer) <= 0.0:
+            player.health -= damage_value
 
 
 def make_projectile_update_options(
@@ -97,10 +102,8 @@ def make_projectile_update_options(
     rng: CrandLike | None = None,
     runtime_state: GameplayState | None = None,
     players: Sequence[PlayerState] | None = None,
-    apply_player_damage: Callable[[int, float], None] | None = None,
+    hit_runtime: ProjectileHitRuntime | None = None,
     apply_creature_damage: CreatureDamageApplier | None = None,
-    begin_hit_presentation: Callable[[ProjectileHit], object] | None = None,
-    finish_hit_presentation: Callable[[ProjectileHit, object], None] | None = None,
 ) -> ProjectileUpdateOptions:
     state = GameplayState() if runtime_state is None else runtime_state
     player_seq: Sequence[PlayerState] = () if players is None else players
@@ -110,12 +113,8 @@ def make_projectile_update_options(
         rng=state.rng if rng is None else rng,
         runtime_state=state,
         players=player_seq,
-        apply_player_damage=(
-            _default_apply_player_damage(player_seq) if apply_player_damage is None else apply_player_damage
-        ),
+        hit_runtime=RecordingProjectileHitRuntime(players=player_seq) if hit_runtime is None else hit_runtime,
         apply_creature_damage=apply_creature_damage,
         ion_aoe_scale=float(ion_aoe_scale),
         detail_preset=int(detail_preset),
-        begin_hit_presentation=begin_hit_presentation,
-        finish_hit_presentation=finish_hit_presentation,
     )


### PR DESCRIPTION
## Summary

- replace primary projectile player-hit and hit-presentation callbacks with a concrete `ProjectileHitRuntime`
- make the world step runtime implement the projectile hit runtime so hit decals/SFX keep their original in-step RNG ordering
- update projectile test factories to use a recording runtime object instead of callback injection

## Verification

- `just check`
- `uv run ruff check src/crimson/projectiles/runtime/projectile_pool.py src/crimson/projectiles/runtime/__init__.py src/crimson/sim/world_state.py tests/support/factories.py tests/creatures/test_ranged_attacks.py tests/gameplay/test_death_timing.py`
- `uv run ty check src/crimson/projectiles/runtime/projectile_pool.py src/crimson/projectiles/runtime/__init__.py src/crimson/sim/world_state.py tests/support/factories.py tests/creatures/test_ranged_attacks.py tests/gameplay/test_death_timing.py`
- `uv run pytest tests/gameplay/test_death_timing.py::test_freeze_hit_path_triggers_tune_and_skips_hit_sfx tests/creatures/test_ranged_attacks.py tests/projectiles/test_projectiles.py tests/projectiles/test_projectile_hit_effects.py tests/weapons/test_shot_stats.py tests/perks/test_ion_gun_master_perk.py tests/perks/test_barrel_greaser_perk.py tests/sim/test_step_pipeline_parity.py tests/gameplay/test_game_world_presentation_rng.py tests/net/cli/test_zig_net_cli.py::test_zig_net_smoke_rollback_reports_bidirectional_jitter_recovery`

## Notes

- The commit hook hit the known transient Zig rollback smoke once; rerunning that exact test passed, and the pre-push hook passed.

## Follow-ups

- Creature damage is still passed through the broader `CreatureDamageApplier` path shared by primary projectiles, secondary projectiles, effects, and bonuses. That should be a separate, wider runtime cleanup.
- `tests/support/builders/runners.py` still has a callback-backed fake runner.
