### PR TITLE
test: replace fake runner callbacks

### DIFF
--- a/tests/sim/test_runtime_pump_ownership.py
+++ b/tests/sim/test_runtime_pump_ownership.py
@@ -20,7 +20,7 @@ from crimson.net.lockstep_protocol import TickFrame
 from crimson.net.lockstep_runtime import HostLockstepRuntimeConfig, LockstepRuntime
 from crimson.sim.hooks import LanFrameSample, LanTickSync, TickResult
 from crimson.sim.input_providers import InputStatus, PerkPickCommand, ResolvedTick
-from crimson.sim.tick_runner import TickBatchResult
+from crimson.sim.tick_runner import TickBatchResult, TickRunner, TickRunnerConfig
 from grim.rand import Crand
 from grim.view import ViewContext
 from tests.support.builders import FakeRunner, make_tick_payload
@@ -119,8 +119,8 @@ def test_interactive_headless_no_runtime_pumps_zero(make_game_state) -> None:
 def test_lan_tick_consumption_drives_runner_until_stall(mocker, make_mode_config) -> None:
     mode = _survival_mode(config=make_mode_config(game_mode=GameMode.SURVIVAL))
     tick_payload = make_tick_payload()
-    runner = FakeRunner(results=
-        [
+    runner = FakeRunner(
+        results=[
             TickBatchResult(
                 ticks_completed=1,
                 batch_status=InputStatus.READY,
@@ -175,13 +175,11 @@ def test_lan_tick_consumption_treats_frame_pop_block_as_non_stall(mocker, make_m
         tick_rate=60,
     )
     mocker.patch.object(mode, "_lan_allow_frame_pop", return_value=False)
-
-    def _block_frame_pop() -> None:
-        provider.pull_tick(0, 1.0 / 60.0)
-
-    runner = FakeRunner(
-        results=[TickBatchResult(ticks_completed=0, batch_status=InputStatus.STALLED, next_tick_index=0)],
-        on_advance=_block_frame_pop,
+    session = make_session()[0]
+    runner = TickRunner(
+        session=session,
+        input_provider=provider,
+        config=TickRunnerConfig(),
     )
     mocker.patch.object(
         mode,
@@ -194,13 +192,13 @@ def test_lan_tick_consumption_treats_frame_pop_block_as_non_stall(mocker, make_m
     stop = mode._consume_lan_tick_frames(
         runtime=_host_lan_runtime(),
         lockstep_runtime=None,
-        session=make_session()[0],
+        session=session,
         role="host",
         dt_tick=1.0 / 60.0,
     )
 
     assert stop is False
-    assert runner.calls == 1
+    assert provider.pop_blocked is True
     assert int(mode._input_stall_count) == before_stall_count
 
 
@@ -251,7 +249,8 @@ def test_lan_tick_consumption_does_not_emit_sync_for_stop_before_finalize(mocker
                 completed_results=ticks,
             ),
         ],
-        on_advance=lambda: provider._samples_by_runner_tick.update(sync_samples),
+        lan_frame_sample_sink=provider._samples_by_runner_tick,
+        lan_frame_samples_by_advance=[sync_samples],
     )
     runtime = _BroadcastTickFrameRuntime()
     tick_sync = _LanTickSyncRuntime(
@@ -315,7 +314,8 @@ def test_lan_tick_consumption_broadcasts_tick_frame_commands(mocker, make_mode_c
                 completed_results=[tick],
             ),
         ],
-        on_advance=lambda: provider._samples_by_runner_tick.update(sync_samples),
+        lan_frame_sample_sink=provider._samples_by_runner_tick,
+        lan_frame_samples_by_advance=[sync_samples],
     )
     runtime = _BroadcastTickFrameRuntime()
     tick_sync = _LanTickSyncRuntime(

--- a/tests/support/builders/runners.py
+++ b/tests/support/builders/runners.py
@@ -1,27 +1,26 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass, field
+import msgspec
 
-from crimson.sim.hooks import TickResult
+from crimson.sim.hooks import LanFrameSample, TickResult
 from crimson.sim.input_providers import InputStatus, ResolvedTick
 from crimson.sim.tick_runner import TickBatchResult
 
 from .tick_payload import make_tick_payload
 
 
-@dataclass
-class FakeRunner:
+class FakeRunner(msgspec.Struct):
     """Configurable fake tick runner for orchestration tests.
 
     When ``results`` is non-empty, pops the first result on each advance.
     Otherwise generates a default batch from ``ticks_requested``.
     """
 
-    results: list[TickBatchResult] = field(default_factory=list)
+    results: list[TickBatchResult] = msgspec.field(default_factory=list)
+    lan_frame_sample_sink: dict[int, LanFrameSample] | None = None
+    lan_frame_samples_by_advance: list[dict[int, LanFrameSample]] = msgspec.field(default_factory=list)
     frame_count: int = 0
     calls: int = 0
-    on_advance: Callable[[], None] | None = None
 
     def begin_frame(self, frame_ctx: object) -> None:
         _ = frame_ctx
@@ -30,8 +29,8 @@ class FakeRunner:
     def advance_ticks(self, *, start_tick: int, ticks_requested: int, tick_dt: float) -> TickBatchResult:
         _ = tick_dt
         self.calls += 1
-        if self.on_advance is not None:
-            self.on_advance()
+        if self.lan_frame_sample_sink is not None and self.lan_frame_samples_by_advance:
+            self.lan_frame_sample_sink.update(self.lan_frame_samples_by_advance.pop(0))
         if self.results:
             result = self.results.pop(0)
             result.next_tick_index = int(start_tick) + int(result.ticks_completed)


### PR DESCRIPTION
## Summary

- convert the shared `FakeRunner` test helper from dataclass + callback to a `msgspec.Struct`
- replace `on_advance` with explicit LAN frame-sample injection data for tests that need canonical frame metadata
- use a real `TickRunner` for the LAN frame-pop-block path so the test exercises the production provider behavior directly

## Verification

- `uv run ruff check tests/support/builders/runners.py tests/sim/test_runtime_pump_ownership.py`
- `uv run ty check tests/support/builders/runners.py tests/sim/test_runtime_pump_ownership.py`
- `uv run pytest tests/sim/test_runtime_pump_ownership.py`
- `sg scan tests/support/builders/runners.py tests/sim/test_runtime_pump_ownership.py`
- `just check`
- pre-commit hook
- pre-push hook

## Follow-ups

- creature damage is still on the shared `CreatureDamageApplier` callback path used by primary projectiles, secondary projectiles, effects, and bonuses
- `tests/support/world_runtime.py` still has a large delegation wrapper that ast-grep now consistently calls out; it may be worth collapsing or replacing with concrete test runtimes
