### PR TITLE
refactor: route creature damage through runtime

### DIFF
--- a/src/crimson/bonuses/apply.py
+++ b/src/crimson/bonuses/apply.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING
 
 from grim.geom import Vec2
 
+from ..creatures.damage_runtime import CreatureDamageRuntime
 from ..perks import PerkId
 from ..perks.helpers import perk_count_get
-from ..projectiles.types import CreatureDamageApplier
 from ..sim.state_types import GameplayState, PlayerState
 from .apply_context import BonusApplyCtx, BonusApplyHandler
 from .double_experience import apply_double_experience
@@ -59,7 +59,7 @@ def bonus_apply(
     detail_preset: int = 5,
     defer_freeze_corpse_fx: bool = False,
     freeze_corpse_indices: set[int] | None = None,
-    apply_creature_damage: CreatureDamageApplier | None = None,
+    creature_damage_runtime: CreatureDamageRuntime | None = None,
 ) -> None:
     """Apply a bonus to player + global timers (subset of `bonus_apply`)."""
 
@@ -86,7 +86,7 @@ def bonus_apply(
         icon_id=int(icon_id),
         defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
         freeze_corpse_indices=freeze_corpse_indices,
-        apply_creature_damage=apply_creature_damage,
+        creature_damage_runtime=creature_damage_runtime,
     )
     handler = _BONUS_APPLY_HANDLERS.get(bonus_id)
     if handler is not None:

--- a/src/crimson/bonuses/apply_context.py
+++ b/src/crimson/bonuses/apply_context.py
@@ -7,7 +7,7 @@ import msgspec
 
 from grim.geom import Vec2
 
-from ..projectiles.types import CreatureDamageApplier
+from ..creatures.damage_runtime import CreatureDamageRuntime
 from ..sim.state_types import GameplayState, PlayerState
 from .hud import _TimerRef
 from .ids import BONUS_BY_ID, BonusId
@@ -30,7 +30,7 @@ class BonusApplyCtx(msgspec.Struct):
     icon_id: int
     defer_freeze_corpse_fx: bool = False
     freeze_corpse_indices: set[int] | None = None
-    apply_creature_damage: CreatureDamageApplier | None = None
+    creature_damage_runtime: CreatureDamageRuntime | None = None
 
     def register_global(self, timer_key: str) -> None:
         self.state.bonus_hud.register(

--- a/src/crimson/bonuses/nuke.py
+++ b/src/crimson/bonuses/nuke.py
@@ -69,7 +69,7 @@ def apply_nuke(ctx: BonusApplyCtx) -> None:
 
     creatures = ctx.creatures
     if creatures:
-        apply_creature_damage = ctx.apply_creature_damage
+        creature_damage_runtime = ctx.creature_damage_runtime
         prev_guard = bool(ctx.state.bonus_spawn_guard)
         ctx.state.bonus_spawn_guard = True
         for idx, creature in enumerate(creatures):
@@ -84,8 +84,8 @@ def apply_nuke(ctx: BonusApplyCtx) -> None:
             dist = delta.length()
             if dist < 256.0:
                 damage = (256.0 - dist) * 5.0
-                if apply_creature_damage is not None:
-                    apply_creature_damage(
+                if creature_damage_runtime is not None:
+                    creature_damage_runtime.apply_creature_damage(
                         int(idx),
                         float(damage),
                         3,

--- a/src/crimson/bonuses/pool.py
+++ b/src/crimson/bonuses/pool.py
@@ -7,9 +7,9 @@ import msgspec
 
 from grim.geom import Vec2
 
+from ..creatures.damage_runtime import CreatureDamageRuntime
 from ..game_modes import GameMode
 from ..perks.helpers import perk_active
-from ..projectiles.types import CreatureDamageApplier
 from ..rng_caller_static import RngCallerStatic
 from ..sim.state_types import BonusPickupEvent, GameplayState, PlayerState
 from ..weapon_runtime.availability import weapon_pick_random_available
@@ -362,7 +362,7 @@ class BonusPool:
         detail_preset: int = 5,
         defer_freeze_corpse_fx: bool = False,
         freeze_corpse_indices: set[int] | None = None,
-        apply_creature_damage: CreatureDamageApplier | None = None,
+        creature_damage_runtime: CreatureDamageRuntime | None = None,
     ) -> list[BonusPickupEvent]:
         if dt <= 0.0:
             return []
@@ -403,7 +403,7 @@ class BonusPool:
                         detail_preset=int(detail_preset),
                         defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
                         freeze_corpse_indices=freeze_corpse_indices,
-                        apply_creature_damage=apply_creature_damage,
+                        creature_damage_runtime=creature_damage_runtime,
                     )
                     entry.picked = True
                     entry.time_left = BONUS_PICKUP_LINGER

--- a/src/crimson/bonuses/update.py
+++ b/src/crimson/bonuses/update.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
+from ..creatures.damage_runtime import CreatureDamageRuntime
 from ..math_parity import f32
 from ..perks.helpers import perk_active
-from ..projectiles.types import CreatureDamageApplier
 from ..sim.state_types import BonusPickupEvent, GameplayState, PlayerState
 from .apply import bonus_apply
 from .hud import bonus_hud_update
@@ -27,7 +27,7 @@ def bonus_telekinetic_update(
     detail_preset: int = 5,
     defer_freeze_corpse_fx: bool = False,
     freeze_corpse_indices: set[int] | None = None,
-    apply_creature_damage: CreatureDamageApplier | None = None,
+    creature_damage_runtime: CreatureDamageRuntime | None = None,
 ) -> list[BonusPickupEvent]:
     """Allow Telekinetic perk owners to pick up bonuses by aiming at them."""
     from ..perks import PerkId
@@ -70,7 +70,7 @@ def bonus_telekinetic_update(
             detail_preset=int(detail_preset),
             defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
             freeze_corpse_indices=freeze_corpse_indices,
-            apply_creature_damage=apply_creature_damage,
+            creature_damage_runtime=creature_damage_runtime,
         )
         entry.picked = True
         entry.time_left = BONUS_PICKUP_LINGER
@@ -101,7 +101,7 @@ def bonus_update(
     detail_preset: int = 5,
     defer_freeze_corpse_fx: bool = False,
     freeze_corpse_indices: set[int] | None = None,
-    apply_creature_damage: CreatureDamageApplier | None = None,
+    creature_damage_runtime: CreatureDamageRuntime | None = None,
 ) -> list[BonusPickupEvent]:
     """Advance world bonuses and global timers (subset of `bonus_update`)."""
 
@@ -113,7 +113,7 @@ def bonus_update(
         detail_preset=int(detail_preset),
         defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
         freeze_corpse_indices=freeze_corpse_indices,
-        apply_creature_damage=apply_creature_damage,
+        creature_damage_runtime=creature_damage_runtime,
     )
     pickups.extend(
         state.bonus_pool.update(
@@ -124,7 +124,7 @@ def bonus_update(
             detail_preset=int(detail_preset),
             defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
             freeze_corpse_indices=freeze_corpse_indices,
-            apply_creature_damage=apply_creature_damage,
+            creature_damage_runtime=creature_damage_runtime,
         ),
     )
 

--- a/src/crimson/creatures/damage_runtime.py
+++ b/src/crimson/creatures/damage_runtime.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import msgspec
+
+from grim.geom import Vec2
+
+from ..owner_ref import OwnerRef
+
+if TYPE_CHECKING:
+    from .runtime import CreatureState
+
+
+class CreatureDamageRuntime(msgspec.Struct):
+    def apply_creature_damage(
+        self,
+        creature_index: int,
+        damage: float,
+        damage_type: int,
+        impulse: Vec2,
+        owner: OwnerRef,
+    ) -> None:
+        _ = creature_index, damage, damage_type, impulse, owner
+
+    def kill_creature_no_corpse(self, creature_index: int, owner: OwnerRef) -> None:
+        _ = creature_index, owner
+
+    def on_secondary_detonation_kill(self, creature_index: int) -> None:
+        _ = creature_index
+
+
+class DirectCreatureDamageRuntime(CreatureDamageRuntime):
+    creatures: Sequence[CreatureState] = ()
+
+    def apply_creature_damage(
+        self,
+        creature_index: int,
+        damage: float,
+        damage_type: int,
+        impulse: Vec2,
+        owner: OwnerRef,
+    ) -> None:
+        _ = damage_type, impulse, owner
+        if damage <= 0.0:
+            return
+        idx = int(creature_index)
+        if not (0 <= idx < len(self.creatures)):
+            return
+        self.creatures[idx].hp -= float(damage)
+
+    def kill_creature_no_corpse(self, creature_index: int, owner: OwnerRef) -> None:
+        _ = owner
+        idx = int(creature_index)
+        if not (0 <= idx < len(self.creatures)):
+            return
+        creature = self.creatures[idx]
+        creature.hp = -1.0
+        creature.active = False

--- a/src/crimson/effects.py
+++ b/src/crimson/effects.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from enum import IntEnum
 from typing import TYPE_CHECKING
 
@@ -12,11 +12,11 @@ from grim.geom import Vec2
 from grim.math import clamp
 from grim.rand import CallerStatic, Crand, CrandLike
 
+from .creatures.damage_runtime import CreatureDamageRuntime, DirectCreatureDamageRuntime
 from .creatures.lifecycle import creature_lifecycle_is_collidable
 from .effects_atlas import EffectId
 from .math_parity import f32
 from .owner_ref import OwnerRef
-from .projectiles.types import CreatureDamageApplier
 from .rng_caller_static import RngCallerStatic
 
 if TYPE_CHECKING:
@@ -59,9 +59,6 @@ class ParticleStyleId(IntEnum):
     BLOW_TORCH = 1
     HR_FLAMER = 2
     BUBBLEGUN = 8
-
-
-CreatureKillHandler = Callable[[int, OwnerRef], None]
 
 
 class Particle(msgspec.Struct):
@@ -171,8 +168,7 @@ class ParticlePool:
         dt: float,
         *,
         creatures: Sequence[CreatureState] | None = None,
-        apply_creature_damage: CreatureDamageApplier | None = None,
-        kill_creature: CreatureKillHandler | None = None,
+        creature_damage_runtime: CreatureDamageRuntime | None = None,
         fx_queue: FxQueue | None = None,
         sprite_effects: SpriteEffectPool | None = None,
     ) -> list[int]:
@@ -188,7 +184,8 @@ class ParticlePool:
         if dt <= 0.0:
             return []
         dt = f32(float(dt))
-        damage_applier = apply_creature_damage
+        if creature_damage_runtime is None and creatures is not None:
+            creature_damage_runtime = DirectCreatureDamageRuntime(creatures=creatures)
 
         def _creature_find_in_radius(*, pos: Vec2, radius: float) -> int:
             if creatures is None:
@@ -255,8 +252,8 @@ class ParticlePool:
                 if style == int(ParticleStyleId.BUBBLEGUN) and entry.target_id != -1:
                     target_id = int(entry.target_id)
                     entry.target_id = -1
-                    if kill_creature is not None:
-                        kill_creature(target_id, entry.owner)
+                    if creature_damage_runtime is not None:
+                        creature_damage_runtime.kill_creature_no_corpse(target_id, entry.owner)
                     elif creatures is not None and 0 <= target_id < len(creatures):
                         creatures[target_id].hp = -1.0
                         creatures[target_id].active = False
@@ -345,8 +342,8 @@ class ParticlePool:
 
                         damage = max(0.0, float(entry.intensity) * 10.0)
                         if damage > 0.0:
-                            if damage_applier is not None:
-                                damage_applier(
+                            if creature_damage_runtime is not None:
+                                creature_damage_runtime.apply_creature_damage(
                                     int(hit_idx),
                                     float(damage),
                                     4,

--- a/src/crimson/projectiles/runtime/behaviors.py
+++ b/src/crimson/projectiles/runtime/behaviors.py
@@ -10,6 +10,7 @@ from grim.geom import Vec2
 from grim.rand import CrandLike
 from grim.sfx_map import SfxId
 
+from ...creatures.damage_runtime import CreatureDamageRuntime
 from ...creatures.damage_types import CreatureDamageType
 from ...creatures.lifecycle import creature_lifecycle_is_collidable
 from ...creatures.spawn import CreatureFlags
@@ -25,7 +26,6 @@ from ..effects import (
     _spawn_splitter_hit_effects,
 )
 from ..types import (
-    CreatureDamageApplier,
     Projectile,
     ProjectileTemplateId,
 )
@@ -47,7 +47,7 @@ class _ProjectileUpdateCtx(msgspec.Struct):
     runtime_state: GameplayState | None
     effects: EffectPool | None
     sfx_queue: MutableSequence[SfxId] | None
-    apply_creature_damage: CreatureDamageApplier | None = None
+    creature_damage_runtime: CreatureDamageRuntime
 
 
 class _ProjectileHitInfo(msgspec.Struct):
@@ -118,7 +118,7 @@ def _linger_ion_aoe(
                 damage_type=CreatureDamageType.ION,
                 impulse=Vec2(),
                 owner=proj.owner,
-                apply_creature_damage=ctx.apply_creature_damage,
+                creature_damage_runtime=ctx.creature_damage_runtime,
             )
 
 
@@ -300,7 +300,7 @@ def _post_hit_shrinkifier(ctx: _ProjectileUpdateCtx, hit: _ProjectileHitInfo) ->
             damage_type=CreatureDamageType.BULLET,
             impulse=Vec2(),
             owner=hit.proj.owner,
-            apply_creature_damage=ctx.apply_creature_damage,
+            creature_damage_runtime=ctx.creature_damage_runtime,
         )
     hit.proj.life_timer = 0.25
 

--- a/src/crimson/projectiles/runtime/collision.py
+++ b/src/crimson/projectiles/runtime/collision.py
@@ -7,9 +7,9 @@ from typing import TYPE_CHECKING
 from grim.geom import Vec2
 
 from ...collision_math import native_find_size_margin
+from ...creatures.damage_runtime import CreatureDamageRuntime
 from ...creatures.lifecycle import creature_lifecycle_is_alive
 from ...owner_ref import OwnerRef
-from ..types import CreatureDamageApplier
 
 if TYPE_CHECKING:
     from ...creatures.runtime import CreatureState
@@ -81,23 +81,20 @@ def _apply_damage_to_creature(
     damage_type: int,
     impulse: Vec2,
     owner: OwnerRef,
-    apply_creature_damage: CreatureDamageApplier | None = None,
+    creature_damage_runtime: CreatureDamageRuntime,
 ) -> None:
     if damage <= 0.0:
         return
     idx = int(creature_index)
     if not (0 <= idx < len(creatures)):
         return
-    if apply_creature_damage is not None:
-        apply_creature_damage(
-            idx,
-            float(damage),
-            int(damage_type),
-            impulse,
-            owner,
-        )
-    else:
-        creatures[idx].hp -= float(damage)
+    creature_damage_runtime.apply_creature_damage(
+        idx,
+        float(damage),
+        int(damage_type),
+        impulse,
+        owner,
+    )
 
 
 __all__ = [

--- a/src/crimson/projectiles/runtime/projectile_pool.py
+++ b/src/crimson/projectiles/runtime/projectile_pool.py
@@ -10,6 +10,7 @@ from grim.geom import Vec2
 from grim.rand import CrandLike
 from grim.sfx_map import SfxId
 
+from ...creatures.damage_runtime import CreatureDamageRuntime, DirectCreatureDamageRuntime
 from ...creatures.damage_types import CreatureDamageType
 from ...creatures.lifecycle import creature_lifecycle_is_alive, creature_lifecycle_is_collidable
 from ...effects import EffectPool
@@ -20,7 +21,6 @@ from ...rng_caller_static import RngCallerStatic
 from ...weapons import weapon_entry_for_projectile_type_id
 from ..types import (
     MAIN_PROJECTILE_POOL_SIZE,
-    CreatureDamageApplier,
     Projectile,
     ProjectileCollisionProfile,
     ProjectileHit,
@@ -63,7 +63,7 @@ class ProjectileUpdateOptions(msgspec.Struct, frozen=True):
     runtime_state: GameplayState
     players: Sequence[PlayerState]
     hit_runtime: ProjectileHitRuntime
-    apply_creature_damage: CreatureDamageApplier | None = None
+    creature_damage_runtime: CreatureDamageRuntime | None = None
     ion_aoe_scale: float = 1.0
     detail_preset: int = 5
 
@@ -174,7 +174,9 @@ class ProjectilePool:
         runtime_state = options.runtime_state
         players = options.players
         hit_runtime = options.hit_runtime
-        apply_creature_damage = options.apply_creature_damage
+        creature_damage_runtime = options.creature_damage_runtime
+        if creature_damage_runtime is None:
+            creature_damage_runtime = DirectCreatureDamageRuntime(creatures=creatures)
 
         if dt <= 0.0:
             return []
@@ -254,7 +256,7 @@ class ProjectilePool:
             runtime_state=runtime_state,
             effects=effects,
             sfx_queue=sfx_queue,
-            apply_creature_damage=apply_creature_damage,
+            creature_damage_runtime=creature_damage_runtime,
         )
 
         def _reset_shock_chain_if_owner(index: int) -> None:
@@ -465,7 +467,7 @@ class ProjectilePool:
                                 damage_type=damage_type,
                                 impulse=impulse,
                                 owner=proj.owner,
-                                apply_creature_damage=apply_creature_damage,
+                                creature_damage_runtime=creature_damage_runtime,
                             )
                             creature_spatial.sync_index(int(hit_idx))
                             if proj.life_timer != 0.25:
@@ -478,7 +480,7 @@ class ProjectilePool:
                                 damage_type=damage_type,
                                 impulse=impulse,
                                 owner=proj.owner,
-                                apply_creature_damage=apply_creature_damage,
+                                creature_damage_runtime=creature_damage_runtime,
                             )
                             creature_spatial.sync_index(int(hit_idx))
                             proj.damage_pool -= float(creature.hp)

--- a/src/crimson/projectiles/runtime/secondary_pool.py
+++ b/src/crimson/projectiles/runtime/secondary_pool.py
@@ -11,6 +11,7 @@ from grim.geom import Vec2
 from grim.rand import Crand
 from grim.sfx_map import SfxId
 
+from ...creatures.damage_runtime import CreatureDamageRuntime, DirectCreatureDamageRuntime
 from ...creatures.damage_types import CreatureDamageType
 from ...creatures.lifecycle import creature_lifecycle_is_alive, creature_lifecycle_is_collidable
 from ...effects import EffectPool, FxQueue, SpriteEffectPool
@@ -20,8 +21,6 @@ from ...owner_ref import OwnerRef
 from ...rng_caller_static import RngCallerStatic
 from ..types import (
     SECONDARY_PROJECTILE_POOL_SIZE,
-    CreatureDamageApplier,
-    SecondaryDetonationKillHandler,
     SecondaryProjectile,
     SecondaryProjectileTypeId,
 )
@@ -73,8 +72,7 @@ class SecondaryStepCtx(msgspec.Struct, frozen=True):
     runtime_state: GameplayState | None = None
     fx_queue: FxQueue | None = None
     detail_preset: int = 5
-    apply_creature_damage: CreatureDamageApplier | None = None
-    on_detonation_kill: SecondaryDetonationKillHandler | None = None
+    creature_damage_runtime: CreatureDamageRuntime | None = None
 
 
 class SecondaryProjectilePool:
@@ -160,8 +158,9 @@ class SecondaryProjectilePool:
         runtime_state = ctx.runtime_state
         fx_queue = ctx.fx_queue
         detail_preset = int(ctx.detail_preset)
-        apply_creature_damage = ctx.apply_creature_damage
-        on_detonation_kill = ctx.on_detonation_kill
+        creature_damage_runtime = ctx.creature_damage_runtime
+        if creature_damage_runtime is None:
+            creature_damage_runtime = DirectCreatureDamageRuntime(creatures=creatures)
 
         if dt <= 0.0:
             return
@@ -180,7 +179,7 @@ class SecondaryProjectilePool:
                 damage_type=CreatureDamageType.EXPLOSION,
                 impulse=impulse,
                 owner=owner,
-                apply_creature_damage=apply_creature_damage,
+                creature_damage_runtime=creature_damage_runtime,
             )
 
         rng = Crand(0)
@@ -248,13 +247,13 @@ class SecondaryProjectilePool:
                             impulse=impulse,
                         )
                         creature_spatial.sync_index(int(creature_idx))
-                        if on_detonation_kill is not None and hp_before > 0.0 and float(creature.hp) <= 0.0:
+                        if hp_before > 0.0 and float(creature.hp) <= 0.0:
                             # Native detonation AoE does an extra two random decals and a
                             # second `creature_handle_death` call after the killing hit.
                             if fx_queue is not None:
                                 fx_queue.add_random(pos=creature.pos, rng=rng)
                                 fx_queue.add_random(pos=creature.pos, rng=rng)
-                            on_detonation_kill(int(creature_idx))
+                            creature_damage_runtime.on_secondary_detonation_kill(int(creature_idx))
                 continue
 
             if not isinstance(rule, (RocketRule, HomingRocketRule, RocketMinigunRule)):

--- a/src/crimson/projectiles/types.py
+++ b/src/crimson/projectiles/types.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from enum import IntEnum
-from typing import TypeAlias
 
 import msgspec
 
@@ -44,12 +42,6 @@ class SecondaryProjectileTypeId(IntEnum):
     HOMING_ROCKET = 2
     DETONATION = 3
     ROCKET_MINIGUN = 4
-
-
-CreatureDamageApplier: TypeAlias = Callable[[int, float, int, Vec2, OwnerRef], None]
-
-
-SecondaryDetonationKillHandler = Callable[[int], None]
 
 
 class ProjectileCollisionProfile(msgspec.Struct, frozen=True):
@@ -96,14 +88,12 @@ class SecondaryProjectile(msgspec.Struct):
 
 
 __all__ = [
-    "CreatureDamageApplier",
     "MAIN_PROJECTILE_POOL_SIZE",
     "Projectile",
     "ProjectileCollisionProfile",
     "ProjectileHit",
     "ProjectileTemplateId",
     "OwnerRef",
-    "SecondaryDetonationKillHandler",
     "SECONDARY_PROJECTILE_POOL_SIZE",
     "SecondaryProjectile",
     "SecondaryProjectileTypeId",

--- a/src/crimson/sim/world_state.py
+++ b/src/crimson/sim/world_state.py
@@ -12,6 +12,7 @@ from ..bonuses.update import bonus_update, bonus_update_pre_pickup_timers
 from ..camera import camera_shake_update
 from ..creatures.anim import creature_anim_advance_phase
 from ..creatures.damage import creature_apply_damage_with_lethal_followup
+from ..creatures.damage_runtime import CreatureDamageRuntime
 from ..creatures.runtime import CreatureDeath, CreaturePool, CreatureUpdateOptions
 from ..creatures.spawn import CreatureAiMode, CreatureFlags, CreatureTypeId, SpawnEnv
 from ..effects import FxQueue, FxQueueRotated
@@ -59,7 +60,7 @@ _WORLD_DT_STEPS = WORLD_DT_STEPS
 _PLAYER_DEATH_HOOKS = PLAYER_DEATH_HOOKS
 
 
-class _WorldStepRuntime(ProjectileHitRuntime):
+class _WorldStepRuntime(ProjectileHitRuntime, CreatureDamageRuntime):
     world: WorldState
     dt: float
     world_size: float
@@ -327,7 +328,7 @@ class WorldState(msgspec.Struct):
                     runtime_state=self.state,
                     players=self.players,
                     hit_runtime=step_runtime,
-                    apply_creature_damage=step_runtime.apply_creature_damage,
+                    creature_damage_runtime=step_runtime,
                 ),
             ),
         )
@@ -338,8 +339,7 @@ class WorldState(msgspec.Struct):
                 runtime_state=self.state,
                 fx_queue=fx_queue,
                 detail_preset=int(detail_preset),
-                apply_creature_damage=step_runtime.apply_creature_damage,
-                on_detonation_kill=step_runtime.on_secondary_detonation_kill,
+                creature_damage_runtime=step_runtime,
             ),
         )
         self._run_post_damage_player_death_hooks(
@@ -354,8 +354,7 @@ class WorldState(msgspec.Struct):
         self.state.particles.update(
             dt,
             creatures=self.creatures.entries,
-            apply_creature_damage=step_runtime.apply_creature_damage,
-            kill_creature=step_runtime.kill_creature_no_corpse,
+            creature_damage_runtime=step_runtime,
             fx_queue=fx_queue,
             sprite_effects=self.state.sprite_effects,
         )
@@ -416,7 +415,7 @@ class WorldState(msgspec.Struct):
             detail_preset=int(detail_preset),
             defer_freeze_corpse_fx=bool(defer_freeze_corpse_fx),
             freeze_corpse_indices=freeze_corpse_indices_at_tick_start,
-            apply_creature_damage=step_runtime.apply_creature_damage,
+            creature_damage_runtime=step_runtime,
         )
         if pickups:
             emit_bonus_pickup_effects(

--- a/tests/gameplay/test_death_timing.py
+++ b/tests/gameplay/test_death_timing.py
@@ -105,9 +105,15 @@ def test_world_step_trooper_death_sfx_respects_preserve_bugs(
 
     def _fake_projectile_step(*_args: object, **_kwargs: object) -> list[ProjectileHit]:
         ctx = cast("PrimaryStepCtx", _args[0])
-        apply_creature_damage = ctx.options.apply_creature_damage
-        assert apply_creature_damage is not None
-        apply_creature_damage(0, 1000.0, CreatureDamageType.BULLET, Vec2(), OwnerRef.from_player(0))
+        creature_damage_runtime = ctx.options.creature_damage_runtime
+        assert creature_damage_runtime is not None
+        creature_damage_runtime.apply_creature_damage(
+            0,
+            1000.0,
+            CreatureDamageType.BULLET,
+            Vec2(),
+            OwnerRef.from_player(0),
+        )
         return []
 
     mocker.patch.object(world.state.projectiles, "step", side_effect=_fake_projectile_step)
@@ -250,9 +256,15 @@ def test_projectile_lethal_hit_records_death_before_particles_update(mocker) -> 
 
     def _fake_projectile_step(*_args: object, **_kwargs: object) -> list[ProjectileHit]:
         ctx = cast("PrimaryStepCtx", _args[0])
-        apply_creature_damage = ctx.options.apply_creature_damage
-        assert apply_creature_damage is not None
-        apply_creature_damage(0, 1000.0, CreatureDamageType.BULLET, Vec2(), OwnerRef.from_player(0))
+        creature_damage_runtime = ctx.options.creature_damage_runtime
+        assert creature_damage_runtime is not None
+        creature_damage_runtime.apply_creature_damage(
+            0,
+            1000.0,
+            CreatureDamageType.BULLET,
+            Vec2(),
+            OwnerRef.from_player(0),
+        )
         return []
 
     def _fake_particles_update(*_args: object, **_kwargs: object) -> None:
@@ -354,9 +366,15 @@ def test_ranged_shock_lethal_has_no_resolved_death_sfx(mocker) -> None:
     def _fake_projectile_step(*args: object, **kwargs: object) -> list[ProjectileHit]:
         _ = kwargs
         ctx = cast("PrimaryStepCtx", args[0])
-        apply_creature_damage = ctx.options.apply_creature_damage
-        if apply_creature_damage is not None:
-            apply_creature_damage(0, 1000.0, CreatureDamageType.BULLET, Vec2(), OwnerRef.from_player(0))
+        creature_damage_runtime = ctx.options.creature_damage_runtime
+        if creature_damage_runtime is not None:
+            creature_damage_runtime.apply_creature_damage(
+                0,
+                1000.0,
+                CreatureDamageType.BULLET,
+                Vec2(),
+                OwnerRef.from_player(0),
+            )
         return []
 
     mocker.patch.object(world.state.projectiles, "step", side_effect=_fake_projectile_step)

--- a/tests/gameplay/test_effects.py
+++ b/tests/gameplay/test_effects.py
@@ -10,6 +10,7 @@ from crimson.owner_ref import OwnerRef
 from crimson.rng_caller_static import RngCallerStatic
 from grim.color import RGBA
 from grim.geom import Vec2
+from tests.support.factories import RecordingCreatureDamageRuntime
 from tests.support.helpers import ScriptedCrand, assert_float_close
 
 
@@ -305,23 +306,14 @@ def test_particle_update_uses_explicit_damage_applier() -> None:
 
     pool = ParticlePool(size=1, rng=ScriptedCrand(0, fallback=ScriptedCrand.Fallback.REPEAT_LAST))
     creature = _new_creature()
-    calls: list[tuple[int, float, int, Vec2, OwnerRef]] = []
-
-    def _applier(
-        creature_index: int,
-        damage: float,
-        damage_type: int,
-        impulse: Vec2,
-        owner: OwnerRef,
-    ) -> None:
-        calls.append((creature_index, damage, damage_type, impulse, owner))
+    damage_runtime = RecordingCreatureDamageRuntime(creatures=[creature], apply_damage=False)
 
     _spawn_hit_particle(pool)
-    pool.update(0.016, creatures=[creature], apply_creature_damage=_applier)
-    assert len(calls) == 1
-    assert calls[0][0] == 0
-    assert calls[0][2] == 4
-    assert calls[0][4] == OwnerRef.from_player(0)
+    pool.update(0.016, creatures=[creature], creature_damage_runtime=damage_runtime)
+    assert len(damage_runtime.calls) == 1
+    assert damage_runtime.calls[0][0] == 0
+    assert damage_runtime.calls[0][2] == 4
+    assert damage_runtime.calls[0][4] == OwnerRef.from_player(0)
     assert_float_close(creature.hp, 100.0)
 
 

--- a/tests/projectiles/test_projectile_spatial_hash.py
+++ b/tests/projectiles/test_projectile_spatial_hash.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from crimson.creatures.runtime import CreatureState
-from crimson.owner_ref import OwnerRef
 from crimson.projectiles.runtime import SecondaryProjectilePool, SecondarySpawnSpec, SecondaryStepCtx
 from crimson.projectiles.runtime.spatial_hash import CreatureSpatialHash
 from crimson.projectiles.types import SecondaryProjectileTypeId
 from grim.geom import Vec2
+from tests.support.factories import RecordingCreatureDamageRuntime
 from tests.support.factories import make_creature_state as _creature
 
 
@@ -58,12 +58,8 @@ def test_secondary_projectile_hit_order_matches_linear_index_scan() -> None:
         _creature(pos=Vec2(70.0, -9.0), hp=1000.0, size=500.0),
     ]
 
-    hit_indices: list[int] = []
+    damage_runtime = RecordingCreatureDamageRuntime(creatures=creatures, apply_damage=False)
 
-    def _apply(idx: int, damage: float, damage_type: int, impulse: Vec2, owner: OwnerRef) -> None:
-        _ = (damage, damage_type, impulse, owner)
-        hit_indices.append(int(idx))
+    pool.step(SecondaryStepCtx(dt=0.1, creatures=creatures, creature_damage_runtime=damage_runtime))
 
-    pool.step(SecondaryStepCtx(dt=0.1, creatures=creatures, apply_creature_damage=_apply))
-
-    assert hit_indices == [0]
+    assert [call[0] for call in damage_runtime.calls] == [0]

--- a/tests/projectiles/test_projectiles.py
+++ b/tests/projectiles/test_projectiles.py
@@ -28,8 +28,8 @@ from crimson.projectiles.types import (
 )
 from crimson.rng_caller_static import RngCallerStatic
 from grim.geom import Vec2
+from tests.support.factories import RecordingCreatureDamageRuntime, make_projectile_update_options
 from tests.support.factories import make_creature_state as _creature
-from tests.support.factories import make_projectile_update_options
 from tests.support.helpers import ScriptedCrand, assert_float_close
 
 
@@ -357,31 +357,31 @@ def test_secondary_projectile_pool_snapshot(snapshot: SnapshotAssertion) -> None
     )
 
 
-def test_secondary_projectile_impulse_callbacks_snapshot(snapshot: SnapshotAssertion, mocker) -> None:
+def test_secondary_projectile_impulse_callbacks_snapshot(snapshot: SnapshotAssertion) -> None:
     pool = SecondaryProjectilePool(size=1)
     pool.spawn_from_spec(
         SecondarySpawnSpec(pos=Vec2(), angle=0.0, type_id=SecondaryProjectileTypeId.ROCKET, time_to_live=2.0),
     )
     creatures: list[CreatureState] = [_creature(pos=Vec2(0.0, -9.0), hp=1000.0)]
+    damage_runtime = RecordingCreatureDamageRuntime(creatures=creatures, apply_damage=False)
 
-    apply_damage = mocker.Mock()
-    pool.step(SecondaryStepCtx(dt=0.1, creatures=creatures, apply_creature_damage=apply_damage))
+    pool.step(SecondaryStepCtx(dt=0.1, creatures=creatures, creature_damage_runtime=damage_runtime))
 
     snapshot.assert_match(
         [
             {
-                "idx": int(call.args[0]),
-                "damage": round(float(call.args[1]), 6),
-                "damage_type": int(call.args[2]),
-                "impulse": _normalize_vec2(call.args[3]),
-                "owner": _normalize_owner(call.args[4]),
+                "idx": int(call[0]),
+                "damage": round(float(call[1]), 6),
+                "damage_type": int(call[2]),
+                "impulse": _normalize_vec2(call[3]),
+                "owner": _normalize_owner(call[4]),
             }
-            for call in apply_damage.call_args_list
+            for call in damage_runtime.calls
         ],
     )
 
 
-def test_secondary_projectile_kill_followup_snapshot(snapshot: SnapshotAssertion, mocker) -> None:
+def test_secondary_projectile_kill_followup_snapshot(snapshot: SnapshotAssertion) -> None:
     pool = SecondaryProjectilePool(size=1)
     pool.spawn_from_spec(
         SecondarySpawnSpec(pos=Vec2(), angle=0.0, type_id=SecondaryProjectileTypeId.DETONATION, time_to_live=1.0),
@@ -389,25 +389,20 @@ def test_secondary_projectile_kill_followup_snapshot(snapshot: SnapshotAssertion
     creatures: list[CreatureState] = [_creature(pos=Vec2(0.0, 0.0), hp=20.0)]
     fx_queue = FxQueue()
 
-    def _apply(idx: int, damage: float, damage_type: int, impulse: Vec2, owner: OwnerRef) -> None:
-        _ = (damage_type, impulse, owner)
-        creatures[int(idx)].hp -= float(damage)
-
-    on_kill = mocker.Mock()
+    damage_runtime = RecordingCreatureDamageRuntime(creatures=creatures)
     pool.step(
         SecondaryStepCtx(
             dt=0.1,
             creatures=creatures,
             fx_queue=fx_queue,
-            apply_creature_damage=_apply,
-            on_detonation_kill=on_kill,
+            creature_damage_runtime=damage_runtime,
         ),
     )
 
     snapshot.assert_match(
         {
             "creature_hp": round(float(creatures[0].hp), 6),
-            "followup_calls": [int(call.args[0]) for call in on_kill.call_args_list],
+            "followup_calls": list(damage_runtime.detonation_kills),
             "fx_count": int(fx_queue.count),
         },
     )

--- a/tests/support/factories.py
+++ b/tests/support/factories.py
@@ -4,12 +4,13 @@ from collections.abc import Sequence
 
 import msgspec
 
+from crimson.creatures.damage_runtime import CreatureDamageRuntime, DirectCreatureDamageRuntime
 from crimson.creatures.runtime import CreatureState, CreatureUpdateOptions
 from crimson.creatures.spawn import CreatureFlags, CreatureTypeId, SpawnEnv
 from crimson.effects import FxQueue, FxQueueRotated
 from crimson.gameplay import GameplayState
+from crimson.owner_ref import OwnerRef
 from crimson.projectiles.runtime import ProjectileHitRuntime, ProjectileUpdateOptions
-from crimson.projectiles.types import CreatureDamageApplier
 from crimson.sim.state_types import PlayerState
 from grim.geom import Vec2
 from grim.rand import CrandLike
@@ -93,6 +94,42 @@ class RecordingProjectileHitRuntime(ProjectileHitRuntime):
             player.health -= damage_value
 
 
+class RecordingCreatureDamageRuntime(DirectCreatureDamageRuntime):
+    calls: list[tuple[int, float, int, Vec2, OwnerRef]] = msgspec.field(default_factory=list)
+    kills: list[tuple[int, OwnerRef]] = msgspec.field(default_factory=list)
+    detonation_kills: list[int] = msgspec.field(default_factory=list)
+    apply_damage: bool = True
+
+    def apply_creature_damage(
+        self,
+        creature_index: int,
+        damage: float,
+        damage_type: int,
+        impulse: Vec2,
+        owner: OwnerRef,
+    ) -> None:
+        _ = owner
+        idx = int(creature_index)
+        damage_value = float(damage)
+        self.calls.append((idx, damage_value, int(damage_type), impulse, owner))
+        if not bool(self.apply_damage):
+            return
+        super().apply_creature_damage(
+            idx,
+            damage_value,
+            int(damage_type),
+            impulse,
+            owner,
+        )
+
+    def kill_creature_no_corpse(self, creature_index: int, owner: OwnerRef) -> None:
+        self.kills.append((int(creature_index), owner))
+        super().kill_creature_no_corpse(creature_index, owner)
+
+    def on_secondary_detonation_kill(self, creature_index: int) -> None:
+        self.detonation_kills.append(int(creature_index))
+
+
 def make_projectile_update_options(
     *,
     world_size: float = 1024.0,
@@ -103,7 +140,7 @@ def make_projectile_update_options(
     runtime_state: GameplayState | None = None,
     players: Sequence[PlayerState] | None = None,
     hit_runtime: ProjectileHitRuntime | None = None,
-    apply_creature_damage: CreatureDamageApplier | None = None,
+    creature_damage_runtime: CreatureDamageRuntime | None = None,
 ) -> ProjectileUpdateOptions:
     state = GameplayState() if runtime_state is None else runtime_state
     player_seq: Sequence[PlayerState] = () if players is None else players
@@ -114,7 +151,7 @@ def make_projectile_update_options(
         runtime_state=state,
         players=player_seq,
         hit_runtime=RecordingProjectileHitRuntime(players=player_seq) if hit_runtime is None else hit_runtime,
-        apply_creature_damage=apply_creature_damage,
+        creature_damage_runtime=creature_damage_runtime,
         ion_aoe_scale=float(ion_aoe_scale),
         detail_preset=int(detail_preset),
     )

--- a/tests/weapons/test_particle_weapons.py
+++ b/tests/weapons/test_particle_weapons.py
@@ -15,6 +15,7 @@ from crimson.weapon_runtime import (
 )
 from crimson.weapons import WeaponId
 from grim.geom import Vec2
+from tests.support.factories import RecordingCreatureDamageRuntime
 from tests.support.helpers import ScriptedCrand, assert_float_close
 
 
@@ -187,12 +188,9 @@ def test_bubblegun_particle_kills_attached_target_on_expire() -> None:
     creature.size = 50.0
     creature.lifecycle_stage = 16.0
 
-    killed: list[tuple[int, OwnerRef]] = []
+    damage_runtime = RecordingCreatureDamageRuntime(creatures=[creature])
 
-    def _kill(creature_index: int, owner: OwnerRef) -> None:
-        killed.append((int(creature_index), owner))
+    state.particles.update(0.016, creatures=[creature], creature_damage_runtime=damage_runtime)
+    state.particles.update(2.0, creatures=[creature], creature_damage_runtime=damage_runtime)
 
-    state.particles.update(0.016, creatures=[creature], kill_creature=_kill)
-    state.particles.update(2.0, creatures=[creature], kill_creature=_kill)
-
-    assert killed == [(0, OwnerRef.from_player(0))]
+    assert damage_runtime.kills == [(0, OwnerRef.from_player(0))]


### PR DESCRIPTION
## Summary

- add a concrete `CreatureDamageRuntime` surface plus a direct HP-subtraction runtime for isolated callers
- route primary projectiles, secondary projectiles, particles, bonuses, and nuke damage through the runtime object instead of `CreatureDamageApplier` callbacks
- keep world-step damage grounded in `creature_apply_damage_with_lethal_followup`, preserving death SFX RNG and creature death bookkeeping in the production runtime
- update tests to use recording runtime objects instead of mock/callback damage appliers

## Verification

- `uv run ruff check ...` on touched Python files
- `uv run ty check ...` on touched Python files
- `uv run pytest tests/gameplay/test_death_timing.py tests/gameplay/test_effects.py tests/weapons/test_particle_weapons.py tests/projectiles/test_projectiles.py tests/projectiles/test_projectile_spatial_hash.py tests/projectiles/test_projectile_hit_effects.py tests/bonuses/test_nuke_bonus.py tests/sim/test_step_pipeline_parity.py`
- `just check`
- rebase onto current `origin/master`
- `just check`
- pre-commit hook
- pre-push hook

## Follow-ups

- rollback is still deferred as requested
- `tests/support/world_runtime.py` still has a broad delegation wrapper worth collapsing in a later PR
- `player_update` and player damage still expose small lethal callback hooks; they are narrower than the creature damage surface but remain callback-shaped
