### PR TITLE
refactor: route player deaths through runtime

### DIFF
--- a/src/crimson/creatures/runtime.py
+++ b/src/crimson/creatures/runtime.py
@@ -40,7 +40,7 @@ from ..math_parity import (
 from ..owner_ref import OwnerRef
 from ..perks import PerkId
 from ..perks.helpers import perk_active
-from ..player_damage import player_take_damage
+from ..player_damage import PlayerDeathRuntime, player_take_damage
 from ..projectiles.types import ProjectileTemplateId
 from ..rng_caller_static import RngCallerStatic
 from ..sim.state_types import GameplayState, PlayerState
@@ -320,6 +320,27 @@ class _CreatureInteractionCtx(msgspec.Struct):
     contact_dist_sq: float = 0.0
 
 
+class _CreatureInteractionPlayerDeathRuntime(PlayerDeathRuntime):
+    ctx: _CreatureInteractionCtx
+
+    def on_player_lethal(self, player: PlayerState, *, dt: float) -> None:
+        _ = player
+        from ..perks.impl.final_revenge import apply_final_revenge_on_player_death
+
+        ctx = self.ctx
+        apply_final_revenge_on_player_death(
+            state=ctx.state,
+            creatures=ctx.pool,
+            players=ctx.players,
+            player=ctx.player,
+            dt=float(dt),
+            world_size=float(max(float(ctx.world_width), float(ctx.world_height))),
+            detail_preset=int(ctx.detail_preset),
+            fx_queue=ctx.fx_queue,
+            deaths=ctx.deaths,
+        )
+
+
 _CreatureInteractionStep = Callable[[_CreatureInteractionCtx], None]
 
 
@@ -458,28 +479,13 @@ def _creature_interaction_contact_damage(ctx: _CreatureInteractionCtx) -> None:
         elif perk_active(ctx.player, PerkId.VEINS_OF_POISON):
             creature.flags |= CreatureFlags.SELF_DAMAGE_TICK
 
-    def _on_player_lethal_final_revenge() -> None:
-        from ..perks.impl.final_revenge import apply_final_revenge_on_player_death
-
-        apply_final_revenge_on_player_death(
-            state=ctx.state,
-            creatures=ctx.pool,
-            players=ctx.players,
-            player=ctx.player,
-            dt=float(ctx.dt),
-            world_size=float(max(float(ctx.world_width), float(ctx.world_height))),
-            detail_preset=int(ctx.detail_preset),
-            fx_queue=ctx.fx_queue,
-            deaths=ctx.deaths,
-        )
-
     player_take_damage(
         ctx.state,
         ctx.player,
         float(creature.contact_damage),
         dt=ctx.dt,
         players=ctx.players,
-        on_lethal=_on_player_lethal_final_revenge,
+        death_runtime=_CreatureInteractionPlayerDeathRuntime(ctx=ctx),
     )
 
     if ctx.fx_queue is not None:

--- a/src/crimson/gameplay.py
+++ b/src/crimson/gameplay.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, cast
 
 import msgspec
@@ -24,6 +24,7 @@ from .perks import PerkId
 from .perks.helpers import perk_active
 from .perks.runtime.player_ticks import apply_player_perk_ticks
 from .perks.state import PerkEffectIntervals, PerkSelectionState
+from .player_damage import PlayerDeathRuntime
 from .projectiles.runtime import (
     ProjectilePool,
     SecondaryProjectilePool,
@@ -545,7 +546,7 @@ def player_update(
     players: list[PlayerState] | None = None,
     creatures: Sequence[CreatureState] | None = None,
     spawn_slots: Sequence[SpawnSlotInit] | None = None,
-    on_player_lethal: Callable[[PlayerState], None] | None = None,
+    player_death_runtime: PlayerDeathRuntime | None = None,
     reload_active_any: bool | None = None,
 ) -> None:
     """Port of `player_update` (0x004136b0) for the rewrite runtime."""
@@ -992,7 +993,7 @@ def player_update(
             creatures=creatures,
             players=players,
             force_pre_swap_fire_gate=bool(force_pre_swap_fire_gate),
-            on_player_lethal=on_player_lethal,
+            player_death_runtime=player_death_runtime,
         ),
     )
 

--- a/src/crimson/player_damage.py
+++ b/src/crimson/player_damage.py
@@ -6,7 +6,9 @@ This is a minimal, rewrite-focused port of `player_take_damage` (0x00425e50).
 See: `docs/crimsonland-exe/player-damage.md`.
 """
 
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
+
+import msgspec
 
 from grim.sfx_map import SfxId
 
@@ -16,7 +18,7 @@ from .perks.helpers import perk_active
 from .rng_caller_static import RngCallerStatic
 from .sim.state_types import GameplayState, PlayerState
 
-__all__ = ["player_take_damage", "player_take_projectile_damage"]
+__all__ = ["PlayerDeathRuntime", "player_take_damage", "player_take_projectile_damage"]
 _PLAYER_PAIN_SFX: tuple[SfxId, ...] = (
     SfxId.TROOPER_INPAIN_01,
     SfxId.TROOPER_INPAIN_02,
@@ -26,6 +28,11 @@ _PLAYER_DEATH_SFX: tuple[SfxId, ...] = (SfxId.TROOPER_DIE_01, SfxId.TROOPER_DIE_
 _THICK_SKINNED_DAMAGE_SCALE_F32 = 0.6660000085830688
 
 
+class PlayerDeathRuntime(msgspec.Struct):
+    def on_player_lethal(self, player: PlayerState, *, dt: float) -> None:
+        _ = player, dt
+
+
 def player_take_damage(
     state: GameplayState,
     player: PlayerState,
@@ -33,7 +40,7 @@ def player_take_damage(
     *,
     dt: float | None = None,
     players: Sequence[PlayerState] | None = None,
-    on_lethal: Callable[[], None] | None = None,
+    death_runtime: PlayerDeathRuntime | None = None,
 ) -> float:
     """Apply damage to a player, returning the actual damage applied."""
 
@@ -101,8 +108,8 @@ def player_take_damage(
             return max(0.0, health_before - float(player.health))
         if not perk_active(player, PerkId.FINAL_REVENGE):
             state.sfx_queue.append(_PLAYER_DEATH_SFX[state.rng.rand_tagged(RngCallerStatic.PLAYER_TAKE_DAMAGE_DEATH_SFX) & 1])
-        elif on_lethal is not None:
-            on_lethal()
+        elif death_runtime is not None:
+            death_runtime.on_player_lethal(player, dt=0.0 if dt is None else float(dt))
             state.player_death_hook_skip_indices.add(int(player.index))
 
     if not dodged:

--- a/src/crimson/sim/world_state.py
+++ b/src/crimson/sim/world_state.py
@@ -27,7 +27,7 @@ from ..gameplay import (
 from ..owner_ref import OwnerRef
 from ..perks.runtime.effects import perks_update_effects
 from ..perks.runtime.manifest import PLAYER_DEATH_HOOKS, WORLD_DT_STEPS
-from ..player_damage import player_take_projectile_damage
+from ..player_damage import PlayerDeathRuntime, player_take_projectile_damage
 from ..projectiles.runtime import PrimaryStepCtx, ProjectileHitRuntime, ProjectileUpdateOptions, SecondaryStepCtx
 from ..projectiles.types import ProjectileHit
 from .input import PlayerInput
@@ -60,7 +60,7 @@ _WORLD_DT_STEPS = WORLD_DT_STEPS
 _PLAYER_DEATH_HOOKS = PLAYER_DEATH_HOOKS
 
 
-class _WorldStepRuntime(ProjectileHitRuntime, CreatureDamageRuntime):
+class _WorldStepRuntime(ProjectileHitRuntime, CreatureDamageRuntime, PlayerDeathRuntime):
     world: WorldState
     dt: float
     world_size: float
@@ -375,10 +375,7 @@ class WorldState(msgspec.Struct):
                 players=self.players,
                 creatures=self.creatures.entries,
                 spawn_slots=self.creatures.spawn_slots,
-                on_player_lethal=lambda dead_player, dt_value=float(player_dt): step_runtime.on_player_lethal(
-                    dead_player,
-                    dt=float(dt_value),
-                ),
+                player_death_runtime=step_runtime,
                 reload_active_any=bool(reload_active_any),
             )
             if dt_player_local is None:

--- a/src/crimson/weapon_runtime/fire.py
+++ b/src/crimson/weapon_runtime/fire.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import msgspec
@@ -13,6 +13,7 @@ from grim.rand import CrandLike
 from ..math_parity import NATIVE_TAU, f32, heading_from_delta_f32
 from ..perks import PerkId
 from ..perks.helpers import perk_active
+from ..player_damage import PlayerDeathRuntime
 from ..projectiles.runtime import SecondarySpawnSpec
 from ..projectiles.types import ProjectileTemplateId, SecondaryProjectileTypeId
 from ..rng_caller_static import RngCallerStatic
@@ -92,7 +93,7 @@ class WeaponFireCtx(msgspec.Struct):
     creatures: Sequence[CreatureState] | None = None
     players: Sequence[PlayerState] | None = None
     force_pre_swap_fire_gate: bool = False
-    on_player_lethal: Callable[[PlayerState], None] | None = None
+    player_death_runtime: PlayerDeathRuntime | None = None
 
 
 class WeaponFireResult(msgspec.Struct, frozen=True):
@@ -206,7 +207,7 @@ def fire_weapon(ctx: WeaponFireCtx) -> WeaponFireResult:
     creatures = ctx.creatures
     players = ctx.players
     force_pre_swap_fire_gate = bool(ctx.force_pre_swap_fire_gate)
-    on_player_lethal = ctx.on_player_lethal
+    player_death_runtime = ctx.player_death_runtime
 
     weapon_id = player.weapon.weapon_id
     weapon = weapon_entry(weapon_id)
@@ -241,7 +242,7 @@ def fire_weapon(ctx: WeaponFireCtx) -> WeaponFireResult:
                 cost,
                 dt=dt,
                 players=players,
-                on_lethal=(lambda: on_player_lethal(player)) if on_player_lethal is not None else None,
+                death_runtime=player_death_runtime,
             )
         else:
             return WeaponFireResult(fired=False)


### PR DESCRIPTION
## Summary

- add `PlayerDeathRuntime` for lethal player damage follow-up
- route Ammunition Within, player update, and creature contact final-revenge paths through runtime objects instead of lambdas/callback fields
- keep world-step runtime owning actual player death hook dispatch, while creature contact builds a concrete interaction runtime around the current decompile-grounded context

## Verification

- `uv run ruff check src/crimson/player_damage.py src/crimson/weapon_runtime/fire.py src/crimson/gameplay.py src/crimson/creatures/runtime.py src/crimson/sim/world_state.py`
- `uv run ty check src/crimson/player_damage.py src/crimson/weapon_runtime/fire.py src/crimson/gameplay.py src/crimson/creatures/runtime.py src/crimson/sim/world_state.py`
- `uv run pytest tests/gameplay/test_player_damage.py tests/weapons/test_weapon_fire_patterns.py tests/perks/test_final_revenge_perk.py tests/gameplay/test_death_timing.py tests/creatures/test_creature_runtime.py tests/sim/test_step_pipeline_parity.py`
- `just check`
- rebased onto current `origin/master`
- `just check`
- pre-push hook

## Follow-ups

- creature death `on_lethal` callbacks remain in `creature_apply_damage_with_lethal_followup` and creature melee/final-revenge paths
- rollback remains deferred as requested
- `tests/support/world_runtime.py` delegation wrapper still looks worth collapsing later
