### PR TITLE
refactor: route creature deaths through runtime

### DIFF
--- a/src/crimson/creatures/damage.py
+++ b/src/crimson/creatures/damage.py
@@ -18,6 +18,7 @@ from ..perks import PerkId
 from ..perks.helpers import perk_active
 from ..rng_caller_static import RngCallerStatic
 from ..sim.state_types import PlayerState
+from .damage_runtime import CreatureDamageRuntime
 from .damage_types import CreatureDamageType
 from .runtime import CREATURE_LIFECYCLE_ALIVE, CreatureState
 from .spawn import CreatureFlags, CreatureTypeId
@@ -297,6 +298,7 @@ def creature_apply_damage(
 def creature_apply_damage_with_lethal_followup(
     creature: CreatureState,
     *,
+    creature_index: int,
     damage_amount: float,
     damage_type: int,
     impulse: Vec2,
@@ -307,7 +309,7 @@ def creature_apply_damage_with_lethal_followup(
     preserve_bugs: bool = False,
     effects: EffectPool | None = None,
     detail_preset: int = 5,
-    on_lethal: Callable[[tuple[SfxId, ...]], None],
+    creature_damage_runtime: CreatureDamageRuntime,
 ) -> bool:
     """Apply damage and run a required lethal follow-up exactly on death transition.
 
@@ -329,6 +331,9 @@ def creature_apply_damage_with_lethal_followup(
         detail_preset=int(detail_preset),
     )
     if killed and death_start_needed:
-        on_lethal(resolve_native_death_sfx(creature, rng=rng, preserve_bugs=preserve_bugs))
+        creature_damage_runtime.on_creature_lethal(
+            int(creature_index),
+            resolve_native_death_sfx(creature, rng=rng, preserve_bugs=preserve_bugs),
+        )
         return True
     return False

--- a/src/crimson/creatures/damage_runtime.py
+++ b/src/crimson/creatures/damage_runtime.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import msgspec
 
 from grim.geom import Vec2
+from grim.sfx_map import SfxId
 
 from ..owner_ref import OwnerRef
 
@@ -29,6 +30,9 @@ class CreatureDamageRuntime(msgspec.Struct):
 
     def on_secondary_detonation_kill(self, creature_index: int) -> None:
         _ = creature_index
+
+    def on_creature_lethal(self, creature_index: int, death_sfx: tuple[SfxId, ...]) -> None:
+        _ = creature_index, death_sfx
 
 
 class DirectCreatureDamageRuntime(CreatureDamageRuntime):

--- a/src/crimson/creatures/runtime.py
+++ b/src/crimson/creatures/runtime.py
@@ -47,6 +47,7 @@ from ..sim.state_types import GameplayState, PlayerState
 from ..sim.timing import ftol_ms_i32
 from ..weapons import weapon_entry_for_projectile_type_id
 from .ai import creature_ai7_tick_link_timer, creature_ai_update_target
+from .damage_runtime import CreatureDamageRuntime
 from .damage_types import CreatureDamageType
 from .lifecycle import (
     CREATURE_LIFECYCLE_ALIVE,
@@ -338,10 +339,73 @@ class _CreatureInteractionPlayerDeathRuntime(PlayerDeathRuntime):
             detail_preset=int(ctx.detail_preset),
             fx_queue=ctx.fx_queue,
             deaths=ctx.deaths,
+            )
+
+
+class _CreatureInteractionCreatureDamageRuntime(CreatureDamageRuntime):
+    ctx: _CreatureInteractionCtx
+
+    def on_creature_lethal(self, creature_index: int, death_sfx: tuple[SfxId, ...]) -> None:
+        ctx = self.ctx
+        creature = ctx.creature
+        ctx.deaths.append(
+            ctx.pool.handle_death(
+                int(creature_index),
+                state=ctx.state,
+                players=ctx.players,
+                rng=ctx.rng,
+                dt=float(ctx.dt),
+                detail_preset=int(ctx.detail_preset),
+                world_width=float(ctx.world_width),
+                world_height=float(ctx.world_height),
+                fx_queue=ctx.fx_queue,
+            ),
         )
+        ctx.sfx.extend(death_sfx)
+        if creature.active:
+            ctx.pool._tick_dead(
+                creature,
+                dt=ctx.dt,
+                world_width=float(ctx.world_width),
+                world_height=float(ctx.world_height),
+                fx_queue_rotated=ctx.fx_queue_rotated,
+                rng=ctx.rng,
+                detail_preset=int(ctx.detail_preset),
+                violence_disabled=int(ctx.violence_disabled),
+            )
 
 
 _CreatureInteractionStep = Callable[[_CreatureInteractionCtx], None]
+
+
+class _CreaturePoolCreatureDamageRuntime(CreatureDamageRuntime):
+    pool: CreaturePool
+    state: GameplayState
+    players: list[PlayerState]
+    rng: CrandLike
+    dt: float
+    detail_preset: int
+    world_width: float
+    world_height: float
+    fx_queue: FxQueue | None
+    deaths: list[CreatureDeath]
+    sfx: list[SfxId]
+
+    def on_creature_lethal(self, creature_index: int, death_sfx: tuple[SfxId, ...]) -> None:
+        self.deaths.append(
+            self.pool.handle_death(
+                int(creature_index),
+                state=self.state,
+                players=self.players,
+                rng=self.rng,
+                dt=float(self.dt),
+                detail_preset=int(self.detail_preset),
+                world_width=float(self.world_width),
+                world_height=float(self.world_height),
+                fx_queue=self.fx_queue,
+            ),
+        )
+        self.sfx.extend(death_sfx)
 
 
 def _creature_interaction_plaguebearer_spread(ctx: _CreatureInteractionCtx) -> None:
@@ -431,35 +495,9 @@ def _creature_interaction_contact_damage(ctx: _CreatureInteractionCtx) -> None:
     if perk_active(ctx.player, PerkId.MR_MELEE):
         from .damage import creature_apply_damage_with_lethal_followup
 
-        def _on_mr_melee_lethal(death_sfx: tuple[SfxId, ...]) -> None:
-            ctx.deaths.append(
-                ctx.pool.handle_death(
-                    ctx.creature_index,
-                    state=ctx.state,
-                    players=ctx.players,
-                    rng=ctx.rng,
-                    dt=float(ctx.dt),
-                    detail_preset=int(ctx.detail_preset),
-                    world_width=float(ctx.world_width),
-                    world_height=float(ctx.world_height),
-                    fx_queue=ctx.fx_queue,
-                ),
-            )
-            ctx.sfx.extend(death_sfx)
-            if creature.active:
-                ctx.pool._tick_dead(
-                    creature,
-                    dt=ctx.dt,
-                        world_width=float(ctx.world_width),
-                        world_height=float(ctx.world_height),
-                        fx_queue_rotated=ctx.fx_queue_rotated,
-                        rng=ctx.rng,
-                        detail_preset=int(ctx.detail_preset),
-                        violence_disabled=int(ctx.violence_disabled),
-                    )
-
         mr_melee_killed = creature_apply_damage_with_lethal_followup(
             creature,
+            creature_index=int(ctx.creature_index),
             damage_amount=25.0,
             damage_type=CreatureDamageType.MELEE,
             impulse=Vec2(),
@@ -470,7 +508,7 @@ def _creature_interaction_contact_damage(ctx: _CreatureInteractionCtx) -> None:
             preserve_bugs=bool(ctx.state.preserve_bugs),
             effects=ctx.state.effects,
             detail_preset=int(ctx.detail_preset),
-            on_lethal=_on_mr_melee_lethal,
+            creature_damage_runtime=_CreatureInteractionCreatureDamageRuntime(ctx=ctx),
         )
 
     if float(ctx.player.shield_timer) <= 0.0:
@@ -906,6 +944,19 @@ class CreaturePool:
         # Native AI7 timer math uses `frame_dt_ms` integer slots with ftol-style
         # truncation semantics.
         dt_ms = ftol_ms_i32(float(dt)) if dt > 0.0 else 0
+        creature_damage_runtime = _CreaturePoolCreatureDamageRuntime(
+            pool=self,
+            state=state,
+            players=players,
+            rng=rng,
+            dt=float(dt),
+            detail_preset=int(detail_preset),
+            world_width=float(world_width),
+            world_height=float(world_height),
+            fx_queue=fx_queue,
+            deaths=deaths,
+            sfx=sfx,
+        )
 
         def _apply_self_damage_tick(creature_index: int, creature: CreatureState) -> bool:
             if dt <= 0.0 or float(state.bonuses.freeze) > 0.0:
@@ -921,24 +972,9 @@ class CreaturePool:
 
             from .damage import creature_apply_damage_with_lethal_followup
 
-            def _on_lethal(death_sfx: tuple[SfxId, ...]) -> None:
-                deaths.append(
-                    self.handle_death(
-                        int(creature_index),
-                        state=state,
-                        players=players,
-                        rng=rng,
-                        dt=float(dt),
-                        detail_preset=int(detail_preset),
-                        world_width=world_width,
-                        world_height=world_height,
-                        fx_queue=fx_queue,
-                    ),
-                )
-                sfx.extend(death_sfx)
-
             return creature_apply_damage_with_lethal_followup(
                 creature,
+                creature_index=int(creature_index),
                 damage_amount=float(damage_amount),
                 damage_type=CreatureDamageType.SELF_TICK,
                 impulse=Vec2(),
@@ -949,7 +985,7 @@ class CreaturePool:
                 preserve_bugs=bool(state.preserve_bugs),
                 effects=state.effects,
                 detail_preset=int(detail_preset),
-                on_lethal=_on_lethal,
+                creature_damage_runtime=creature_damage_runtime,
             )
 
         for idx, creature in enumerate(self._entries):

--- a/src/crimson/perks/impl/final_revenge.py
+++ b/src/crimson/perks/impl/final_revenge.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from grim.geom import Vec2
 from grim.sfx_map import SfxId
 
+from ...creatures.damage_runtime import CreatureDamageRuntime
 from ...creatures.damage_types import CreatureDamageType
 from ...effects import FxQueue
 from ...owner_ref import OwnerRef
@@ -15,6 +16,33 @@ from ..runtime.hook_types import PerkHooks
 
 if TYPE_CHECKING:
     from ...creatures.runtime import CreatureDeath, CreaturePool
+
+
+class _FinalRevengeCreatureDamageRuntime(CreatureDamageRuntime):
+    state: GameplayState
+    creatures: CreaturePool
+    players: list[PlayerState]
+    dt: float
+    world_size: float
+    detail_preset: int
+    fx_queue: FxQueue | None
+    deaths: list[CreatureDeath]
+
+    def on_creature_lethal(self, creature_index: int, death_sfx: tuple[SfxId, ...]) -> None:
+        self.deaths.append(
+            self.creatures.handle_death(
+                int(creature_index),
+                state=self.state,
+                players=self.players,
+                rng=self.state.rng,
+                dt=float(self.dt),
+                detail_preset=int(self.detail_preset),
+                world_width=float(self.world_size),
+                world_height=float(self.world_size),
+                fx_queue=self.fx_queue,
+            ),
+        )
+        self.state.sfx_queue.extend(death_sfx)
 
 
 def apply_final_revenge_on_player_death(
@@ -45,6 +73,16 @@ def apply_final_revenge_on_player_death(
 
     prev_guard = bool(state.bonus_spawn_guard)
     state.bonus_spawn_guard = True
+    creature_damage_runtime = _FinalRevengeCreatureDamageRuntime(
+        state=state,
+        creatures=creatures,
+        players=players,
+        dt=float(dt),
+        world_size=float(world_size),
+        detail_preset=int(detail_preset),
+        fx_queue=fx_queue,
+        deaths=deaths,
+    )
     for creature_idx, creature in enumerate(creatures.entries):
         if not creature.active:
             continue
@@ -58,9 +96,9 @@ def apply_final_revenge_on_player_death(
             continue
 
         damage = remaining * 5.0
-        death_creature_idx = int(creature_idx)
         creature_apply_damage_with_lethal_followup(
             creature,
+            creature_index=int(creature_idx),
             damage_amount=damage,
             damage_type=CreatureDamageType.EXPLOSION,
             impulse=Vec2(),
@@ -71,22 +109,7 @@ def apply_final_revenge_on_player_death(
             preserve_bugs=bool(state.preserve_bugs),
             effects=state.effects,
             detail_preset=int(detail_preset),
-            on_lethal=lambda death_sfx, death_creature_idx=death_creature_idx: (
-                deaths.append(
-                    creatures.handle_death(
-                        int(death_creature_idx),
-                        state=state,
-                        players=players,
-                        rng=state.rng,
-                        dt=float(dt),
-                        detail_preset=int(detail_preset),
-                        world_width=float(world_size),
-                        world_height=float(world_size),
-                        fx_queue=fx_queue,
-                    ),
-                ),
-                state.sfx_queue.extend(death_sfx),
-            ),
+            creature_damage_runtime=creature_damage_runtime,
         )
 
     state.bonus_spawn_guard = prev_guard

--- a/src/crimson/sim/world_state.py
+++ b/src/crimson/sim/world_state.py
@@ -99,6 +99,7 @@ class _WorldStepRuntime(ProjectileHitRuntime, CreatureDamageRuntime, PlayerDeath
             return
         creature_apply_damage_with_lethal_followup(
             creature,
+            creature_index=idx,
             damage_amount=float(damage),
             damage_type=int(damage_type),
             impulse=impulse,
@@ -109,16 +110,19 @@ class _WorldStepRuntime(ProjectileHitRuntime, CreatureDamageRuntime, PlayerDeath
             preserve_bugs=bool(self.world.state.preserve_bugs),
             effects=self.world.state.effects,
             detail_preset=int(self.detail_preset),
-            on_lethal=lambda death_sfx: self.world._record_creature_death(
-                creature_index=idx,
-                dt=float(self.dt),
-                detail_preset=int(self.detail_preset),
-                world_size=float(self.world_size),
-                fx_queue=self.fx_queue,
-                deaths=self.deaths,
-                sfx=self.sfx,
-                death_sfx=death_sfx,
-            ),
+            creature_damage_runtime=self,
+        )
+
+    def on_creature_lethal(self, creature_index: int, death_sfx: tuple[SfxId, ...]) -> None:
+        self.world._record_creature_death(
+            creature_index=int(creature_index),
+            dt=float(self.dt),
+            detail_preset=int(self.detail_preset),
+            world_size=float(self.world_size),
+            fx_queue=self.fx_queue,
+            deaths=self.deaths,
+            sfx=self.sfx,
+            death_sfx=death_sfx,
         )
 
     def on_secondary_detonation_kill(self, creature_index: int) -> None:

--- a/tests/creatures/test_creature_damage_callsite_guardrails.py
+++ b/tests/creatures/test_creature_damage_callsite_guardrails.py
@@ -16,8 +16,17 @@ def _direct_creature_apply_damage_calls(path: Path) -> list[int]:
     return lines
 
 
+def _function_keyword_only_args(path: Path, function_name: str) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            return [arg.arg for arg in node.args.kwonlyargs]
+    msg = f"{function_name} not found in {path}"
+    raise AssertionError(msg)
+
+
 def test_runtime_damage_paths_use_lethal_followup_helper() -> None:
-    repo_root = Path(__file__).resolve().parents[1]
+    repo_root = Path(__file__).resolve().parents[2]
     src_root = repo_root / "src" / "crimson"
     allowed = {
         src_root / "creatures" / "damage.py",
@@ -33,3 +42,13 @@ def test_runtime_damage_paths_use_lethal_followup_helper() -> None:
         offenders.append(f"{path}:{','.join(str(line) for line in lines)}")
 
     assert not offenders, "Direct creature_apply_damage callsites found in runtime code: " + "; ".join(offenders)
+
+
+def test_lethal_followup_helper_uses_runtime_object() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    damage_path = repo_root / "src" / "crimson" / "creatures" / "damage.py"
+
+    args = _function_keyword_only_args(damage_path, "creature_apply_damage_with_lethal_followup")
+
+    assert "creature_damage_runtime" in args
+    assert "on_lethal" not in args


### PR DESCRIPTION
## Summary

- add `on_creature_lethal` to `CreatureDamageRuntime`
- route world-step, MR Melee contact, self-damage tick, and Final Revenge creature death follow-up through runtime objects instead of `on_lethal` closures
- keep native death SFX resolution inside `creature_apply_damage_with_lethal_followup`, so RNG-consuming parity remains adjacent to damage application
- tighten the creature damage guardrail test so it resolves the real repo root and asserts the helper uses a runtime object rather than a callback parameter

## Verification

- `uv run ruff check src/crimson/creatures/damage.py src/crimson/creatures/damage_runtime.py src/crimson/creatures/runtime.py src/crimson/sim/world_state.py src/crimson/perks/impl/final_revenge.py tests/creatures/test_creature_damage_callsite_guardrails.py`
- `uv run ty check src/crimson/creatures/damage.py src/crimson/creatures/damage_runtime.py src/crimson/creatures/runtime.py src/crimson/sim/world_state.py src/crimson/perks/impl/final_revenge.py tests/creatures/test_creature_damage_callsite_guardrails.py`
- `uv run pytest tests/creatures/test_creature_damage.py tests/creatures/test_creature_damage_callsite_guardrails.py tests/creatures/test_creature_runtime.py tests/perks/test_final_revenge_perk.py tests/gameplay/test_death_timing.py tests/sim/test_step_pipeline_parity.py`
- `just check`
- reran `uv run pytest tests/net/cli/test_zig_net_cli.py -q` after an intermittent rollback-smoke failure in the first full check attempt
- `just check`
- rebased onto current `origin/master`
- `just check`
- pre-push hook

## Follow-ups

- rollback remains deferred as requested
- `tests/support/world_runtime.py` delegation wrapper is still a good next cleanup target
- replay/render progress callback APIs are still callback-shaped, but they are mostly boundary/progress reporting rather than deterministic simulation callbacks
