### PR TITLE
refactor: route presentation reactions through runtime

### DIFF
--- a/src/crimson/modes/base_gameplay_mode.py
+++ b/src/crimson/modes/base_gameplay_mode.py
@@ -81,6 +81,7 @@ from ..sim.input_providers import (
 )
 from ..sim.presentation_reactions import (
     PostApplyReaction,
+    PostApplyReactionRuntime,
     apply_post_apply_reaction,
     build_post_apply_reaction,
 )
@@ -128,6 +129,13 @@ class _ModePresentationApplyRuntime(PresentationApplyRuntime):
             self.reactions_by_tick.get(int(output.tick_index), PostApplyReaction()),
             dt_seconds=float(output.dt_sim),
         )
+
+
+class _ModePostApplyReactionRuntime(PostApplyReactionRuntime):
+    mode: BaseGameplayMode
+
+    def play_sfx(self, sfx: SfxId) -> None:
+        self.mode.audio_bridge.router.play_sfx(sfx)
 
 
 class _ModeLocalInputRuntime(LocalInputRuntime):
@@ -1857,7 +1865,7 @@ class BaseGameplayMode:
         _ = dt_seconds
         apply_post_apply_reaction(
             reaction=reaction,
-            play_sfx=self.audio_bridge.router.play_sfx,
+            runtime=_ModePostApplyReactionRuntime(mode=self),
         )
 
     def _process_tick_batch_results(

--- a/src/crimson/modes/quest_mode.py
+++ b/src/crimson/modes/quest_mode.py
@@ -38,6 +38,7 @@ from ..sim.bootstrap import advance_explicit_terrain, advance_unlock_terrain
 from ..sim.hooks import TickResult
 from ..sim.presentation_reactions import (
     PostApplyReaction,
+    PostApplyReactionRuntime,
     apply_post_apply_reaction,
     build_post_apply_reaction,
 )
@@ -84,6 +85,16 @@ class QuestRunOutcome(msgspec.Struct, frozen=True):
     shots_hit: int
     most_used_weapon_id: WeaponId
     player_health_values: tuple[float, ...] = ()
+
+
+class _QuestPostApplyReactionRuntime(PostApplyReactionRuntime):
+    mode: QuestMode
+
+    def play_sfx(self, sfx: SfxId) -> None:
+        self.mode.audio_bridge.router.play_sfx(sfx)
+
+    def play_completion_music(self) -> None:
+        self.mode._play_quest_completion_music()
 
 
 class QuestMode(BaseGameplayMode):
@@ -328,8 +339,7 @@ class QuestMode(BaseGameplayMode):
         _ = dt_seconds
         apply_post_apply_reaction(
             reaction=reaction,
-            play_sfx=self.audio_bridge.router.play_sfx,
-            play_completion_music=self._play_quest_completion_music,
+            runtime=_QuestPostApplyReactionRuntime(mode=self),
         )
 
     def _play_quest_completion_music(self) -> None:

--- a/src/crimson/modes/replay_playback_mode.py
+++ b/src/crimson/modes/replay_playback_mode.py
@@ -14,6 +14,7 @@ from grim.fonts.small import SmallFontData, draw_small_text, load_small_font, me
 from grim.geom import Vec2
 from grim.rand import Crand
 from grim.raylib_api import rl
+from grim.sfx_map import SfxId
 from grim.view import ViewContext
 
 from ..game_modes import GameMode
@@ -39,6 +40,7 @@ from ..sim.clock import FixedStepClock
 from ..sim.hooks import TickResult
 from ..sim.presentation_reactions import (
     PostApplyReaction,
+    PostApplyReactionRuntime,
     apply_post_apply_reaction,
     build_post_apply_reaction,
 )
@@ -85,6 +87,19 @@ class _ReplayPresentationApplyRuntime(PresentationApplyRuntime):
 
     def output_applied(self, output: PresentationTickOutput) -> None:
         self.mode._apply_post_apply_reaction(self.reactions_by_tick[int(output.tick_index)])
+
+
+class _ReplayPostApplyReactionRuntime(PostApplyReactionRuntime):
+    mode: ReplayPlaybackMode
+
+    def play_sfx(self, sfx: SfxId) -> None:
+        runtime = self.mode._runtime
+        if runtime is None:
+            return
+        runtime.audio_bridge.router.play_sfx(sfx)
+
+    def play_completion_music(self) -> None:
+        self.mode._play_quest_completion_music()
 
 
 class ReplayPlaybackMode:
@@ -435,8 +450,7 @@ class ReplayPlaybackMode:
             return
         apply_post_apply_reaction(
             reaction=reaction,
-            play_sfx=runtime.audio_bridge.router.play_sfx,
-            play_completion_music=self._play_quest_completion_music,
+            runtime=_ReplayPostApplyReactionRuntime(mode=self),
         )
 
     def _play_quest_completion_music(self) -> None:

--- a/src/crimson/sim/presentation_reactions.py
+++ b/src/crimson/sim/presentation_reactions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass
+import msgspec
 
 from grim.sfx_map import SfxId
 
@@ -9,16 +8,22 @@ from .hooks import TickResult
 from .sessions import QuestSpawnState
 
 
-@dataclass(frozen=True, slots=True)
-class QuestPresentationReaction:
+class QuestPresentationReaction(msgspec.Struct, frozen=True):
     play_hit_sfx: bool = False
     play_completion_music: bool = False
 
 
-@dataclass(frozen=True, slots=True)
-class PostApplyReaction:
+class PostApplyReaction(msgspec.Struct, frozen=True):
     sfx: tuple[SfxId, ...] = ()
     quest: QuestPresentationReaction | None = None
+
+
+class PostApplyReactionRuntime(msgspec.Struct):
+    def play_sfx(self, sfx: SfxId) -> None:
+        _ = sfx
+
+    def play_completion_music(self) -> None:
+        pass
 
 
 def build_post_apply_reaction(
@@ -42,15 +47,15 @@ def build_post_apply_reaction(
 def apply_post_apply_reaction(
     *,
     reaction: PostApplyReaction,
-    play_sfx: Callable[[SfxId], None] | None,
-    play_completion_music: Callable[[], None] | None = None,
+    runtime: PostApplyReactionRuntime | None = None,
 ) -> None:
+    if runtime is None:
+        return
     quest = reaction.quest
-    if play_sfx is not None:
-        for sfx in reaction.sfx:
-            play_sfx(sfx)
-        if quest is not None and bool(quest.play_hit_sfx):
-            play_sfx(SfxId.QUESTHIT)
+    for sfx in reaction.sfx:
+        runtime.play_sfx(sfx)
+    if quest is not None and bool(quest.play_hit_sfx):
+        runtime.play_sfx(SfxId.QUESTHIT)
 
-    if quest is not None and bool(quest.play_completion_music) and play_completion_music is not None:
-        play_completion_music()
+    if quest is not None and bool(quest.play_completion_music):
+        runtime.play_completion_music()

--- a/src/crimson/world/standalone_tick_harness.py
+++ b/src/crimson/world/standalone_tick_harness.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from grim.sfx_map import SfxId
+
 from ..game_modes import GameMode
 from ..sim.batch_apply import (
     PresentationApplyRuntime,
@@ -15,6 +17,7 @@ from ..sim.frame_pump import advance_tick_runner_frame
 from ..sim.input_providers import LocalInputProvider, LocalInputRuntime
 from ..sim.presentation_reactions import (
     PostApplyReaction,
+    PostApplyReactionRuntime,
     apply_post_apply_reaction,
     build_post_apply_reaction,
 )
@@ -32,8 +35,15 @@ class _StandalonePresentationApplyRuntime(PresentationApplyRuntime):
     def output_applied(self, output: PresentationTickOutput) -> None:
         apply_post_apply_reaction(
             reaction=self.reactions_by_tick.get(int(output.tick_index), PostApplyReaction()),
-            play_sfx=self.runtime.audio_bridge.router.play_sfx,
+            runtime=_StandalonePostApplyReactionRuntime(runtime=self.runtime),
         )
+
+
+class _StandalonePostApplyReactionRuntime(PostApplyReactionRuntime):
+    runtime: WorldRuntime
+
+    def play_sfx(self, sfx: SfxId) -> None:
+        self.runtime.audio_bridge.router.play_sfx(sfx)
 
 
 @dataclass(slots=True)

--- a/tests/contracts/test_architecture_contracts.py
+++ b/tests/contracts/test_architecture_contracts.py
@@ -481,7 +481,7 @@ def test_contract_9_post_apply_reactions_are_shared() -> None:
     replay_source = inspect.getsource(replay_playback_mode.ReplayPlaybackMode._apply_post_apply_reaction)
     world_source = inspect.getsource(standalone_tick_harness_module._StandalonePresentationApplyRuntime.output_applied)
 
-    assert 'play_sfx(SfxId.QUESTHIT)' in helper_source
+    assert 'runtime.play_sfx(SfxId.QUESTHIT)' in helper_source
     assert "PerkPickCommand" not in gameplay_source
     assert 'play_sfx(SfxId.UI_BONUS)' not in gameplay_source
     assert "apply_post_apply_reaction(" in replay_source

--- a/tests/sim/test_presentation_reactions.py
+++ b/tests/sim/test_presentation_reactions.py
@@ -4,11 +4,23 @@ from crimson.sim.input import PlayerInput
 from crimson.sim.input_providers import PerkPickCommand
 from crimson.sim.presentation_reactions import (
     PostApplyReaction,
+    PostApplyReactionRuntime,
     QuestPresentationReaction,
     apply_post_apply_reaction,
 )
 from grim.sfx_map import SfxId
 from tests.support.builders.session import make_session
+
+
+class RecordingPostApplyReactionRuntime(PostApplyReactionRuntime):
+    sfx: list[SfxId]
+    music: list[str]
+
+    def play_sfx(self, sfx: SfxId) -> None:
+        self.sfx.append(sfx)
+
+    def play_completion_music(self) -> None:
+        self.music.append("crimsonquest")
 
 
 def test_session_step_tick_adds_bonus_post_apply_sfx_for_successful_perk_pick() -> None:
@@ -47,8 +59,7 @@ def test_quest_presentation_reaction_tracks_audio_flags() -> None:
 
 
 def test_apply_post_apply_reaction_applies_sfx_and_completion_music() -> None:
-    play_sfx = []
-    play_completion_music = []
+    runtime = RecordingPostApplyReactionRuntime(sfx=[], music=[])
 
     apply_post_apply_reaction(
         reaction=PostApplyReaction(
@@ -58,9 +69,8 @@ def test_apply_post_apply_reaction_applies_sfx_and_completion_music() -> None:
                 play_completion_music=True,
             ),
         ),
-        play_sfx=play_sfx.append,
-        play_completion_music=lambda: play_completion_music.append("crimsonquest"),
+        runtime=runtime,
     )
 
-    assert play_sfx == [SfxId.UI_BONUS, SfxId.QUESTHIT]
-    assert play_completion_music == ["crimsonquest"]
+    assert runtime.sfx == [SfxId.UI_BONUS, SfxId.QUESTHIT]
+    assert runtime.music == ["crimsonquest"]

--- a/tests/support/world_runtime.py
+++ b/tests/support/world_runtime.py
@@ -8,7 +8,11 @@ from crimson.render.rtx.mode import RtxRenderMode
 from crimson.sim.hooks import TickResult
 from crimson.sim.input import PlayerInput
 from crimson.sim.input_providers import ResolvedTick
-from crimson.sim.presentation_reactions import apply_post_apply_reaction, build_post_apply_reaction
+from crimson.sim.presentation_reactions import (
+    PostApplyReactionRuntime,
+    apply_post_apply_reaction,
+    build_post_apply_reaction,
+)
 from crimson.sim.sessions import (
     DeterministicSession,
     DeterministicSessionTick,
@@ -22,6 +26,14 @@ from grim.audio import AudioState
 from grim.config import CrimsonConfig
 from grim.geom import Vec2
 from grim.rand import Crand
+from grim.sfx_map import SfxId
+
+
+class _WorldRuntimeHostPostApplyReactionRuntime(PostApplyReactionRuntime):
+    host: WorldRuntimeHost
+
+    def play_sfx(self, sfx: SfxId) -> None:
+        self.host.audio_bridge.router.play_sfx(sfx)
 
 
 class WorldRuntimeHost:
@@ -323,6 +335,6 @@ class WorldRuntimeHost:
                     payload=tick,
                 ),
             ),
-            play_sfx=self.audio_bridge.router.play_sfx,
+            runtime=_WorldRuntimeHostPostApplyReactionRuntime(host=self),
         )
         return tick


### PR DESCRIPTION
## Summary

- convert post-apply presentation reaction data from dataclasses to `msgspec.Struct`
- replace `play_sfx` / `play_completion_music` callback parameters with `PostApplyReactionRuntime`
- add concrete reaction runtimes for gameplay mode, quest mode, replay playback, standalone world ticks, and test support
- keep the shared reaction helper as the single owner for quest-hit SFX and quest-completion music dispatch rules

## Verification

- `uv run ruff check src/crimson/sim/presentation_reactions.py src/crimson/modes/base_gameplay_mode.py src/crimson/modes/quest_mode.py src/crimson/modes/replay_playback_mode.py src/crimson/world/standalone_tick_harness.py tests/support/world_runtime.py tests/sim/test_presentation_reactions.py tests/contracts/test_architecture_contracts.py`
- `uv run ty check src/crimson/sim/presentation_reactions.py src/crimson/modes/base_gameplay_mode.py src/crimson/modes/quest_mode.py src/crimson/modes/replay_playback_mode.py src/crimson/world/standalone_tick_harness.py tests/support/world_runtime.py tests/sim/test_presentation_reactions.py tests/contracts/test_architecture_contracts.py`
- `uv run pytest tests/sim/test_presentation_reactions.py tests/contracts/test_architecture_contracts.py tests/replay/test_replay_playback_mode_audio.py tests/sim/test_presentation_step.py tests/sim/test_step_pipeline_parity.py`
- `just check`
- rebased onto current `origin/master`
- `just check`
- pre-push hook

## Follow-ups

- rollback remains deferred as requested
- `tests/support/world_runtime.py` still has a delegation wrapper that the ast-grep rule keeps flagging
- render sink transport callbacks and replay progress callbacks remain boundary callbacks; they are lower-risk than simulation/presentation reaction callbacks
