### PR TITLE
refactor: route presentation plans through runtime

### DIFF
--- a/src/crimson/bonuses/fire_bullets.py
+++ b/src/crimson/bonuses/fire_bullets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Fire Bullets feature hooks for deterministic presentation output."""
 
-from collections.abc import Callable
+import msgspec
 
 from grim.geom import Vec2
 from grim.rand import CrandLike
@@ -12,6 +12,11 @@ from ..math_parity import f32
 from ..projectiles.types import ProjectileHit
 from ..rng_caller_static import RngCallerStatic
 from .apply_context import BonusApplyCtx, bonus_apply_seconds
+
+
+class LargeHitDecalRuntime(msgspec.Struct):
+    def spawn_freeze_shard(self, pos: Vec2, angle: float) -> None:
+        _ = pos, angle
 
 
 def apply_fire_bullets(ctx: BonusApplyCtx) -> None:
@@ -40,7 +45,7 @@ def queue_large_hit_decal_streak(
     fx_queue: FxQueue,
     rng: CrandLike,
     freeze_origin: Vec2 | None = None,
-    spawn_freeze_shard: Callable[[Vec2, float], None] | None = None,
+    runtime: LargeHitDecalRuntime | None = None,
 ) -> None:
     """Queue the large decal streak used by Fire Bullets impact hits."""
     direction = Vec2.from_angle(base_angle)
@@ -53,13 +58,13 @@ def queue_large_hit_decal_streak(
         # Native `projectile_update` consumes one unconditional draw per loop
         # before the freeze branch (`crt_rand` @ 0x0042184c).
         rng.rand_tagged(RngCallerStatic.PROJECTILE_UPDATE_LARGE_STREAK_BURN)
-        if spawn_freeze_shard is not None and freeze_origin is not None:
+        if runtime is not None and freeze_origin is not None:
             freeze_pos = freeze_origin + direction * (dist * 20.0)
             freeze_angle = (
                 float(base_angle)
                 + float(rng.rand_tagged(RngCallerStatic.PROJECTILE_UPDATE_LARGE_STREAK_FREEZE_ANGLE) % 100) * 0.01
             )
-            spawn_freeze_shard(freeze_pos, freeze_angle)
+            runtime.spawn_freeze_shard(freeze_pos, freeze_angle)
         fx_queue.add_random(
             pos=hit.target + direction * (dist * 20.0),
             rng=rng,

--- a/src/crimson/features/presentation/projectile_decals.py
+++ b/src/crimson/features/presentation/projectile_decals.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-
 from grim.geom import Vec2
 from grim.rand import CrandLike
 
-from ...bonuses.fire_bullets import queue_large_hit_decal_streak
+from ...bonuses.fire_bullets import LargeHitDecalRuntime, queue_large_hit_decal_streak
 from ...effects import FxQueue
 from ...projectiles.types import ProjectileHit, ProjectileTemplateId
 
@@ -17,7 +15,7 @@ def queue_projectile_large_streak_decal(
     fx_queue: FxQueue,
     rng: CrandLike,
     freeze_origin: Vec2 | None = None,
-    spawn_freeze_shard: Callable[[Vec2, float], None] | None = None,
+    runtime: LargeHitDecalRuntime | None = None,
 ) -> bool:
     type_id = hit.type_id
     if type_id not in (ProjectileTemplateId.GAUSS_GUN, ProjectileTemplateId.FIRE_BULLETS):
@@ -28,6 +26,6 @@ def queue_projectile_large_streak_decal(
         fx_queue=fx_queue,
         rng=rng,
         freeze_origin=freeze_origin,
-        spawn_freeze_shard=spawn_freeze_shard,
+        runtime=runtime,
     )
     return True

--- a/src/crimson/sim/presentation_step.py
+++ b/src/crimson/sim/presentation_step.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable, Sequence
-from typing import Protocol
+from collections.abc import Sequence
 
 import msgspec
 
@@ -10,6 +9,7 @@ from grim.geom import Vec2
 from grim.rand import CrandLike
 from grim.sfx_map import SfxId
 
+from ..bonuses.fire_bullets import LargeHitDecalRuntime
 from ..bonuses.freeze import freeze_bonus_active
 from ..effects import FxQueue
 from ..features.presentation import queue_projectile_large_streak_decal
@@ -43,10 +43,12 @@ class DeterministicPresentationPlan(msgspec.Struct):
     post_apply_sfx: tuple[SfxId, ...] = ()
 
 
-class PresentationAudioSink(Protocol):
-    def trigger_game_tune(self) -> str | None: ...
+class PresentationPlanRuntime(msgspec.Struct):
+    def trigger_game_tune(self) -> str | None:
+        return None
 
-    def play_sfx(self, sfx: SfxId) -> None: ...
+    def play_sfx(self, sfx: SfxId) -> None:
+        _ = sfx
 
 
 def plan_player_audio_sfx(
@@ -128,7 +130,21 @@ class ProjectileDecalPostCtx(msgspec.Struct, frozen=True):
     base_angle: float
     type_id: int
     freeze_active: bool
-    freeze_shard_spawn: Callable[[Vec2, float], None] | None = None
+    large_hit_decal_runtime: LargeHitDecalRuntime | None = None
+
+
+class _ProjectileFreezeShardRuntime(LargeHitDecalRuntime):
+    state: GameplayState
+    rng: CrandLike
+    detail_preset: int
+
+    def spawn_freeze_shard(self, pos: Vec2, angle: float) -> None:
+        self.state.effects.spawn_freeze_shard(
+            pos=pos,
+            angle=float(angle),
+            rng=self.rng,
+            detail_preset=int(self.detail_preset),
+        )
 
 
 def queue_projectile_decals(
@@ -170,18 +186,13 @@ def queue_projectile_decals_pre_hit(
 ) -> ProjectileDecalPostCtx:
     freeze_active = freeze_bonus_active(state=state)
     bloody = bool(players) and perk_active(players[0], PerkId.BLOODY_MESS_QUICK_LEARNER)
-    freeze_shard_spawn: Callable[[Vec2, float], None] | None = None
+    large_hit_decal_runtime: LargeHitDecalRuntime | None = None
     if freeze_active:
-
-        def _spawn_freeze_shard(pos: Vec2, angle: float) -> None:
-            state.effects.spawn_freeze_shard(
-                pos=pos,
-                angle=float(angle),
-                rng=rng,
-                detail_preset=int(detail_preset),
-            )
-
-        freeze_shard_spawn = _spawn_freeze_shard
+        large_hit_decal_runtime = _ProjectileFreezeShardRuntime(
+            state=state,
+            rng=rng,
+            detail_preset=int(detail_preset),
+        )
 
     type_id = hit.type_id
 
@@ -269,7 +280,7 @@ def queue_projectile_decals_pre_hit(
         base_angle=float(base_angle),
         type_id=int(type_id),
         freeze_active=bool(freeze_active),
-        freeze_shard_spawn=freeze_shard_spawn,
+        large_hit_decal_runtime=large_hit_decal_runtime,
     )
 
 
@@ -292,7 +303,7 @@ def queue_projectile_decals_post_hit(
         fx_queue=fx_queue,
         rng=rng,
         freeze_origin=hit.hit if bool(post_ctx.freeze_active) else None,
-        spawn_freeze_shard=post_ctx.freeze_shard_spawn,
+        runtime=post_ctx.large_hit_decal_runtime,
     )
 
     if bool(hook_handled) or bool(post_ctx.freeze_active):
@@ -389,12 +400,12 @@ def plan_world_presentation_step(
 def apply_presentation_plan(
     *,
     plan: DeterministicPresentationPlan,
-    audio_sink: PresentationAudioSink | None,
+    runtime: PresentationPlanRuntime | None,
     apply_audio: bool = True,
 ) -> None:
-    if not bool(apply_audio) or audio_sink is None:
+    if not bool(apply_audio) or runtime is None:
         return
     if bool(plan.trigger_game_tune):
-        audio_sink.trigger_game_tune()
+        runtime.trigger_game_tune()
     for sfx in plan.sfx:
-        audio_sink.play_sfx(sfx)
+        runtime.play_sfx(sfx)

--- a/src/crimson/world/audio_bridge.py
+++ b/src/crimson/world/audio_bridge.py
@@ -7,9 +7,10 @@ import msgspec
 
 from grim.audio import AudioState
 from grim.rand import Crand
+from grim.sfx_map import SfxId
 
 from ..audio_router import AudioRouter
-from ..sim.presentation_step import DeterministicPresentationPlan, apply_presentation_plan
+from ..sim.presentation_step import DeterministicPresentationPlan, PresentationPlanRuntime, apply_presentation_plan
 
 
 def _zero_reflex_boost() -> float:
@@ -48,6 +49,16 @@ class AudioBridge(msgspec.Struct):
     def apply_plan(self, *, plan: DeterministicPresentationPlan, apply_audio: bool = True) -> None:
         apply_presentation_plan(
             plan=plan,
-            audio_sink=self.router,
+            runtime=_AudioBridgePresentationPlanRuntime(bridge=self),
             apply_audio=bool(apply_audio),
         )
+
+
+class _AudioBridgePresentationPlanRuntime(PresentationPlanRuntime):
+    bridge: AudioBridge
+
+    def trigger_game_tune(self) -> str | None:
+        return self.bridge.router.trigger_game_tune()
+
+    def play_sfx(self, sfx: SfxId) -> None:
+        self.bridge.router.play_sfx(sfx)

--- a/tests/sim/test_presentation_step.py
+++ b/tests/sim/test_presentation_step.py
@@ -9,6 +9,7 @@ from crimson.projectiles.types import ProjectileHit, ProjectileTemplateId
 from crimson.rng_caller_static import RngCallerStatic
 from crimson.sim.presentation_step import (
     DeterministicPresentationPlan,
+    PresentationPlanRuntime,
     apply_presentation_plan,
     plan_hit_sfx,
     plan_world_presentation_step,
@@ -493,9 +494,8 @@ def test_plan_world_presentation_step_prefers_preplanned_hit_outputs() -> None:
 
 
 def test_apply_presentation_plan_dispatches_audio_in_order() -> None:
-    class _Sink:
-        def __init__(self) -> None:
-            self.events: list[str] = []
+    class _Runtime(PresentationPlanRuntime):
+        events: list[str]
 
         def trigger_game_tune(self) -> str | None:
             self.events.append("tune")
@@ -504,20 +504,19 @@ def test_apply_presentation_plan_dispatches_audio_in_order() -> None:
         def play_sfx(self, sfx: SfxId) -> None:
             self.events.append(sfx.value)
 
-    sink = _Sink()
+    runtime = _Runtime(events=[])
     apply_presentation_plan(
         plan=DeterministicPresentationPlan(trigger_game_tune=True, sfx=[SfxId.UI_BONUS, SfxId.UI_LEVELUP]),
-        audio_sink=sink,
+        runtime=runtime,
         apply_audio=True,
     )
 
-    assert sink.events == ["tune", SfxId.UI_BONUS.value, SfxId.UI_LEVELUP.value]
+    assert runtime.events == ["tune", SfxId.UI_BONUS.value, SfxId.UI_LEVELUP.value]
 
 
 def test_apply_presentation_plan_skips_when_audio_disabled() -> None:
-    class _Sink:
-        def __init__(self) -> None:
-            self.called = False
+    class _Runtime(PresentationPlanRuntime):
+        called: bool = False
 
         def trigger_game_tune(self) -> str | None:
             self.called = True
@@ -527,11 +526,11 @@ def test_apply_presentation_plan_skips_when_audio_disabled() -> None:
             _ = sfx
             self.called = True
 
-    sink = _Sink()
+    runtime = _Runtime()
     apply_presentation_plan(
         plan=DeterministicPresentationPlan(trigger_game_tune=True, sfx=[SfxId.UI_BONUS]),
-        audio_sink=sink,
+        runtime=runtime,
         apply_audio=False,
     )
 
-    assert sink.called is False
+    assert runtime.called is False


### PR DESCRIPTION
## Summary

- replace the presentation audio sink protocol with `PresentationPlanRuntime`
- route audio plan application through an `AudioBridge` runtime object
- replace freeze-shard decal callbacks with `LargeHitDecalRuntime`
- keep native RNG-consuming projectile decal ordering in the existing presentation path

## Verification

- `just check`
- rebased onto current `origin/master`
- `just check`
- pre-push hook

## Follow-ups

- `AudioBridge.reflex_boost_timer_source` is still callback-shaped and could become a small state runtime later
- `tests/support/world_runtime.py` delegation wrapper is still flagged by ast-grep
- replay/render progress callbacks remain lower-priority boundary callbacks
