### PR TITLE
refactor: route audio reflex state through runtime

### DIFF
--- a/src/crimson/audio_router.py
+++ b/src/crimson/audio_router.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import msgspec
@@ -29,17 +28,20 @@ _BULLET_HIT_SFX = (
 )
 
 
+class AudioRouterRuntime(msgspec.Struct):
+    def reflex_boost_timer(self) -> float:
+        return 0.0
+
+
 class AudioRouter(msgspec.Struct):
     audio_rng: Crand
     audio: AudioState | None = None
     demo_mode_active: bool = False
     sfx_enabled: bool = True
-    reflex_boost_timer_source: Callable[[], float] | None = None
+    runtime: AudioRouterRuntime = msgspec.field(default_factory=AudioRouterRuntime)
+
     def _reflex_boost_timer(self) -> float:
-        source = self.reflex_boost_timer_source
-        if source is None:
-            return 0.0
-        return float(source())
+        return float(self.runtime.reflex_boost_timer())
 
     def play_sfx(self, sfx: SfxId) -> None:
         if self.audio is None or (not self.sfx_enabled):

--- a/src/crimson/world/audio_bridge.py
+++ b/src/crimson/world/audio_bridge.py
@@ -1,35 +1,31 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import cast
-
-import msgspec
-
 from grim.audio import AudioState
 from grim.rand import Crand
 from grim.sfx_map import SfxId
 
-from ..audio_router import AudioRouter
+from ..audio_router import AudioRouter, AudioRouterRuntime
 from ..sim.presentation_step import DeterministicPresentationPlan, PresentationPlanRuntime, apply_presentation_plan
 
 
-def _zero_reflex_boost() -> float:
-    return 0.0
-
-
-class AudioBridge(msgspec.Struct):
-    audio_rng: Crand
-    demo_mode_active: bool = False
-    reflex_boost_timer_source: Callable[[], float] = _zero_reflex_boost
-    audio: AudioState | None = None
-    router: AudioRouter = cast(AudioRouter, None)
-
-    def __post_init__(self) -> None:
+class AudioBridge:
+    def __init__(
+        self,
+        *,
+        audio_rng: Crand,
+        demo_mode_active: bool = False,
+        runtime: AudioRouterRuntime | None = None,
+        audio: AudioState | None = None,
+    ) -> None:
+        self.audio_rng = audio_rng
+        self.demo_mode_active = bool(demo_mode_active)
+        self.audio = audio
+        self.runtime = runtime if runtime is not None else AudioRouterRuntime()
         self.router = AudioRouter(
             audio_rng=self.audio_rng,
             audio=self.audio,
             demo_mode_active=bool(self.demo_mode_active),
-            reflex_boost_timer_source=self.reflex_boost_timer_source,
+            runtime=self.runtime,
         )
 
     def sync(

--- a/src/crimson/world/runtime.py
+++ b/src/crimson/world/runtime.py
@@ -8,6 +8,7 @@ from grim.geom import Vec2
 from grim.rand import Crand
 from grim.raylib_api import rl
 
+from ..audio_router import AudioRouterRuntime
 from ..render.frame import RenderFrame
 from ..render.rtx.mode import RtxRenderMode
 from ..render.world import viewport
@@ -16,6 +17,13 @@ from .audio_bridge import AudioBridge
 from .render_resources import RenderResources
 from .sim_world_state import SimWorldState
 from .terrain_runtime import TerrainRuntime
+
+
+class _WorldAudioRouterRuntime(AudioRouterRuntime):
+    sim_world: SimWorldState
+
+    def reflex_boost_timer(self) -> float:
+        return float(self.sim_world.state.bonuses.reflex_boost)
 
 
 class WorldRuntime:
@@ -62,7 +70,7 @@ class WorldRuntime:
         self.render_resources = render_resources
         self.audio_bridge = AudioBridge(
             demo_mode_active=bool(self.demo_mode_active),
-            reflex_boost_timer_source=lambda: float(self.sim_world.state.bonuses.reflex_boost),
+            runtime=_WorldAudioRouterRuntime(sim_world=self.sim_world),
             audio=self.audio,
             audio_rng=self.audio_rng,
         )

--- a/tests/contracts/test_architecture_contracts.py
+++ b/tests/contracts/test_architecture_contracts.py
@@ -390,7 +390,6 @@ def test_contract_5_plan_vs_apply_isolation_for_audio_and_render_side_effects(mo
 
     audio_bridge = AudioBridge(
         demo_mode_active=False,
-        reflex_boost_timer_source=lambda: 0.0,
         audio=object(),  # type: ignore[arg-type]  # sentinel; play_sfx is patched
         audio_rng=Crand(0xBEEF),
     )


### PR DESCRIPTION
## Summary

- replace the audio reflex timer callback with an `AudioRouterRuntime`
- let `WorldRuntime` provide the live world-backed audio runtime object
- remove `AudioBridge.__post_init__` and callback/cast construction plumbing

## Verification

- `uv run ruff check src/crimson/audio_router.py src/crimson/world/audio_bridge.py src/crimson/world/runtime.py tests/contracts/test_architecture_contracts.py tests/gameplay/test_game_world_audio.py tests/gameplay/test_game_tune_trigger.py`
- `uv run ty check src/crimson/audio_router.py src/crimson/world/audio_bridge.py src/crimson/world/runtime.py tests/contracts/test_architecture_contracts.py tests/gameplay/test_game_world_audio.py tests/gameplay/test_game_tune_trigger.py`
- `uv run pytest tests/gameplay/test_game_world_audio.py tests/gameplay/test_game_tune_trigger.py tests/contracts/test_architecture_contracts.py tests/replay/test_replay_playback_mode_audio.py`
- `just check`
- rebased onto current `origin/master`
- `just check`
- pre-push hook

## Follow-ups

- `tests/support/world_runtime.py` still has pure delegation wrappers flagged by ast-grep
- replay/render progress callbacks remain lower-priority boundary callbacks
