### PR TITLE
refactor: route replay render progress through runtime

### DIFF
--- a/src/crimson/cli/__init__.py
+++ b/src/crimson/cli/__init__.py
@@ -19,8 +19,9 @@ app.add_typer(dbg_app, name="dbg")
 app.add_typer(net_app, name="net")
 app.add_typer(relay_app, name="relay")
 
-def _replay_render_progress_callback(*, total_ticks: int, render_audio: bool):
-    return _replay._replay_render_progress_callback(
+
+def _replay_render_progress_runtime(*, total_ticks: int, render_audio: bool):
+    return _replay._replay_render_progress_runtime(
         total_ticks=total_ticks,
         render_audio=render_audio,
         tqdm_factory=tqdm,

--- a/src/crimson/cli/replay.py
+++ b/src/crimson/cli/replay.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from ..game_modes import GameMode
 from ..paths import default_runtime_dir
 from ..quests.level import QuestLevel
+from ..replay.driver.replay_render import ReplayRenderProgress
 from ..weapons import WeaponId
 
 if TYPE_CHECKING:
@@ -48,10 +49,6 @@ class _ProgressBarLike(Protocol):
     def close(self) -> None: ...
 
 
-ReplayRenderProgressCallback = Callable[["ReplayRenderPhase", int, int, int], None]
-ReplayRenderProgressClose = Callable[[], None]
-
-
 def _resolve_replay_path(replay_file: Path, *, base_dir: Path) -> tuple[Path, tuple[Path, ...]]:
     """Resolve a replay path, with a convenience lookup under the runtime dir.
 
@@ -78,52 +75,47 @@ def _default_replay_render_output_path(replay_path: Path) -> Path:
     return Path(replay_path).with_suffix(".render.mp4")
 
 
-def _replay_render_progress_callback(
-    *,
-    total_ticks: int,
-    render_audio: bool,
-    tqdm_factory: Callable[..., _ProgressBarLike] = tqdm,
-) -> tuple[ReplayRenderProgressCallback | None, ReplayRenderProgressClose | None]:
-    if int(total_ticks) <= 0:
-        return None, None
-
-    video_bar = tqdm_factory(
-        total=int(total_ticks),
-        unit="tick",
-        desc="replay video",
-        leave=True,
-    )
+class _ReplayRenderProgressBars(ReplayRenderProgress):
+    total_ticks: int
+    render_audio: bool
+    tqdm_factory: Callable[..., _ProgressBarLike]
+    video_bar: _ProgressBarLike
     audio_bar: _ProgressBarLike | None = None
-    video_last_tick = 0
-    audio_last_tick = 0
+    video_last_tick: int = 0
+    audio_last_tick: int = 0
 
-    def _ensure_audio_bar(total: int) -> _ProgressBarLike:
-        nonlocal audio_bar
-        if audio_bar is not None:
-            return audio_bar
-        audio_bar = tqdm_factory(
+    def _ensure_audio_bar(self, total: int) -> _ProgressBarLike:
+        if self.audio_bar is not None:
+            return self.audio_bar
+        self.audio_bar = self.tqdm_factory(
             total=int(total),
             unit="tick",
             desc="replay audio",
             leave=True,
         )
-        return audio_bar
+        return self.audio_bar
 
-    def callback(phase: str, frame_count: int, tick_index: int, callback_total_ticks: int) -> None:
-        nonlocal video_last_tick, audio_last_tick
-        resolved_total = int(total_ticks)
-        if int(callback_total_ticks) > 0:
-            resolved_total = int(callback_total_ticks)
+    def update(
+        self,
+        *,
+        phase: ReplayRenderPhase,
+        frame_count: int,
+        tick_index: int,
+        total_ticks: int,
+    ) -> None:
+        resolved_total = int(self.total_ticks)
+        if int(total_ticks) > 0:
+            resolved_total = int(total_ticks)
         if int(resolved_total) <= 0:
             return
-        if str(phase) == "video":
-            bar = video_bar
-            last_tick = int(video_last_tick)
-        elif str(phase) == "audio":
-            if not bool(render_audio):
+        if phase == "video":
+            bar = self.video_bar
+            last_tick = int(self.video_last_tick)
+        elif phase == "audio":
+            if not bool(self.render_audio):
                 return
-            bar = _ensure_audio_bar(int(resolved_total))
-            last_tick = int(audio_last_tick)
+            bar = self._ensure_audio_bar(int(resolved_total))
+            last_tick = int(self.audio_last_tick)
         else:
             return
         if int(bar.total) != int(resolved_total):
@@ -133,18 +125,37 @@ def _replay_render_progress_callback(
         if int(delta) <= 0:
             return
         bar.update(int(delta))
-        if str(phase) == "video":
+        if phase == "video":
             bar.set_postfix(frames=int(frame_count), refresh=False)
-            video_last_tick = int(tick)
+            self.video_last_tick = int(tick)
         else:
-            audio_last_tick = int(tick)
+            self.audio_last_tick = int(tick)
 
-    def close() -> None:
-        video_bar.close()
-        if audio_bar is not None:
-            audio_bar.close()
+    def close(self) -> None:
+        self.video_bar.close()
+        if self.audio_bar is not None:
+            self.audio_bar.close()
 
-    return callback, close
+
+def _replay_render_progress_runtime(
+    *,
+    total_ticks: int,
+    render_audio: bool,
+    tqdm_factory: Callable[..., _ProgressBarLike] = tqdm,
+) -> ReplayRenderProgress | None:
+    if int(total_ticks) <= 0:
+        return None
+    return _ReplayRenderProgressBars(
+        total_ticks=int(total_ticks),
+        render_audio=bool(render_audio),
+        tqdm_factory=tqdm_factory,
+        video_bar=tqdm_factory(
+            total=int(total_ticks),
+            unit="tick",
+            desc="replay video",
+            leave=True,
+        ),
+    )
 
 
 def _render_checkpoint_diff_failure(diff: ReplayDiffResult) -> None:
@@ -1530,13 +1541,13 @@ def cmd_replay_render(
     output_path = Path(out) if out is not None else _default_replay_render_output_path(replay_path)
 
     replay_bytes = Path(replay_path).read_bytes()
-    progress_close: ReplayRenderProgressClose | None = None
+    progress_runtime: ReplayRenderProgress | None = None
     try:
         replay = load_replay(replay_bytes)
         total_ticks = len(replay.ticks)
         if max_ticks is not None:
             total_ticks = min(int(total_ticks), max(0, int(max_ticks)))
-        progress_callback, progress_close = _replay_render_progress_callback(
+        progress_runtime = _replay_render_progress_runtime(
             total_ticks=total_ticks,
             render_audio=bool(audio),
         )
@@ -1557,14 +1568,14 @@ def cmd_replay_render(
             pixel_format=str(pixel_format),
             overwrite=bool(overwrite),
             mute_audio=not bool(audio),
-            progress=progress_callback,
+            progress=progress_runtime,
         )
     except (ReplayCodecError, ReplayGameVersionError, ReplayRenderError, ReplayRunnerError) as exc:
         typer.echo(f"replay render failed: {exc}", err=True)
         raise typer.Exit(code=1) from exc
     finally:
-        if progress_close is not None:
-            progress_close()
+        if progress_runtime is not None:
+            progress_runtime.close()
 
     message = (
         f"ok: output={render.output_path} "

--- a/src/crimson/replay/driver/replay_render.py
+++ b/src/crimson/replay/driver/replay_render.py
@@ -5,7 +5,6 @@ import shutil
 import subprocess
 import tempfile
 import time
-from collections.abc import Callable
 from pathlib import Path
 from typing import Literal
 
@@ -50,6 +49,21 @@ class ReplayRenderResult(msgspec.Struct, frozen=True):
     width: int
     height: int
     run_result: RunResult
+
+
+class ReplayRenderProgress(msgspec.Struct):
+    def update(
+        self,
+        *,
+        phase: ReplayRenderPhase,
+        frame_count: int,
+        tick_index: int,
+        total_ticks: int,
+    ) -> None:
+        _ = phase, frame_count, tick_index, total_ticks
+
+    def close(self) -> None:
+        return None
 
 
 class _FfmpegVideoTransport:
@@ -141,7 +155,7 @@ def run_replay_render_video(
     pixel_format: str = "yuv420p",
     overwrite: bool = False,
     mute_audio: bool = True,
-    progress: Callable[[ReplayRenderPhase, int, int, int], None] | None = None,
+    progress: ReplayRenderProgress | None = None,
 ) -> ReplayRenderResult:
     from grim.assets import load_runtime_resources, unload_runtime_resources
     from grim.config import ensure_crimson_cfg
@@ -268,13 +282,23 @@ def run_replay_render_video(
                 render_pipeline.present()
                 frame_count += 1
                 if progress is not None:
-                    progress("video", frame_count, mode.tick_index, total_ticks)
+                    progress.update(
+                        phase="video",
+                        frame_count=frame_count,
+                        tick_index=mode.tick_index,
+                        total_ticks=total_ticks,
+                    )
 
             if frame_count <= 0:
                 raise ReplayRenderError("replay render produced no frames")
 
             if progress is not None:
-                progress("video", frame_count, total_ticks, total_ticks)
+                progress.update(
+                    phase="video",
+                    frame_count=frame_count,
+                    tick_index=total_ticks,
+                    total_ticks=total_ticks,
+                )
             render_pipeline.flush()
             render_pipeline.close()
             render_pipeline = None
@@ -311,7 +335,12 @@ def run_replay_render_video(
                     target_audio_frames=round(frame_count * captured_audio.effective_sample_rate / fps),
                 )
                 if progress is not None:
-                    progress("audio", frame_count, total_ticks, total_ticks)
+                    progress.update(
+                        phase="audio",
+                        frame_count=frame_count,
+                        tick_index=total_ticks,
+                        total_ticks=total_ticks,
+                    )
         except ReplayRenderError:
             if render_pipeline is not None:
                 render_pipeline.close()
@@ -448,7 +477,7 @@ def _capture_replay_audio_track(
     trace_rng: bool,
     output_path: Path,
     replay_tick_rate: int,
-    progress: Callable[[ReplayRenderPhase, int, int, int], None] | None = None,
+    progress: ReplayRenderProgress | None = None,
     total_ticks: int = 0,
 ) -> _CapturedAudioTrack:
     from ...modes.replay_playback_mode import ReplayPlaybackMode
@@ -491,7 +520,12 @@ def _capture_replay_audio_track(
                 raise ReplayRenderError("audio capture aborted: replay playback requested close")
             capture.flush_pending()
             if progress is not None and total_ticks > 0:
-                progress("audio", 0, mode.tick_index, total_ticks)
+                progress.update(
+                    phase="audio",
+                    frame_count=0,
+                    tick_index=mode.tick_index,
+                    total_ticks=total_ticks,
+                )
             next_tick_deadline += tick_dt
             sleep_s = next_tick_deadline - time.perf_counter()
             if sleep_s > 0.0:

--- a/tests/replay/cli/test_benchmark.py
+++ b/tests/replay/cli/test_benchmark.py
@@ -593,7 +593,7 @@ def test_replay_render_uses_render_video_runner(tmp_path: Path, mocker) -> None:
     assert kwargs["output_path"] == replay_path.with_suffix(".render.mp4")
 
 
-def test_replay_render_progress_callback_uses_separate_video_audio_bars(mocker) -> None:
+def test_replay_render_progress_runtime_uses_separate_video_audio_bars(mocker) -> None:
     import crimson.cli as cli_mod
 
     class _FakeBar:
@@ -624,17 +624,16 @@ def test_replay_render_progress_callback_uses_separate_video_audio_bars(mocker) 
 
     mocker.patch.object(cli_mod, "tqdm", side_effect=fake_tqdm)
 
-    callback, close = cli_mod._replay_render_progress_callback(total_ticks=10, render_audio=True)
-    assert callback is not None
-    assert close is not None
+    progress = cli_mod._replay_render_progress_runtime(total_ticks=10, render_audio=True)
+    assert progress is not None
     assert len(bars) == 1
     video_bar = bars[0]
 
-    callback("video", 3, 5, 10)
-    callback("audio", 0, 4, 10)
-    callback("video", 4, 10, 10)
-    callback("audio", 0, 10, 10)
-    close()
+    progress.update(phase="video", frame_count=3, tick_index=5, total_ticks=10)
+    progress.update(phase="audio", frame_count=0, tick_index=4, total_ticks=10)
+    progress.update(phase="video", frame_count=4, tick_index=10, total_ticks=10)
+    progress.update(phase="audio", frame_count=0, tick_index=10, total_ticks=10)
+    progress.close()
 
     assert len(bars) == 2
     audio_bar = bars[1]

--- a/tests/replay/test_replay_render_audio.py
+++ b/tests/replay/test_replay_render_audio.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import call
 
 import pytest
 
@@ -104,9 +103,20 @@ def test_capture_audio_track_reports_progress_without_manual_fx_queue_clears(moc
         def __init__(self) -> None:
             self.audio = SimpleNamespace(sound_disabled=False, music_disabled=False)
 
-    from unittest.mock import Mock
+    class _Progress(replay_render_mod.ReplayRenderProgress):
+        events: list[tuple[str, int, int, int]]
 
-    progress = Mock()
+        def update(
+            self,
+            *,
+            phase: replay_render_mod.ReplayRenderPhase,
+            frame_count: int,
+            tick_index: int,
+            total_ticks: int,
+        ) -> None:
+            self.events.append((phase, int(frame_count), int(tick_index), int(total_ticks)))
+
+    progress = _Progress(events=[])
 
     captured = replay_render_mod._capture_replay_audio_track(
         rl=_FakeRl(),
@@ -127,10 +137,10 @@ def test_capture_audio_track_reports_progress_without_manual_fx_queue_clears(moc
     assert captured.channels == 2
     assert captured.captured_frames == 2400
     assert captured.captured_ticks == 3
-    assert progress.call_args_list == [
-        call("audio", 0, 1, 120),
-        call("audio", 0, 2, 120),
-        call("audio", 0, 3, 120),
+    assert progress.events == [
+        ("audio", 0, 1, 120),
+        ("audio", 0, 2, 120),
+        ("audio", 0, 3, 120),
     ]
 
 


### PR DESCRIPTION
## Summary

- replace replay render progress callbacks with a `ReplayRenderProgress` runtime object
- move CLI video/audio tqdm state into `_ReplayRenderProgressBars`
- keep render and audio capture progress semantics unchanged

## Verification

- `uv run ruff check src/crimson/cli/__init__.py src/crimson/cli/replay.py src/crimson/replay/driver/replay_render.py tests/replay/test_replay_render_audio.py tests/replay/cli/test_benchmark.py`
- `uv run ty check src/crimson/cli/__init__.py src/crimson/cli/replay.py src/crimson/replay/driver/replay_render.py tests/replay/test_replay_render_audio.py tests/replay/cli/test_benchmark.py`
- `uv run pytest tests/replay/test_replay_render_audio.py tests/replay/cli/test_benchmark.py`
- `just check`
- rebased onto current `origin/master`
- `just check-zig` after an intermittent reconnect jitter smoke failure in the first post-rebase full run
- `just check`
- pre-push hook

## Follow-ups

- replay benchmark still has a lower-level tick progress callback path
- `BaseGameplayMode.camera` is still flagged as a pure delegation property
