### PR TITLE
refactor: route video sink through transport

### DIFF
--- a/src/crimson/render/sink.py
+++ b/src/crimson/render/sink.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
 
 from grim.render_pipeline import RenderPresent, RenderSink, WindowSink
 
-__all__ = ["RenderPresent", "RenderSink", "WindowSink", "NullSink", "VideoSink"]
+__all__ = ["RenderPresent", "RenderSink", "WindowSink", "NullSink", "VideoSink", "VideoTransport"]
 
 
 class NullSink:
@@ -24,6 +23,20 @@ class NullSink:
         pass
 
 
+class VideoTransport:
+    def open(self) -> None:
+        return None
+
+    def present_frame(self) -> None:
+        return None
+
+    def flush(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
 class VideoSink:
     """Video-export sink. Fail-fast by policy: presentation errors abort rendering."""
 
@@ -31,40 +44,30 @@ class VideoSink:
         self,
         *,
         output_path: Path,
-        open_transport: Callable[[], None] | None = None,
-        present_frame: RenderPresent | None = None,
-        flush_transport: Callable[[], None] | None = None,
-        close_transport: Callable[[], None] | None = None,
+        transport: VideoTransport | None = None,
     ) -> None:
         self.output_path = Path(output_path)
-        self._open_transport = open_transport
-        self._present_frame = present_frame
-        self._flush_transport = flush_transport
-        self._close_transport = close_transport
+        self._transport = transport if transport is not None else VideoTransport()
         self._opened = False
         self._flushed = False
 
     def open(self) -> None:
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
-        if self._open_transport is not None:
-            self._open_transport()
+        self._transport.open()
         self._opened = True
         self._flushed = False
 
     def present(self) -> None:
-        if self._present_frame is not None:
-            self._present_frame()
+        self._transport.present_frame()
 
     def flush(self) -> None:
         if not self._opened or self._flushed:
             return
-        if self._flush_transport is not None:
-            self._flush_transport()
+        self._transport.flush()
         self._flushed = True
 
     def close(self) -> None:
         if not self._opened:
             return
-        if self._close_transport is not None:
-            self._close_transport()
+        self._transport.close()
         self._opened = False

--- a/src/crimson/replay/driver/replay_render.py
+++ b/src/crimson/replay/driver/replay_render.py
@@ -11,7 +11,7 @@ from typing import Literal
 import msgspec
 
 from ...render.pipeline import RenderPipeline
-from ...render.sink import VideoSink
+from ...render.sink import VideoSink, VideoTransport
 from ...replay import Replay
 from .playback_driver import build_verify_playback_driver
 from .setup import RunResult
@@ -66,7 +66,7 @@ class ReplayRenderProgress(msgspec.Struct):
         return None
 
 
-class _FfmpegVideoTransport:
+class _FfmpegVideoTransport(VideoTransport):
     def __init__(
         self,
         *,
@@ -258,10 +258,7 @@ def run_replay_render_video(
             render_pipeline = RenderPipeline(
                 sink=VideoSink(
                     output_path=video_out_path,
-                    open_transport=video_transport.open,
-                    present_frame=video_transport.present_frame,
-                    flush_transport=video_transport.flush,
-                    close_transport=video_transport.close,
+                    transport=video_transport,
                 ),
                 begin_end_drawing=True,
                 begin_draw=rl.begin_drawing,

--- a/tests/render/test_render_backend_sink_contract.py
+++ b/tests/render/test_render_backend_sink_contract.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from crimson.render.pipeline import RenderPipeline
-from crimson.render.sink import NullSink, VideoSink, WindowSink
+from crimson.render.sink import NullSink, VideoSink, VideoTransport, WindowSink
 
 
 def test_render_pipeline_lifecycle_and_resize_behavior() -> None:
@@ -135,12 +135,22 @@ def test_window_sink_raises_on_present_error() -> None:
 def test_video_sink_transport_and_fail_fast_behavior(tmp_path: Path) -> None:
     events: list[str] = []
 
+    class _EventVideoTransport(VideoTransport):
+        def open(self) -> None:
+            events.append("open")
+
+        def present_frame(self) -> None:
+            events.append("present")
+
+        def flush(self) -> None:
+            events.append("flush")
+
+        def close(self) -> None:
+            events.append("close")
+
     sink = VideoSink(
         output_path=tmp_path / "nested" / "out.mp4",
-        open_transport=lambda: events.append("open"),
-        present_frame=lambda: events.append("present"),
-        flush_transport=lambda: events.append("flush"),
-        close_transport=lambda: events.append("close"),
+        transport=_EventVideoTransport(),
     )
     sink.open()
     sink.present()
@@ -149,12 +159,13 @@ def test_video_sink_transport_and_fail_fast_behavior(tmp_path: Path) -> None:
 
     assert events == ["open", "present", "flush", "close"]
 
-    def _raise_present() -> None:
-        raise RuntimeError("present failed")
+    class _FailingVideoTransport(VideoTransport):
+        def present_frame(self) -> None:
+            raise RuntimeError("present failed")
 
     sink = VideoSink(
         output_path=tmp_path / "out.mp4",
-        present_frame=_raise_present,
+        transport=_FailingVideoTransport(),
     )
     sink.open()
     with pytest.raises(RuntimeError, match="present failed"):


### PR DESCRIPTION
## Summary

- replace `VideoSink` lifecycle callback parameters with a `VideoTransport` runtime object
- pass the existing ffmpeg transport directly from replay rendering
- update render sink contract tests to use concrete transport objects

## Verification

- `uv run ruff check src/crimson/render/sink.py src/crimson/replay/driver/replay_render.py tests/render/test_render_backend_sink_contract.py`
- `uv run ty check src/crimson/render/sink.py src/crimson/replay/driver/replay_render.py tests/render/test_render_backend_sink_contract.py`
- `uv run pytest tests/render/test_render_backend_sink_contract.py tests/replay/test_replay_render_audio.py tests/replay/cli/test_benchmark.py`
- `just check`
- pre-push hook

## Follow-ups

- `RenderPipeline` still accepts separate draw-boundary callbacks; that can become a small draw-scope runtime next
- `WindowSink` still accepts a single present callback, but that is a narrower adapter seam than the old video sink lifecycle bundle
