### PR TITLE
refactor: route render drawing through scope

### DIFF
--- a/src/crimson/render/pipeline.py
+++ b/src/crimson/render/pipeline.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from grim.render_pipeline import RenderPipeline
+from grim.render_pipeline import RaylibDrawScope, RenderDrawScope, RenderPipeline
 
-__all__ = ["RenderPipeline"]
+__all__ = ["RaylibDrawScope", "RenderDrawScope", "RenderPipeline"]

--- a/src/crimson/replay/driver/replay_render.py
+++ b/src/crimson/replay/driver/replay_render.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 import msgspec
 
-from ...render.pipeline import RenderPipeline
+from ...render.pipeline import RaylibDrawScope, RenderPipeline
 from ...render.sink import VideoSink, VideoTransport
 from ...replay import Replay
 from .playback_driver import build_verify_playback_driver
@@ -260,9 +260,7 @@ def run_replay_render_video(
                     output_path=video_out_path,
                     transport=video_transport,
                 ),
-                begin_end_drawing=True,
-                begin_draw=rl.begin_drawing,
-                end_draw=rl.end_drawing,
+                draw_scope=RaylibDrawScope(raylib=rl),
             )
             render_pipeline.open(width=capture_width, height=capture_height)
             assert render_pipeline is not None

--- a/src/grim/app.py
+++ b/src/grim/app.py
@@ -8,7 +8,7 @@ import msgspec
 
 from grim.raylib_api import rl
 
-from .render_pipeline import RenderPipeline, WindowSink
+from .render_pipeline import RaylibDrawScope, RenderPipeline, WindowSink
 from .view import View
 
 SCREENSHOT_DIR = Path("screenshots")
@@ -56,9 +56,7 @@ def run_view(
     run_hooks = hooks if hooks is not None else RunViewHooks()
     render_pipeline = RenderPipeline(
         sink=WindowSink(),
-        begin_end_drawing=True,
-        begin_draw=rl.begin_drawing,
-        end_draw=rl.end_drawing,
+        draw_scope=RaylibDrawScope(raylib=rl),
     )
     try:
         view.open()

--- a/src/grim/render_pipeline.py
+++ b/src/grim/render_pipeline.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Protocol
+from typing import Any, Protocol
 
 RenderDraw = Callable[[], None]
 RenderPresent = Callable[[], None]
@@ -43,6 +43,23 @@ class WindowSink:
         self._opened = False
 
 
+class RenderDrawScope:
+    def draw(self, draw_frame: RenderDraw) -> None:
+        draw_frame()
+
+
+class RaylibDrawScope(RenderDrawScope):
+    def __init__(self, *, raylib: Any) -> None:
+        self._rl = raylib
+
+    def draw(self, draw_frame: RenderDraw) -> None:
+        self._rl.begin_drawing()
+        try:
+            draw_frame()
+        finally:
+            self._rl.end_drawing()
+
+
 class RenderPipeline:
     """Shared draw/present orchestration for live and replay contexts."""
 
@@ -51,17 +68,11 @@ class RenderPipeline:
         *,
         sink: RenderSink,
         on_resize: Callable[[int, int], None] | None = None,
-        begin_end_drawing: bool = False,
-        begin_draw: Callable[[], None] | None = None,
-        end_draw: Callable[[], None] | None = None,
+        draw_scope: RenderDrawScope | None = None,
     ) -> None:
-        if bool(begin_end_drawing) and (begin_draw is None or end_draw is None):
-            raise ValueError("begin_draw and end_draw are required when begin_end_drawing=True")
         self._sink = sink
         self._on_resize = on_resize
-        self._begin_end_drawing = bool(begin_end_drawing)
-        self._begin_draw = begin_draw
-        self._end_draw = end_draw
+        self._draw_scope = draw_scope if draw_scope is not None else RenderDrawScope()
         self._opened = False
         self._width = -1
         self._height = -1
@@ -106,18 +117,7 @@ class RenderPipeline:
     def draw(self, *, draw_frame: RenderDraw, width: int, height: int) -> None:
         self._ensure_open(width=int(width), height=int(height))
         self._resize_if_needed(width=int(width), height=int(height))
-        if self._begin_end_drawing:
-            begin_draw = self._begin_draw
-            end_draw = self._end_draw
-            if begin_draw is None or end_draw is None:
-                raise RuntimeError("render pipeline missing begin/end draw callbacks")
-            begin_draw()
-            try:
-                draw_frame()
-            finally:
-                end_draw()
-            return
-        draw_frame()
+        self._draw_scope.draw(draw_frame)
 
     def present(self) -> None:
         if not self._opened:

--- a/tests/grim/test_grim_app_render_pipeline.py
+++ b/tests/grim/test_grim_app_render_pipeline.py
@@ -83,15 +83,11 @@ class _PipelineSpy:
         *,
         sink: Any,
         on_resize: Any = None,
-        begin_end_drawing: bool = False,
-        begin_draw: Any = None,
-        end_draw: Any = None,
+        draw_scope: Any = None,
     ) -> None:
         self.sink = sink
         self.on_resize = on_resize
-        self.begin_end_drawing = begin_end_drawing
-        self.begin_draw = begin_draw
-        self.end_draw = end_draw
+        self.draw_scope = draw_scope
         self.draw_calls: list[tuple[int, int]] = []
         self.present_calls = 0
         self.close_calls = 0
@@ -112,9 +108,11 @@ def test_run_view_uses_render_pipeline(monkeypatch) -> None:
     fake_rl = _FakeRl()
     view = _ViewSpy()
     sink_sentinel = object()
+    draw_scope_sentinel = object()
 
     monkeypatch.setattr(grim_app, "rl", fake_rl)
     monkeypatch.setattr(grim_app, "WindowSink", lambda: sink_sentinel)
+    monkeypatch.setattr(grim_app, "RaylibDrawScope", lambda *, raylib: draw_scope_sentinel)
     _PipelineSpy.instances.clear()
     monkeypatch.setattr(grim_app, "RenderPipeline", _PipelineSpy)
 
@@ -123,9 +121,7 @@ def test_run_view_uses_render_pipeline(monkeypatch) -> None:
     assert len(_PipelineSpy.instances) == 1
     pipeline = _PipelineSpy.instances[0]
     assert pipeline.sink is sink_sentinel
-    assert pipeline.begin_end_drawing is True
-    assert pipeline.begin_draw == fake_rl.begin_drawing
-    assert pipeline.end_draw == fake_rl.end_drawing
+    assert pipeline.draw_scope is draw_scope_sentinel
     assert pipeline.draw_calls == [(800, 450)]
     assert pipeline.present_calls == 1
     assert pipeline.close_calls == 1

--- a/tests/render/test_render_backend_sink_contract.py
+++ b/tests/render/test_render_backend_sink_contract.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
 
-from crimson.render.pipeline import RenderPipeline
+from crimson.render.pipeline import RaylibDrawScope, RenderDrawScope, RenderPipeline
 from crimson.render.sink import NullSink, VideoSink, VideoTransport, WindowSink
 
 
@@ -26,12 +27,18 @@ def test_render_pipeline_lifecycle_and_resize_behavior() -> None:
         def close(self) -> None:
             events.append("sink.close")
 
+    class _EventDrawScope(RenderDrawScope):
+        def draw(self, draw_frame: Callable[[], None]) -> None:
+            events.append("draw.begin")
+            try:
+                draw_frame()
+            finally:
+                events.append("draw.end")
+
     pipeline = RenderPipeline(
         sink=_Sink(),
         on_resize=lambda width, height: events.append(f"resize:{int(width)}x{int(height)}"),
-        begin_end_drawing=True,
-        begin_draw=lambda: events.append("draw.begin"),
-        end_draw=lambda: events.append("draw.end"),
+        draw_scope=_EventDrawScope(),
     )
     pipeline.render(draw_frame=lambda: events.append("draw.frame.1"), width=640, height=480)
     pipeline.render(draw_frame=lambda: events.append("draw.frame.2"), width=640, height=480)
@@ -82,6 +89,28 @@ def test_render_pipeline_closes_sink_when_open_fails() -> None:
         pipeline.render(draw_frame=lambda: None, width=640, height=480)
 
     assert events == ["sink.open", "sink.close"]
+
+
+def test_raylib_draw_scope_balances_begin_end_on_draw_error() -> None:
+    events: list[str] = []
+
+    class _RaylibRuntime:
+        def begin_drawing(self) -> None:
+            events.append("begin")
+
+        def end_drawing(self) -> None:
+            events.append("end")
+
+    def _raise_draw() -> None:
+        events.append("draw")
+        raise RuntimeError("draw failed")
+
+    scope = RaylibDrawScope(raylib=_RaylibRuntime())
+
+    with pytest.raises(RuntimeError, match="draw failed"):
+        scope.draw(_raise_draw)
+
+    assert events == ["begin", "draw", "end"]
 
 
 def test_render_pipeline_resets_open_state_when_close_fails() -> None:


### PR DESCRIPTION
## Summary

- replace `RenderPipeline` draw-boundary callbacks with a `RenderDrawScope` runtime object
- add `RaylibDrawScope` for balanced `begin_drawing` / `end_drawing`
- route live view and replay video rendering through the shared draw scope

## Verification

- `uv run ruff check src/grim/render_pipeline.py src/grim/app.py src/crimson/render/pipeline.py src/crimson/replay/driver/replay_render.py tests/render/test_render_backend_sink_contract.py tests/grim/test_grim_app_render_pipeline.py`
- `uv run ty check src/grim/render_pipeline.py src/grim/app.py src/crimson/render/pipeline.py src/crimson/replay/driver/replay_render.py tests/render/test_render_backend_sink_contract.py tests/grim/test_grim_app_render_pipeline.py`
- `uv run pytest tests/render/test_render_backend_sink_contract.py tests/grim/test_grim_app_render_pipeline.py tests/replay/test_replay_render_audio.py tests/replay/cli/test_benchmark.py`
- `just check`
- pre-push hook

## Follow-ups

- `RunViewHooks` still stores two small callables for app-level close/screenshot integration
- `WindowSink` still has a single optional present callback
- `BaseGameplayMode.camera` remains the recurring pure-delegation cleanup candidate
