### PR TITLE
refactor: route view run hooks through runtime

### DIFF
--- a/src/crimson/cli/replay.py
+++ b/src/crimson/cli/replay.py
@@ -821,7 +821,7 @@ def cmd_replay_play(
     ),
 ) -> None:
     """Play back a recorded replay."""
-    from grim.app import RunViewHooks, run_view
+    from grim.app import ViewRunHooks, run_view
     from grim.config import ensure_crimson_cfg
     from grim.console import create_console
     from grim.view import ViewContext
@@ -858,10 +858,7 @@ def cmd_replay_play(
         height=height,
         title=title,
         fps=fps,
-        hooks=RunViewHooks(
-            should_close=view.should_close,
-            consume_screenshot_request=view.consume_screenshot_request,
-        ),
+        hooks=ViewRunHooks(view),
     )
 
 

--- a/src/crimson/cli/root.py
+++ b/src/crimson/cli/root.py
@@ -39,30 +39,6 @@ def _safe_relpath(name: str) -> Path:
     return Path(*parts)
 
 
-def _view_run_hooks(view: object):
-    from grim.app import RunViewHooks
-
-    def should_close() -> bool:
-        should_close_fn = getattr(view, "should_close", None)
-        if callable(should_close_fn):
-            return bool(should_close_fn())
-        close_requested = getattr(view, "close_requested", False)
-        if isinstance(close_requested, bool):
-            return close_requested
-        return False
-
-    def consume_screenshot_request() -> bool:
-        consume_fn = getattr(view, "consume_screenshot_request", None)
-        if callable(consume_fn):
-            return bool(consume_fn())
-        return False
-
-    return RunViewHooks(
-        should_close=should_close,
-        consume_screenshot_request=consume_screenshot_request,
-    )
-
-
 def _extract_one(paq_path: Path, assets_root: Path) -> int:
     out_root = assets_root / paq_path.stem
     out_root.mkdir(parents=True, exist_ok=True)
@@ -228,7 +204,7 @@ def cmd_view(
     assets_dir: Path = typer.Option(Path("artifacts") / "assets", help="assets root (default: ./artifacts/assets)"),
 ) -> None:
     """Launch a Raylib debug view."""
-    from grim.app import run_view
+    from grim.app import ViewRunHooks, run_view
     from grim.view import ViewContext
 
     from ..debug_views import all_views, view_by_name
@@ -263,14 +239,13 @@ def cmd_view(
     else:
         view = view_def.factory()
     title = f"{view_def.title} — Crimsonland"
-    hooks = _view_run_hooks(view)
     run_view(
         RuntimeResourcesView(view, assets_dir=assets_dir),
         width=width,
         height=height,
         title=title,
         fps=fps,
-        hooks=hooks,
+        hooks=ViewRunHooks(view),
     )
 
 

--- a/src/crimson/game/runtime.py
+++ b/src/crimson/game/runtime.py
@@ -7,7 +7,7 @@ import webbrowser
 from pathlib import Path
 
 from grim import music
-from grim.app import RunViewHooks, run_view
+from grim.app import ViewRunHooks, run_view
 from grim.config import ensure_crimson_cfg
 from grim.console import (
     CommandHandler,
@@ -330,10 +330,7 @@ def run_game(config: GameConfig) -> None:
             fps=config.fps,
             config_flags=config_flags,
             exit_key=rl.KeyboardKey.KEY_NULL,
-            hooks=RunViewHooks(
-                should_close=view.should_close,
-                consume_screenshot_request=view.consume_screenshot_request,
-            ),
+            hooks=ViewRunHooks(view),
         )
         if state is not None:
             state.status.save_if_dirty()

--- a/src/grim/app.py
+++ b/src/grim/app.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 import shutil
-from collections.abc import Callable
 from pathlib import Path
-
-import msgspec
 
 from grim.raylib_api import rl
 
@@ -15,13 +12,32 @@ SCREENSHOT_DIR = Path("screenshots")
 SCREENSHOT_KEY = rl.KeyboardKey.KEY_F12
 
 
-def _false_hook() -> bool:
-    return False
+class RunViewHooks:
+    def should_close(self) -> bool:
+        return False
+
+    def consume_screenshot_request(self) -> bool:
+        return False
 
 
-class RunViewHooks(msgspec.Struct, frozen=True):
-    should_close: Callable[[], bool] = _false_hook
-    consume_screenshot_request: Callable[[], bool] = _false_hook
+class ViewRunHooks(RunViewHooks):
+    def __init__(self, view: object) -> None:
+        self._view = view
+
+    def should_close(self) -> bool:
+        should_close_fn = getattr(self._view, "should_close", None)
+        if callable(should_close_fn):
+            return bool(should_close_fn())
+        close_requested = getattr(self._view, "close_requested", False)
+        if isinstance(close_requested, bool):
+            return close_requested
+        return False
+
+    def consume_screenshot_request(self) -> bool:
+        consume_fn = getattr(self._view, "consume_screenshot_request", None)
+        if callable(consume_fn):
+            return bool(consume_fn())
+        return False
 
 
 def _next_screenshot_index(directory: Path) -> int:

--- a/tests/grim/test_grim_app_render_pipeline.py
+++ b/tests/grim/test_grim_app_render_pipeline.py
@@ -130,3 +130,29 @@ def test_run_view_uses_render_pipeline(monkeypatch) -> None:
     assert view.draw_calls == 1
     assert view.close_calls == 1
     assert fake_rl.close_calls == 1
+
+
+def test_view_run_hooks_read_view_runtime_methods_and_flags() -> None:
+    class _ViewWithMethods:
+        def __init__(self) -> None:
+            self.screenshots = 1
+
+        def should_close(self) -> bool:
+            return True
+
+        def consume_screenshot_request(self) -> bool:
+            self.screenshots -= 1
+            return self.screenshots >= 0
+
+    method_hooks = grim_app.ViewRunHooks(_ViewWithMethods())
+    assert method_hooks.should_close() is True
+    assert method_hooks.consume_screenshot_request() is True
+    assert method_hooks.consume_screenshot_request() is False
+
+    class _FlagView:
+        close_requested = True
+
+    flag_view = _FlagView()
+    flag_hooks = grim_app.ViewRunHooks(flag_view)
+    assert flag_hooks.should_close() is True
+    assert flag_hooks.consume_screenshot_request() is False


### PR DESCRIPTION
## Summary

- replace `RunViewHooks` callback fields with a runtime object API
- add `ViewRunHooks` to read close/screenshot behavior from view objects
- remove per-callsite close/screenshot closure construction in debug views, replay playback, and game runtime

## Verification

- `uv run ruff check src/grim/app.py src/crimson/cli/root.py src/crimson/cli/replay.py src/crimson/game/runtime.py tests/grim/test_grim_app_render_pipeline.py`
- `uv run ty check src/grim/app.py src/crimson/cli/root.py src/crimson/cli/replay.py src/crimson/game/runtime.py tests/grim/test_grim_app_render_pipeline.py`
- `uv run pytest tests/grim/test_grim_app_render_pipeline.py tests/debug/cli/test_view_cli.py tests/replay/cli/test_play.py tests/replay/cli/test_benchmark.py`
- `just check`
- pre-push hook

## Follow-ups

- `WindowSink` still has a single optional present callback
- `BaseGameplayMode.camera` remains the recurring pure-delegation cleanup candidate
